### PR TITLE
feat(session): opt-in PTY session logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ All notable changes to SSHub are documented in this file.
 ### Added
 
 - **Session logging** — opt-in capture of embedded SSH session PTY output to plain-text
-  files under `~/.local/share/sshub/logs/<host>/<timestamp>.log`. Toggle globally in
-  Settings (`Ctrl+H`) or per host in the host form (`inherit` / `on` / `off`). Size-based
-  rotation and per-host retention cap are configurable in `config.toml`. The audit tab
-  shows the log path for each connect event. **Warning:** logs capture everything echoed
-  to the terminal, including passwords if they appear on screen. (Schema v12.)
+  files under `~/.local/share/sshub/logs/<host-dir>/`, with rotated segment files inside
+  (managed hosts use `{sanitized-name}-{id}`). Toggle globally in Settings (`Ctrl+H`) or
+  per host in the host form (`inherit` / `on` / `off`). Size-based rotation and per-host
+  retention cap are configurable in `config.toml`. The audit tab shows the log directory
+  path for each connect event. Pure `~/.ssh/config` aliases without a launcher
+  row may share a log directory when sanitized host names collide. **Warning:** logs
+  capture everything echoed to the terminal, including passwords if they appear on
+  screen. (Schema v12.)
 
 ## [0.8.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to SSHub are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Session logging** — opt-in capture of embedded SSH session PTY output to plain-text
+  files under `~/.local/share/sshub/logs/<host>/<timestamp>.log`. Toggle globally in
+  Settings (`Ctrl+H`) or per host in the host form (`inherit` / `on` / `off`). Size-based
+  rotation and per-host retention cap are configurable in `config.toml`. The audit tab
+  shows the log path for each connect event. **Warning:** logs capture everything echoed
+  to the terminal, including passwords if they appear on screen. (Schema v12.)
+
 ## [0.8.0] - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ max_file_bytes = 10485760   # rotate at 10 MiB
 retention_files = 50        # keep newest 50 logs per host
 
 [terminal]
-```
 # "kitty", "ghostty", or a custom command template
 launcher = "kitty"
 # custom_command = "alacritty -e ssh {host}"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The settings overlay (`Ctrl+H`) — toggle an opaque background, OS logos, quit 
 - **Tunnels** — define and manage SSH tunnels (local/remote/dynamic SOCKS). Start, stop, and monitor from the TUI
 - **Keys** — identity management with ssh-agent integration. Add/remove keys from agent, see loaded status
 - **Audit** — log of all connection events with filtering by status (ok/fail) and time range (today/week/month); session connect events record the path to the session log when logging is enabled
-- **Session logging** — opt-in capture of PTY session output to `~/.local/share/sshub/logs/<host>/`. Enable globally in Settings (`Ctrl+H`) or override per host (`inherit` / `on` / `off`). **Logs capture everything echoed to the terminal, including passwords if they appear on screen.**
+- **Session logging** — opt-in capture of PTY session output to `~/.local/share/sshub/logs/<host-dir>/` (managed hosts use `{name}-{id}`; pure `~/.ssh/config` aliases without a launcher row may share a directory when sanitized names collide). Enable globally in Settings (`Ctrl+H`) or override per host (`inherit` / `on` / `off`). **Logs capture everything echoed to the terminal, including passwords if they appear on screen.**
 - **Settings overlay** (`Ctrl+H`) — toggle session logging, opaque background (for transparent terminals), OS logos, quit confirmation, and the startup animation
 - **Hybrid sources** — hosts from `~/.ssh/config` (read-only) and launcher-managed (full CRUD) merge without duplicates
 - **Import/Export** — import from `~/.ssh/config` or Termius backups; export managed hosts back to ssh config format

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ The settings overlay (`Ctrl+H`) — toggle an opaque background, OS logos, quit 
 - **Multiple groups & Favorites** — a host can belong to several groups at once; a reserved Favorites group and a ★ marker in the list, toggled with `f`
 - **Tunnels** — define and manage SSH tunnels (local/remote/dynamic SOCKS). Start, stop, and monitor from the TUI
 - **Keys** — identity management with ssh-agent integration. Add/remove keys from agent, see loaded status
-- **Audit** — log of all connection events with filtering by status (ok/fail) and time range (today/week/month)
-- **Settings overlay** (`Ctrl+H`) — toggle an opaque background (for transparent terminals), OS logos, quit confirmation, and the startup animation
+- **Audit** — log of all connection events with filtering by status (ok/fail) and time range (today/week/month); session connect events record the path to the session log when logging is enabled
+- **Session logging** — opt-in capture of PTY session output to `~/.local/share/sshub/logs/<host>/`. Enable globally in Settings (`Ctrl+H`) or override per host (`inherit` / `on` / `off`). **Logs capture everything echoed to the terminal, including passwords if they appear on screen.**
+- **Settings overlay** (`Ctrl+H`) — toggle session logging, opaque background (for transparent terminals), OS logos, quit confirmation, and the startup animation
 - **Hybrid sources** — hosts from `~/.ssh/config` (read-only) and launcher-managed (full CRUD) merge without duplicates
 - **Import/Export** — import from `~/.ssh/config` or Termius backups; export managed hosts back to ssh config format
 - **Hot reload** — edits to `~/.ssh/config` update the host list live via file watcher
@@ -207,7 +208,13 @@ Defaults below. Rebind any action with **Ctrl+K** (saved to `config.toml`). Pres
 `~/.config/sshub/config.toml`:
 
 ```toml
+[session_logging]
+enabled = false
+max_file_bytes = 10485760   # rotate at 10 MiB
+retention_files = 50        # keep newest 50 logs per host
+
 [terminal]
+```
 # "kitty", "ghostty", or a custom command template
 launcher = "kitty"
 # custom_command = "alacritty -e ssh {host}"

--- a/src/app/connect.rs
+++ b/src/app/connect.rs
@@ -134,21 +134,27 @@ impl App {
             let mut log_writer = None;
             let mut log_path = None;
             if log_enabled {
-                if let Ok(data_dir) = crate::config::data_dir() {
-                    let cfg = &self.config.session_logging;
-                    match crate::session_log::SessionLogWriter::open(
-                        &data_dir,
-                        &host_name,
-                        cfg.max_file_bytes,
-                        cfg.retention_files,
-                    ) {
-                        Ok(w) => {
-                            log_path = Some(w.path().display().to_string());
-                            log_writer = Some(w);
+                match crate::config::data_dir() {
+                    Ok(data_dir) => {
+                        let cfg = &self.config.session_logging;
+                        match crate::session_log::SessionLogWriter::open(
+                            &data_dir,
+                            &host_name,
+                            cfg.max_file_bytes,
+                            cfg.retention_files,
+                        ) {
+                            Ok(w) => {
+                                log_path = Some(w.path().display().to_string());
+                                log_writer = Some(w);
+                            }
+                            Err(e) => {
+                                self.host_notice =
+                                    Some(format!("Session logging unavailable: {e:#}"));
+                            }
                         }
-                        Err(e) => {
-                            self.host_notice = Some(format!("Session logging unavailable: {e:#}"));
-                        }
+                    }
+                    Err(e) => {
+                        self.host_notice = Some(format!("Session logging unavailable: {e:#}"));
                     }
                 }
             }

--- a/src/app/connect.rs
+++ b/src/app/connect.rs
@@ -140,11 +140,12 @@ impl App {
                         match crate::session_log::SessionLogWriter::open(
                             &data_dir,
                             &host_name,
+                            entry.managed_id(),
                             cfg.max_file_bytes,
                             cfg.retention_files,
                         ) {
                             Ok(w) => {
-                                log_path = Some(w.path().display().to_string());
+                                log_path = Some(w.host_dir().display().to_string());
                                 log_writer = Some(w);
                             }
                             Err(e) => {

--- a/src/app/connect.rs
+++ b/src/app/connect.rs
@@ -131,22 +131,30 @@ impl App {
                 self.config.session_logging.enabled,
                 entry.session_logging_override(),
             );
-            let mut log_writer = None;
-            let mut log_path = None;
-            if log_enabled {
-                match crate::config::data_dir() {
-                    Ok(data_dir) => {
-                        let cfg = &self.config.session_logging;
-                        match crate::session_log::SessionLogWriter::open(
-                            &data_dir,
-                            &host_name,
-                            entry.managed_id(),
-                            cfg.max_file_bytes,
-                            cfg.retention_files,
-                        ) {
-                            Ok(w) => {
-                                log_path = Some(w.host_dir().display().to_string());
-                                log_writer = Some(w);
+
+            match crate::session::Session::spawn(config, rows, cols, None) {
+                Ok(mut session) => {
+                    let mut log_path = None;
+                    if log_enabled {
+                        match crate::config::data_dir() {
+                            Ok(data_dir) => {
+                                let cfg = &self.config.session_logging;
+                                match crate::session_log::SessionLogWriter::open(
+                                    &data_dir,
+                                    &host_name,
+                                    entry.managed_id(),
+                                    cfg.max_file_bytes,
+                                    cfg.retention_files,
+                                ) {
+                                    Ok(w) => {
+                                        log_path = Some(w.host_dir().display().to_string());
+                                        session.set_log(w);
+                                    }
+                                    Err(e) => {
+                                        self.host_notice =
+                                            Some(format!("Session logging unavailable: {e:#}"));
+                                    }
+                                }
                             }
                             Err(e) => {
                                 self.host_notice =
@@ -154,14 +162,6 @@ impl App {
                             }
                         }
                     }
-                    Err(e) => {
-                        self.host_notice = Some(format!("Session logging unavailable: {e:#}"));
-                    }
-                }
-            }
-
-            match crate::session::Session::spawn(config, rows, cols, log_writer) {
-                Ok(session) => {
                     self.sessions.push(session);
                     self.active_session = Some(self.sessions.len() - 1);
                     self.mode = AppMode::Connecting;

--- a/src/app/connect.rs
+++ b/src/app/connect.rs
@@ -126,7 +126,34 @@ impl App {
                 meta,
                 pending_secret: pending_secret.clone(),
             };
-            match crate::session::Session::spawn(config, rows, cols) {
+
+            let log_enabled = crate::session_log::effective_enabled(
+                self.config.session_logging.enabled,
+                entry.session_logging_override(),
+            );
+            let mut log_writer = None;
+            let mut log_path = None;
+            if log_enabled {
+                if let Ok(data_dir) = crate::config::data_dir() {
+                    let cfg = &self.config.session_logging;
+                    match crate::session_log::SessionLogWriter::open(
+                        &data_dir,
+                        &host_name,
+                        cfg.max_file_bytes,
+                        cfg.retention_files,
+                    ) {
+                        Ok(w) => {
+                            log_path = Some(w.path().display().to_string());
+                            log_writer = Some(w);
+                        }
+                        Err(e) => {
+                            self.host_notice = Some(format!("Session logging unavailable: {e:#}"));
+                        }
+                    }
+                }
+            }
+
+            match crate::session::Session::spawn(config, rows, cols, log_writer) {
                 Ok(session) => {
                     self.sessions.push(session);
                     self.active_session = Some(self.sessions.len() - 1);
@@ -137,13 +164,14 @@ impl App {
                         via,
                         "launched",
                         "session started",
+                        log_path.as_deref(),
                     );
                 }
                 Err(e) => {
                     let err_msg = format!("Session spawn failed: {e:#}");
                     let _ = self
                         .store
-                        .log_auth_event(&host_name, username, via, "fail", &err_msg);
+                        .log_auth_event(&host_name, username, via, "fail", &err_msg, None);
                     self.push_ssh_log(crate::ssh::probe::SshLogEntry {
                         host_name: host_name.clone(),
                         line: err_msg.clone(),

--- a/src/app/field_picker.rs
+++ b/src/app/field_picker.rs
@@ -215,11 +215,30 @@ impl App {
         let Some(form) = self.host_form.as_mut() else {
             return;
         };
-        if !form.field.is_picker() && !form.field.is_toggle() {
+        if !form.field.is_picker() && !form.field.is_toggle() && !form.field.is_tri_state() {
             return;
         }
         if form.field == HostFormField::ForwardAgent {
             form.forward_agent = !form.forward_agent;
+            form.dirty = true;
+            return;
+        }
+        if form.field == HostFormField::SessionLogging {
+            form.session_logging = if delta >= 0 {
+                form.session_logging.next()
+            } else {
+                match form.session_logging {
+                    crate::session_log::SessionLoggingOverride::Inherit => {
+                        crate::session_log::SessionLoggingOverride::Off
+                    }
+                    crate::session_log::SessionLoggingOverride::On => {
+                        crate::session_log::SessionLoggingOverride::Inherit
+                    }
+                    crate::session_log::SessionLoggingOverride::Off => {
+                        crate::session_log::SessionLoggingOverride::On
+                    }
+                }
+            };
             form.dirty = true;
             return;
         }

--- a/src/app/host_crud.rs
+++ b/src/app/host_crud.rs
@@ -103,6 +103,7 @@ impl App {
         new_host.proxy_jump = host.proxy_jump.clone();
         new_host.forward_agent = host.forward_agent.unwrap_or(false);
         new_host.remote_command = host.remote_command.clone();
+        new_host.session_logging = meta.session_logging;
         new_host.identity_id = self.match_identity_for_ssh_host(host)?;
         self.store.create_host(&new_host)?;
         Ok(name)

--- a/src/app/host_detail.rs
+++ b/src/app/host_detail.rs
@@ -14,10 +14,12 @@ impl App {
             .environment()
             .unwrap_or_default()
             .to_string();
+        let session_logging = self.hosts[host_idx].session_logging_override();
         self.detail_edit = Some(HostDetailEdit {
             tags: tags.clone(),
             description,
             environment,
+            session_logging,
             field: DetailEditField::Tags,
             cursor: text_input::char_len(&tags),
         });
@@ -71,7 +73,6 @@ impl App {
                 self.hosts[host_idx] = HostEntry::Managed(updated);
             }
         } else {
-            let session_logging = self.hosts[host_idx].session_logging_override();
             let meta = crate::metadata::HostMetadata {
                 host_name: host_name.clone(),
                 tags,
@@ -79,7 +80,7 @@ impl App {
                 environment,
                 favorite,
                 last_connected,
-                session_logging,
+                session_logging: edit.session_logging,
             };
             self.metadata.upsert(&meta)?;
             if let Some((_, stored_meta)) = self.hosts[host_idx].legacy_mut() {
@@ -96,7 +97,9 @@ impl App {
             return;
         };
         edit.field = edit.field.next();
-        edit.cursor = text_input::char_len(edit.active_field());
+        if !edit.field.is_tri_state() {
+            edit.cursor = text_input::char_len(edit.active_field());
+        }
     }
 
     pub(crate) fn detail_edit_field_prev(&mut self) {
@@ -104,13 +107,42 @@ impl App {
             return;
         };
         edit.field = edit.field.prev();
-        edit.cursor = text_input::char_len(edit.active_field());
+        if !edit.field.is_tri_state() {
+            edit.cursor = text_input::char_len(edit.active_field());
+        }
+    }
+
+    pub(crate) fn detail_edit_cycle_session_logging(&mut self, delta: i32) {
+        let Some(edit) = self.detail_edit.as_mut() else {
+            return;
+        };
+        if edit.field != DetailEditField::SessionLogging {
+            return;
+        }
+        edit.session_logging = if delta >= 0 {
+            edit.session_logging.next()
+        } else {
+            match edit.session_logging {
+                crate::session_log::SessionLoggingOverride::Inherit => {
+                    crate::session_log::SessionLoggingOverride::Off
+                }
+                crate::session_log::SessionLoggingOverride::On => {
+                    crate::session_log::SessionLoggingOverride::Inherit
+                }
+                crate::session_log::SessionLoggingOverride::Off => {
+                    crate::session_log::SessionLoggingOverride::On
+                }
+            }
+        };
     }
 
     pub(crate) fn detail_edit_backspace(&mut self) {
         let Some(edit) = self.detail_edit.as_mut() else {
             return;
         };
+        if edit.field.is_tri_state() {
+            return;
+        }
         let c = edit.cursor;
         edit.cursor = text_input::backspace_at(edit.active_field_mut(), c);
     }
@@ -119,6 +151,9 @@ impl App {
         let Some(edit) = self.detail_edit.as_mut() else {
             return;
         };
+        if edit.field.is_tri_state() {
+            return;
+        }
         let c = edit.cursor;
         edit.cursor = text_input::insert_at(edit.active_field_mut(), c, ch);
     }

--- a/src/app/host_detail.rs
+++ b/src/app/host_detail.rs
@@ -71,6 +71,7 @@ impl App {
                 self.hosts[host_idx] = HostEntry::Managed(updated);
             }
         } else {
+            let session_logging = self.hosts[host_idx].session_logging_override();
             let meta = crate::metadata::HostMetadata {
                 host_name: host_name.clone(),
                 tags,
@@ -78,7 +79,7 @@ impl App {
                 environment,
                 favorite,
                 last_connected,
-                ..Default::default()
+                session_logging,
             };
             self.metadata.upsert(&meta)?;
             if let Some((_, stored_meta)) = self.hosts[host_idx].legacy_mut() {

--- a/src/app/host_detail.rs
+++ b/src/app/host_detail.rs
@@ -78,6 +78,7 @@ impl App {
                 environment,
                 favorite,
                 last_connected,
+                ..Default::default()
             };
             self.metadata.upsert(&meta)?;
             if let Some((_, stored_meta)) = self.hosts[host_idx].legacy_mut() {

--- a/src/app/host_detail.rs
+++ b/src/app/host_detail.rs
@@ -67,6 +67,7 @@ impl App {
                 tags: Some(tags),
                 notes: Some(description),
                 environment: Some(environment),
+                session_logging: Some(edit.session_logging),
                 ..Default::default()
             };
             if let Some(updated) = self.store.update_host(id, &update)? {

--- a/src/app/host_form.rs
+++ b/src/app/host_form.rs
@@ -66,6 +66,7 @@ impl App {
                 proxy_jump: managed.proxy_jump.clone().unwrap_or_default(),
                 forward_agent: managed.forward_agent,
                 remote_command: managed.remote_command.clone().unwrap_or_default(),
+                session_logging: managed.session_logging,
                 os_icon_index: os_icon_index_from_option(&managed.os_icon),
                 password: String::new(),
                 has_password: managed.has_password,
@@ -109,6 +110,7 @@ impl App {
                 proxy_jump: String::new(),
                 forward_agent: false,
                 remote_command: String::new(),
+                session_logging: crate::session_log::SessionLoggingOverride::Inherit,
                 os_icon_index: 0,
                 password: String::new(),
                 has_password: false,
@@ -192,6 +194,7 @@ impl App {
                     tags: Some(tags),
                     has_password: Some(new_has_password),
                     username: Some(username.clone()),
+                    session_logging: Some(form.session_logging),
                     ..Default::default()
                 },
             )?;
@@ -264,6 +267,7 @@ impl App {
                     remote_command: Some(remote_command),
                     has_password: Some(new_has_password),
                     username: Some(username),
+                    session_logging: Some(form.session_logging),
                     ..Default::default()
                 },
             )?;
@@ -285,6 +289,7 @@ impl App {
                 source: HostSource::Launcher,
                 has_password: new_has_password,
                 username,
+                session_logging: form.session_logging,
             })?;
             self.store.set_host_groups(created.id, &group_ids)?;
             if host_pw_changed {
@@ -325,10 +330,10 @@ impl App {
                 self.host_form_field_next();
             }
             KeyCode::BackTab | KeyCode::Up => self.host_form_field_prev(),
-            KeyCode::Right if field.is_picker() || field.is_toggle() => {
+            KeyCode::Right if field.is_picker() || field.is_toggle() || field.is_tri_state() => {
                 self.host_form_picker_scroll(1);
             }
-            KeyCode::Left if field.is_picker() || field.is_toggle() => {
+            KeyCode::Left if field.is_picker() || field.is_toggle() || field.is_tri_state() => {
                 self.host_form_picker_scroll(-1);
             }
             // Text fields: move the edit cursor within the field.
@@ -336,7 +341,9 @@ impl App {
                 self.host_form_cursor_key(key.code)
             }
             KeyCode::Char(' ')
-                if key.modifiers.is_empty() && field == HostFormField::ForwardAgent =>
+                if key.modifiers.is_empty()
+                    && (field == HostFormField::ForwardAgent
+                        || field == HostFormField::SessionLogging) =>
             {
                 self.host_form_toggle();
             }
@@ -345,7 +352,8 @@ impl App {
                 if (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)
                     && !c.is_control()
                     && !field.is_picker()
-                    && !field.is_toggle() =>
+                    && !field.is_toggle()
+                    && !field.is_tri_state() =>
             {
                 self.host_form_insert(c);
             }
@@ -379,6 +387,9 @@ impl App {
         }
         if form.field == HostFormField::ForwardAgent {
             form.forward_agent = !form.forward_agent;
+            form.dirty = true;
+        } else if form.field == HostFormField::SessionLogging {
+            form.session_logging = form.session_logging.next();
             form.dirty = true;
         }
     }

--- a/src/app/identities.rs
+++ b/src/app/identities.rs
@@ -34,6 +34,7 @@ impl App {
                     "agent",
                     "ok",
                     &format!("key removed from agent: {}", key_path.to_string_lossy()),
+                    None,
                 );
                 self.agent_info = None;
                 self.agent_info_updated =
@@ -48,6 +49,7 @@ impl App {
                     "agent",
                     "fail",
                     &format!("remove from agent failed: {e:#}"),
+                    None,
                 );
             }
         }
@@ -72,6 +74,7 @@ impl App {
                     "agent",
                     "launched",
                     &format!("key added to agent: {}", key_path.to_string_lossy()),
+                    None,
                 );
                 self.agent_info = None;
                 self.agent_info_updated =
@@ -86,6 +89,7 @@ impl App {
                     "agent",
                     "fail",
                     &format!("add to agent failed: {e:#}"),
+                    None,
                 );
             }
         }

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -703,18 +703,27 @@ impl App {
             1 => a.os_logo,
             2 => a.confirm_quit,
             3 => a.disable_animation,
+            4 => self.config.session_logging.enabled,
             _ => false,
         }
     }
 
     /// Flip the Settings toggle at row `i` and persist immediately.
     fn toggle_setting(&mut self, i: usize) {
-        let a = &mut self.config.appearance;
         match i {
-            0 => a.opaque_background = !a.opaque_background,
-            1 => a.os_logo = !a.os_logo,
-            2 => a.confirm_quit = !a.confirm_quit,
-            3 => a.disable_animation = !a.disable_animation,
+            0 => {
+                self.config.appearance.opaque_background =
+                    !self.config.appearance.opaque_background;
+            }
+            1 => self.config.appearance.os_logo = !self.config.appearance.os_logo,
+            2 => self.config.appearance.confirm_quit = !self.config.appearance.confirm_quit,
+            3 => {
+                self.config.appearance.disable_animation =
+                    !self.config.appearance.disable_animation;
+            }
+            4 => {
+                self.config.session_logging.enabled = !self.config.session_logging.enabled;
+            }
             _ => {}
         }
         self.save_config_quietly();

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -317,6 +317,7 @@ impl App {
         if self.detail_edit.is_none() {
             return Ok(());
         }
+        let field = self.detail_edit.as_ref().unwrap().field;
 
         match key.code {
             _ if self.is_action(KeyAction::Cancel, &key) => self.cancel_host_detail()?,
@@ -326,10 +327,18 @@ impl App {
             KeyCode::BackTab => self.detail_edit_field_prev(),
             _ if self.is_action(KeyAction::MoveDown, &key) => self.detail_edit_field_next(),
             _ if self.is_action(KeyAction::MoveUp, &key) => self.detail_edit_field_prev(),
+            KeyCode::Right if field.is_tri_state() => self.detail_edit_cycle_session_logging(1),
+            KeyCode::Left if field.is_tri_state() => self.detail_edit_cycle_session_logging(-1),
+            KeyCode::Char(' ')
+                if key.modifiers.is_empty() && field == DetailEditField::SessionLogging =>
+            {
+                self.detail_edit_cycle_session_logging(1);
+            }
             KeyCode::Backspace if key.modifiers.is_empty() => self.detail_edit_backspace(),
             KeyCode::Char(c)
                 if (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)
-                    && !c.is_control() =>
+                    && !c.is_control()
+                    && !field.is_tri_state() =>
             {
                 self.detail_edit_insert(c);
             }

--- a/src/app/tests/host_crud.rs
+++ b/src/app/tests/host_crud.rs
@@ -1,0 +1,23 @@
+use super::*;
+
+#[test]
+pub(crate) fn duplicate_legacy_preserves_session_logging_override() {
+    let mut app = test_app(vec![("legacy-web", host("legacy-web"))]);
+    legacy_meta(&mut app.hosts[0]).session_logging = crate::session_log::SessionLoggingOverride::On;
+
+    let (ssh_host, meta) = match &app.hosts[0] {
+        HostEntry::Legacy { host, meta } => (host.clone(), meta.clone()),
+        _ => panic!("expected legacy host"),
+    };
+
+    let copy_name = app.duplicate_legacy_to_launcher(&ssh_host, &meta).unwrap();
+    let created = app
+        .store
+        .get_host_by_name(&copy_name)
+        .unwrap()
+        .expect("duplicate host row");
+    assert_eq!(
+        created.session_logging,
+        crate::session_log::SessionLoggingOverride::On
+    );
+}

--- a/src/app/tests/host_detail.rs
+++ b/src/app/tests/host_detail.rs
@@ -123,6 +123,53 @@ pub(crate) fn host_detail_save_preserves_session_logging_override() {
 }
 
 #[test]
+pub(crate) fn host_detail_session_logging_cycle_and_save() {
+    let metadata: Arc<dyn MetadataStore> = Arc::new(MetadataDb::default());
+    let resolver = MockResolver::new(vec![("web", host("web"))]);
+    let (launcher, _launched) = RecordingLauncher::new();
+    let mut app = App::new_with_deps(
+        AppConfig::default(),
+        AppDeps {
+            resolver: Box::new(resolver),
+            metadata: Arc::clone(&metadata),
+            store: test_store(),
+            launcher: Box::new(launcher),
+            password_store: Box::new(crate::credentials::NoopPasswordStore),
+        },
+    );
+    app.reload_hosts().unwrap();
+    assert_eq!(
+        app.hosts[0].session_logging_override(),
+        crate::session_log::SessionLoggingOverride::Inherit
+    );
+
+    app.enter_host_detail().unwrap();
+    for _ in 0..3 {
+        app.handle_key(key(KeyCode::Tab)).unwrap();
+    }
+    assert_eq!(
+        app.detail_edit.as_ref().unwrap().field,
+        DetailEditField::SessionLogging
+    );
+    app.handle_key(key(KeyCode::Char(' '))).unwrap();
+    assert_eq!(
+        app.detail_edit.as_ref().unwrap().session_logging,
+        crate::session_log::SessionLoggingOverride::On
+    );
+    app.handle_key(key(KeyCode::Enter)).unwrap();
+
+    assert_eq!(
+        app.hosts[0].session_logging_override(),
+        crate::session_log::SessionLoggingOverride::On
+    );
+    let stored = metadata.get("web").unwrap().unwrap();
+    assert_eq!(
+        stored.session_logging,
+        crate::session_log::SessionLoggingOverride::On
+    );
+}
+
+#[test]
 pub(crate) fn host_detail_esc_discards_unsaved_edits() {
     let metadata: Arc<dyn MetadataStore> = Arc::new(MetadataDb::default());
     let resolver = MockResolver::new(vec![("web", host("web"))]);

--- a/src/app/tests/host_detail.rs
+++ b/src/app/tests/host_detail.rs
@@ -170,6 +170,41 @@ pub(crate) fn host_detail_session_logging_cycle_and_save() {
 }
 
 #[test]
+pub(crate) fn host_detail_managed_save_persists_session_logging() {
+    let store = test_store();
+    let created = store
+        .create_host(&NewHost::launcher("managed", "10.0.0.1"))
+        .unwrap();
+    let resolver = MockResolver::new(vec![]);
+    let (launcher, _launched) = RecordingLauncher::new();
+    let mut app = App::new_with_deps(
+        AppConfig::default(),
+        AppDeps {
+            resolver: Box::new(resolver),
+            metadata: Arc::new(MetadataDb::default()),
+            store: Arc::clone(&store),
+            launcher: Box::new(launcher),
+            password_store: Box::new(crate::credentials::NoopPasswordStore),
+        },
+    );
+    app.reload_hosts().unwrap();
+    assert_eq!(app.hosts.len(), 1);
+
+    app.enter_host_detail().unwrap();
+    while app.detail_edit.as_ref().unwrap().field != DetailEditField::SessionLogging {
+        app.detail_edit_field_next();
+    }
+    app.detail_edit_cycle_session_logging(1);
+    app.save_host_detail().unwrap();
+
+    let updated = store.get_host(created.id).unwrap().expect("host row");
+    assert_eq!(
+        updated.session_logging,
+        crate::session_log::SessionLoggingOverride::On
+    );
+}
+
+#[test]
 pub(crate) fn host_detail_esc_discards_unsaved_edits() {
     let metadata: Arc<dyn MetadataStore> = Arc::new(MetadataDb::default());
     let resolver = MockResolver::new(vec![("web", host("web"))]);

--- a/src/app/tests/host_detail.rs
+++ b/src/app/tests/host_detail.rs
@@ -89,6 +89,40 @@ pub(crate) fn host_detail_save_persists_metadata() {
 }
 
 #[test]
+pub(crate) fn host_detail_save_preserves_session_logging_override() {
+    let metadata: Arc<dyn MetadataStore> = Arc::new(MetadataDb::default());
+    let resolver = MockResolver::new(vec![("web", host("web"))]);
+    let (launcher, _launched) = RecordingLauncher::new();
+    let mut app = App::new_with_deps(
+        AppConfig::default(),
+        AppDeps {
+            resolver: Box::new(resolver),
+            metadata: Arc::clone(&metadata),
+            store: test_store(),
+            launcher: Box::new(launcher),
+            password_store: Box::new(crate::credentials::NoopPasswordStore),
+        },
+    );
+    app.reload_hosts().unwrap();
+    legacy_meta(&mut app.hosts[0]).session_logging = crate::session_log::SessionLoggingOverride::On;
+    metadata.upsert(legacy_meta(&mut app.hosts[0])).unwrap();
+
+    app.enter_host_detail().unwrap();
+    app.handle_key(key_char('x')).unwrap();
+    app.handle_key(key(KeyCode::Enter)).unwrap();
+
+    assert_eq!(
+        app.hosts[0].session_logging_override(),
+        crate::session_log::SessionLoggingOverride::On
+    );
+    let stored = metadata.get("web").unwrap().unwrap();
+    assert_eq!(
+        stored.session_logging,
+        crate::session_log::SessionLoggingOverride::On
+    );
+}
+
+#[test]
 pub(crate) fn host_detail_esc_discards_unsaved_edits() {
     let metadata: Arc<dyn MetadataStore> = Arc::new(MetadataDb::default());
     let resolver = MockResolver::new(vec![("web", host("web"))]);

--- a/src/app/tests/host_form.rs
+++ b/src/app/tests/host_form.rs
@@ -69,8 +69,8 @@ pub(crate) fn host_form_up_down_navigate_fields_in_both_directions() {
         HostFormField::Address
     );
 
-    // Navigate to the end (12 downs from Address)
-    for _ in 0..12 {
+    // Navigate to the end (13 downs from Address)
+    for _ in 0..13 {
         app.handle_key(key(KeyCode::Down)).unwrap();
     }
     assert_eq!(app.host_form.as_ref().unwrap().field, HostFormField::OsIcon);
@@ -78,7 +78,7 @@ pub(crate) fn host_form_up_down_navigate_fields_in_both_directions() {
     app.handle_key(key(KeyCode::Up)).unwrap();
     assert_eq!(
         app.host_form.as_ref().unwrap().field,
-        HostFormField::RemoteCommand
+        HostFormField::SessionLogging
     );
 }
 

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -109,6 +109,7 @@ pub(crate) fn legacy_meta(entry: &mut HostEntry) -> &mut crate::metadata::HostMe
     entry.legacy_mut().expect("legacy host").1
 }
 
+mod host_crud;
 mod host_detail;
 mod host_form;
 mod identity_group;

--- a/src/app/tests/session.rs
+++ b/src/app/tests/session.rs
@@ -24,7 +24,7 @@ pub(crate) fn enter_starts_embedded_session() {
         meta: crate::session::SessionMeta::default(),
         pending_secret: None,
     };
-    let session = crate::session::Session::spawn(config, 24, 80).unwrap();
+    let session = crate::session::Session::spawn(config, 24, 80, None).unwrap();
     app.sessions.push(session);
     app.active_session = Some(0);
     app.mode = AppMode::Connecting;
@@ -72,7 +72,7 @@ pub(crate) fn ctrl_t_opens_host_picker() {
         pending_secret: None,
     };
     app.sessions
-        .push(crate::session::Session::spawn(cfg, 24, 80).unwrap());
+        .push(crate::session::Session::spawn(cfg, 24, 80, None).unwrap());
     app.active_session = Some(0);
     app.mode = AppMode::Session;
 
@@ -113,7 +113,7 @@ pub(crate) fn session_tabs_switch_detach_and_focus() {
     };
     for _ in 0..3 {
         app.sessions
-            .push(crate::session::Session::spawn(cfg.clone(), 24, 80).unwrap());
+            .push(crate::session::Session::spawn(cfg.clone(), 24, 80, None).unwrap());
     }
     app.active_session = Some(2);
     app.mode = AppMode::Session;
@@ -168,7 +168,7 @@ pub(crate) fn shutdown_all_kills_detached_sessions() {
         pending_secret: None,
     };
     app.sessions
-        .push(crate::session::Session::spawn(cfg, 24, 80).unwrap());
+        .push(crate::session::Session::spawn(cfg, 24, 80, None).unwrap());
     app.active_session = Some(0);
     app.mode = AppMode::Session;
 

--- a/src/app/tunnels.rs
+++ b/src/app/tunnels.rs
@@ -103,6 +103,7 @@ impl App {
                 "tunnel",
                 "ok",
                 &format!("tunnel stopped :{} {}", tunnel.local_port, label),
+                None,
             );
         } else {
             match self.tunnel_manager.start(&tunnel, host.as_ref()) {
@@ -114,6 +115,7 @@ impl App {
                         "tunnel",
                         "launched",
                         &format!("tunnel started :{} {}", tunnel.local_port, label),
+                        None,
                     );
                 }
                 Err(e) => {
@@ -124,6 +126,7 @@ impl App {
                         "tunnel",
                         "fail",
                         &format!("tunnel failed :{} — {e:#}", tunnel.local_port),
+                        None,
                     );
                 }
             }
@@ -149,6 +152,7 @@ impl App {
                 "tunnel",
                 "ok",
                 &format!("tunnel killed :{}", tunnel.local_port),
+                None,
             );
         }
         Ok(())

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -334,13 +334,15 @@ pub enum DetailEditField {
     Tags = 0,
     Description = 1,
     Environment = 2,
+    SessionLogging = 3,
 }
 
 impl DetailEditField {
-    const ALL: [DetailEditField; 3] = [
+    const ALL: [DetailEditField; 4] = [
         DetailEditField::Tags,
         DetailEditField::Description,
         DetailEditField::Environment,
+        DetailEditField::SessionLogging,
     ];
 
     pub(crate) fn next(self) -> Self {
@@ -352,6 +354,10 @@ impl DetailEditField {
         let idx = self as usize;
         Self::ALL[(idx + Self::ALL.len() - 1) % Self::ALL.len()]
     }
+
+    pub(crate) fn is_tri_state(self) -> bool {
+        matches!(self, Self::SessionLogging)
+    }
 }
 
 /// In-progress metadata edits while in HostDetail mode.
@@ -360,6 +366,7 @@ pub struct HostDetailEdit {
     pub tags: String,
     pub description: String,
     pub environment: String,
+    pub session_logging: crate::session_log::SessionLoggingOverride,
     pub field: DetailEditField,
     pub cursor: usize,
 }
@@ -901,6 +908,7 @@ impl HostDetailEdit {
             DetailEditField::Tags => &self.tags,
             DetailEditField::Description => &self.description,
             DetailEditField::Environment => &self.environment,
+            DetailEditField::SessionLogging => "",
         }
     }
 
@@ -909,6 +917,7 @@ impl HostDetailEdit {
             DetailEditField::Tags => &mut self.tags,
             DetailEditField::Description => &mut self.description,
             DetailEditField::Environment => &mut self.environment,
+            DetailEditField::SessionLogging => &mut self.tags,
         }
     }
 }

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -95,7 +95,7 @@ pub enum VisualRow {
 /// in `tui::screens::settings`) and avoid ambiguous-width chars like the em
 /// dash — some terminals draw those 2 cells wide, pushing the tail of the
 /// line onto the popup border.
-pub const SETTINGS_ITEMS: [(&str, &str); 4] = [
+pub const SETTINGS_ITEMS: [(&str, &str); 5] = [
     (
         "Opaque background",
         "fixes unreadable text on transparent terminals",
@@ -105,6 +105,10 @@ pub const SETTINGS_ITEMS: [(&str, &str); 4] = [
     (
         "Disable startup animation",
         "skip the intro splash (applies next launch)",
+    ),
+    (
+        "Session logging",
+        "save PTY output under ~/.local/share/sshub/logs",
     ),
 ];
 
@@ -429,6 +433,13 @@ impl HostEntry {
         }
     }
 
+    pub fn session_logging_override(&self) -> crate::session_log::SessionLoggingOverride {
+        match self {
+            Self::Managed(m) => m.session_logging,
+            Self::Legacy { meta, .. } => meta.session_logging,
+        }
+    }
+
     pub fn source(&self) -> HostSource {
         match self {
             Self::Managed(m) => m.source,
@@ -547,6 +558,7 @@ pub struct HostFormEdit {
     pub proxy_jump: String,
     pub forward_agent: bool,
     pub remote_command: String,
+    pub session_logging: crate::session_log::SessionLoggingOverride,
     pub os_icon_index: usize,
     pub password: String,
     pub has_password: bool,
@@ -576,13 +588,14 @@ pub enum HostFormField {
     ProxyJump = 7,
     ForwardAgent = 8,
     RemoteCommand = 9,
-    OsIcon = 10,
-    Password = 11,
-    Username = 12,
+    SessionLogging = 10,
+    OsIcon = 11,
+    Password = 12,
+    Username = 13,
 }
 
 impl HostFormField {
-    pub const ALL: [HostFormField; 13] = [
+    pub const ALL: [HostFormField; 14] = [
         HostFormField::Address,
         HostFormField::Password,
         HostFormField::Username,
@@ -595,6 +608,7 @@ impl HostFormField {
         HostFormField::ProxyJump,
         HostFormField::ForwardAgent,
         HostFormField::RemoteCommand,
+        HostFormField::SessionLogging,
         HostFormField::OsIcon,
     ];
 
@@ -633,6 +647,7 @@ impl HostFormField {
             HostFormField::ProxyJump => "ProxyJump",
             HostFormField::ForwardAgent => "Agent forward",
             HostFormField::RemoteCommand => "Startup command",
+            HostFormField::SessionLogging => "Session log",
             HostFormField::OsIcon => "OS icon",
             HostFormField::Password => "Password",
             HostFormField::Username => "Username",
@@ -648,6 +663,10 @@ impl HostFormField {
 
     pub(crate) fn is_toggle(self) -> bool {
         matches!(self, HostFormField::ForwardAgent)
+    }
+
+    pub(crate) fn is_tri_state(self) -> bool {
+        matches!(self, HostFormField::SessionLogging)
     }
 }
 
@@ -820,7 +839,7 @@ impl HostFormEdit {
             HostFormField::Tags => &self.tags,
             HostFormField::ProxyJump => &self.proxy_jump,
             HostFormField::RemoteCommand => &self.remote_command,
-            HostFormField::ForwardAgent => "",
+            HostFormField::ForwardAgent | HostFormField::SessionLogging => "",
             HostFormField::Password => &self.password,
         }
     }
@@ -838,7 +857,7 @@ impl HostFormEdit {
             HostFormField::Tags => &mut self.tags,
             HostFormField::ProxyJump => &mut self.proxy_jump,
             HostFormField::RemoteCommand => &mut self.remote_command,
-            HostFormField::ForwardAgent => &mut self.address,
+            HostFormField::ForwardAgent | HostFormField::SessionLogging => &mut self.address,
             HostFormField::Password => &mut self.password,
         }
     }

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -917,7 +917,7 @@ impl HostDetailEdit {
             DetailEditField::Tags => &mut self.tags,
             DetailEditField::Description => &mut self.description,
             DetailEditField::Environment => &mut self.environment,
-            DetailEditField::SessionLogging => &mut self.tags,
+            DetailEditField::SessionLogging => &mut self.environment,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,36 @@ fn default_true() -> bool {
     true
 }
 
+fn default_session_log_max_bytes() -> u64 {
+    10 * 1024 * 1024
+}
+
+fn default_session_log_retention() -> usize {
+    50
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionLoggingConfig {
+    /// When true, embedded SSH sessions write PTY output to log files unless a
+    /// per-host override disables it.
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_session_log_max_bytes")]
+    pub max_file_bytes: u64,
+    #[serde(default = "default_session_log_retention")]
+    pub retention_files: usize,
+}
+
+impl Default for SessionLoggingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_file_bytes: default_session_log_max_bytes(),
+            retention_files: default_session_log_retention(),
+        }
+    }
+}
+
 fn default_date_format() -> String {
     "%Y-%m-%d %H:%M".to_string()
 }
@@ -69,6 +99,8 @@ pub struct AppConfig {
     #[serde(default)]
     pub appearance: AppearanceConfig,
     #[serde(default)]
+    pub session_logging: SessionLoggingConfig,
+    #[serde(default)]
     pub keybinds: KeybindsConfig,
 }
 
@@ -78,6 +110,7 @@ impl Default for AppConfig {
             terminal: TerminalKind::Kitty,
             launch_command: None,
             appearance: AppearanceConfig::default(),
+            session_logging: SessionLoggingConfig::default(),
             keybinds: KeybindsConfig::default(),
         }
     }
@@ -295,6 +328,14 @@ mod tests {
         assert!(config.launch_command.is_none());
         assert!(config.appearance.show_detail_panel);
         assert_eq!(config.appearance.date_format, "%Y-%m-%d %H:%M");
+    }
+
+    #[test]
+    fn parse_config_session_logging_defaults() {
+        let config = parse_config_str("").unwrap();
+        assert!(!config.session_logging.enabled);
+        assert_eq!(config.session_logging.max_file_bytes, 10 * 1024 * 1024);
+        assert_eq!(config.session_logging.retention_files, 50);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod ping;
 pub mod search;
 pub mod secure_fs;
 pub mod session;
+pub mod session_log;
 pub mod sftp;
 pub mod ssh;
 pub mod store;

--- a/src/metadata/db.rs
+++ b/src/metadata/db.rs
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS host_metadata (
     description    TEXT,
     environment    TEXT,
     favorite       INTEGER NOT NULL DEFAULT 0,
-    last_connected INTEGER
+    last_connected INTEGER,
+    session_logging INTEGER
 );
 ";
 
@@ -44,6 +45,7 @@ impl MetadataDb {
         crate::secure_fs::restrict_file(path);
         conn.execute_batch("PRAGMA busy_timeout = 5000;")?;
         conn.execute_batch(SCHEMA)?;
+        migrate_metadata_columns(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -52,6 +54,7 @@ impl MetadataDb {
     fn open_in_memory() -> Result<Self> {
         let conn = Connection::open_in_memory()?;
         conn.execute_batch(SCHEMA)?;
+        migrate_metadata_columns(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
         })
@@ -69,6 +72,17 @@ impl MetadataDb {
     }
 }
 
+fn migrate_metadata_columns(conn: &Connection) -> Result<()> {
+    let has_col: bool = conn
+        .prepare("SELECT COUNT(*) FROM pragma_table_info('host_metadata') WHERE name = 'session_logging'")?
+        .query_row([], |row| row.get::<_, i64>(0))
+        .map(|c| c > 0)?;
+    if !has_col {
+        conn.execute_batch("ALTER TABLE host_metadata ADD COLUMN session_logging INTEGER;")?;
+    }
+    Ok(())
+}
+
 impl Default for MetadataDb {
     fn default() -> Self {
         Self::open_in_memory().expect("open in-memory metadata db")
@@ -79,7 +93,7 @@ impl MetadataStore for MetadataDb {
     fn get(&self, host_name: &str) -> Result<Option<HostMetadata>> {
         self.with_conn(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT host_name, tags, description, environment, favorite, last_connected
+                "SELECT host_name, tags, description, environment, favorite, last_connected, session_logging
                  FROM host_metadata WHERE host_name = ?1",
             )?;
             stmt.query_row(params![host_name], row_to_metadata)
@@ -91,7 +105,7 @@ impl MetadataStore for MetadataDb {
     fn get_all(&self) -> Result<Vec<HostMetadata>> {
         self.with_conn(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT host_name, tags, description, environment, favorite, last_connected
+                "SELECT host_name, tags, description, environment, favorite, last_connected, session_logging
                  FROM host_metadata ORDER BY host_name",
             )?;
             let rows = stmt.query_map([], row_to_metadata)?;
@@ -106,14 +120,15 @@ impl MetadataStore for MetadataDb {
         self.with_conn(|conn| {
             conn.execute(
                 "INSERT INTO host_metadata
-                    (host_name, tags, description, environment, favorite, last_connected)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                    (host_name, tags, description, environment, favorite, last_connected, session_logging)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
                  ON CONFLICT(host_name) DO UPDATE SET
                     tags = excluded.tags,
                     description = excluded.description,
                     environment = excluded.environment,
                     favorite = excluded.favorite,
-                    last_connected = excluded.last_connected",
+                    last_connected = excluded.last_connected,
+                    session_logging = excluded.session_logging",
                 params![
                     meta.host_name,
                     tags_json,
@@ -121,6 +136,7 @@ impl MetadataStore for MetadataDb {
                     meta.environment,
                     favorite,
                     meta.last_connected,
+                    meta.session_logging.to_db(),
                 ],
             )?;
             Ok(())
@@ -221,6 +237,7 @@ fn row_to_metadata(row: &rusqlite::Row<'_>) -> rusqlite::Result<HostMetadata> {
         environment: row.get(3)?,
         favorite: row.get::<_, i64>(4)? != 0,
         last_connected: row.get(5)?,
+        session_logging: crate::session_log::SessionLoggingOverride::from_db(row.get(6).ok()),
     })
 }
 
@@ -248,6 +265,7 @@ mod tests {
             environment: Some("prod".into()),
             favorite: true,
             last_connected: Some(1_700_000_000),
+            ..Default::default()
         };
 
         db.upsert(&meta).unwrap();

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -10,6 +10,7 @@ pub struct HostMetadata {
     pub environment: Option<String>,
     pub favorite: bool,
     pub last_connected: Option<i64>,
+    pub session_logging: crate::session_log::SessionLoggingOverride,
 }
 
 impl HostMetadata {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -262,6 +262,11 @@ impl Session {
         })
     }
 
+    /// Attach a session log writer after the PTY child is running.
+    pub fn set_log(&mut self, log: crate::session_log::SessionLogWriter) {
+        self.log = Some(log);
+    }
+
     // ── Text selection ────────────────────────────────────────────
 
     /// Begin a selection at visible cell (row, col).

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -189,11 +189,18 @@ pub struct Session {
     /// edge), `-1` toward older (top edge); `col` is the pointer column to keep
     /// extending the selection to. `None` = not autoscrolling.
     drag_autoscroll: Option<(i32, u16)>,
+    /// Optional PTY transcript writer; closed on session end.
+    log: Option<crate::session_log::SessionLogWriter>,
 }
 
 impl Session {
     /// Spawn the child on a freshly allocated PTY and start the reader thread.
-    pub fn spawn(config: SessionConfig, rows: u16, cols: u16) -> Result<Self> {
+    pub fn spawn(
+        config: SessionConfig,
+        rows: u16,
+        cols: u16,
+        log: Option<crate::session_log::SessionLogWriter>,
+    ) -> Result<Self> {
         // Reserve 1 row for header + 1 row for footer; ensure non-zero PTY.
         let pty_rows = rows.saturating_sub(2).max(1);
         let pty_cols = cols.max(1);
@@ -251,6 +258,7 @@ impl Session {
             copy_notice: None,
             drag_autoscroll: None,
             config,
+            log,
         })
     }
 
@@ -432,6 +440,13 @@ impl Session {
             match event {
                 PtyEvent::Bytes(bytes) => {
                     self.parser.process(&bytes);
+                    if let Some(log) = self.log.as_mut() {
+                        if log.append(&bytes).is_err() {
+                            self.diagnostics
+                                .push("session log write failed; logging disabled".into());
+                            self.log = None;
+                        }
+                    }
                     had_bytes = true;
                     self.saw_pty_bytes = true;
                 }
@@ -876,6 +891,9 @@ fn line_before_cursor(screen: &vt100::Screen) -> String {
 
 impl Drop for Session {
     fn drop(&mut self) {
+        if let Some(log) = self.log.take() {
+            let _ = log.close();
+        }
         // PtyRuntime::Drop kills the child and joins the reader thread.
     }
 }
@@ -1023,7 +1041,7 @@ mod prompt_tests {
             meta: SessionMeta::default(),
             pending_secret: None,
         };
-        let mut s = Session::spawn(config, 24, 80).unwrap();
+        let mut s = Session::spawn(config, 24, 80, None).unwrap();
 
         // Pump the reader threads; both writes are tiny and immediate.
         let mut got_err = false;
@@ -1072,7 +1090,7 @@ mod prompt_tests {
             meta: SessionMeta::default(),
             pending_secret: None,
         };
-        let mut s = Session::spawn(config, 24, 80).unwrap();
+        let mut s = Session::spawn(config, 24, 80, None).unwrap();
         // The child's exit and its stderr bytes race between the two reader
         // threads; the main loop keeps draining regardless, so wait for both.
         let mut exited = false;

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -151,6 +151,7 @@ pub struct SessionLogWriter {
     max_file_bytes: u64,
     retention_files: usize,
     file_serial: u32,
+    closed: bool,
 }
 
 impl SessionLogWriter {
@@ -182,6 +183,7 @@ impl SessionLogWriter {
             max_file_bytes,
             retention_files,
             file_serial: 0,
+            closed: false,
         })
     }
 
@@ -221,13 +223,16 @@ impl SessionLogWriter {
     pub fn close(mut self) -> Result<()> {
         self.writer.flush()?;
         prune_retention(&self.host_dir, self.retention_files)?;
-        std::mem::forget(self);
+        self.closed = true;
         Ok(())
     }
 }
 
 impl Drop for SessionLogWriter {
     fn drop(&mut self) {
+        if self.closed {
+            return;
+        }
         let _ = self.writer.flush();
         let _ = prune_retention(&self.host_dir, self.retention_files);
     }

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -1,8 +1,9 @@
 //! PTY session transcript logging to plain-text files under the data directory.
 
-use std::fs::{self, File};
+use std::fs::{self, File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
@@ -83,16 +84,50 @@ pub fn sanitize_host_dir(name: &str) -> String {
     }
 }
 
-fn timestamp_filename(serial: u32) -> String {
-    let secs = SystemTime::now()
+fn timestamp_secs() -> u64 {
+    SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
-        .as_secs();
+        .as_secs()
+}
+
+static OPEN_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn unique_log_filename(serial: u32) -> String {
+    let secs = timestamp_secs();
+    let pid = std::process::id();
+    let open_id = OPEN_COUNTER.fetch_add(1, Ordering::Relaxed);
     if serial == 0 {
-        format!("{secs}.log")
+        format!("{secs}-{pid}-{open_id}.log")
     } else {
-        format!("{secs}-{serial}.log")
+        format!("{secs}-{pid}-{open_id}-{serial}.log")
     }
+}
+
+fn create_unique_log_file(host_dir: &Path, serial: u32) -> Result<(PathBuf, File)> {
+    let base_name = unique_log_filename(serial);
+    for attempt in 0..100u32 {
+        let name = if attempt == 0 {
+            base_name.clone()
+        } else {
+            format!("{}-{}.log", base_name.trim_end_matches(".log"), attempt)
+        };
+        let path = host_dir.join(&name);
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => {
+                secure_fs::restrict_file(&path);
+                return Ok((path, file));
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => {
+                return Err(e).with_context(|| format!("create session log {}", path.display()));
+            }
+        }
+    }
+    anyhow::bail!(
+        "could not allocate unique session log filename in {}",
+        host_dir.display()
+    )
 }
 
 /// Append-only session log writer with size-based rotation and retention pruning.
@@ -124,10 +159,7 @@ impl SessionLogWriter {
             .with_context(|| format!("create host log dir {}", host_dir.display()))?;
         secure_fs::restrict_dir(&host_dir);
 
-        let current_path = host_dir.join(timestamp_filename(0));
-        let file = File::create(&current_path)
-            .with_context(|| format!("create session log {}", current_path.display()))?;
-        secure_fs::restrict_file(&current_path);
+        let (current_path, file) = create_unique_log_file(&host_dir, 0)?;
 
         Ok(Self {
             host_dir,
@@ -160,21 +192,26 @@ impl SessionLogWriter {
         self.writer.flush()?;
 
         self.file_serial += 1;
-        let new_path = self.host_dir.join(timestamp_filename(self.file_serial));
-        let file = File::create(&new_path)
-            .with_context(|| format!("rotate session log {}", new_path.display()))?;
-        secure_fs::restrict_file(&new_path);
+        let (new_path, file) = create_unique_log_file(&self.host_dir, self.file_serial)?;
         self.current_path = new_path;
         self.writer = BufWriter::new(file);
         self.bytes_written = 0;
+        prune_retention(&self.host_dir, self.retention_files)?;
         Ok(())
     }
 
     pub fn close(mut self) -> Result<()> {
         self.writer.flush()?;
-        drop(self.writer);
         prune_retention(&self.host_dir, self.retention_files)?;
+        std::mem::forget(self);
         Ok(())
+    }
+}
+
+impl Drop for SessionLogWriter {
+    fn drop(&mut self) {
+        let _ = self.writer.flush();
+        let _ = prune_retention(&self.host_dir, self.retention_files);
     }
 }
 
@@ -185,11 +222,7 @@ pub fn prune_retention(host_dir: &Path, retention_files: usize) -> Result<()> {
     }
     let mut logs: Vec<(PathBuf, std::time::SystemTime)> = fs::read_dir(host_dir)?
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .is_some_and(|ext| ext == "log")
-        })
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "log"))
         .filter_map(|e| {
             let mtime = e.metadata().ok()?.modified().ok()?;
             Some((e.path(), mtime))
@@ -274,6 +307,17 @@ mod tests {
         let second = w.path().to_path_buf();
         assert_ne!(first, second);
         w.close()?;
+        Ok(())
+    }
+
+    #[test]
+    fn concurrent_opens_get_distinct_files_same_second() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let w1 = SessionLogWriter::open(tmp.path(), "web", 1024, 10)?;
+        let w2 = SessionLogWriter::open(tmp.path(), "web", 1024, 10)?;
+        assert_ne!(w1.path(), w2.path());
+        drop(w1);
+        drop(w2);
         Ok(())
     }
 }

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -1,0 +1,279 @@
+//! PTY session transcript logging to plain-text files under the data directory.
+
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+
+use crate::secure_fs;
+
+/// Per-host override for session logging (tri-state).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SessionLoggingOverride {
+    #[default]
+    Inherit,
+    On,
+    Off,
+}
+
+impl SessionLoggingOverride {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Inherit => "inherit",
+            Self::On => "on",
+            Self::Off => "off",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::Inherit => Self::On,
+            Self::On => Self::Off,
+            Self::Off => Self::Inherit,
+        }
+    }
+
+    pub fn from_db(value: Option<i64>) -> Self {
+        match value {
+            None => Self::Inherit,
+            Some(0) => Self::Off,
+            Some(1) => Self::On,
+            _ => Self::Inherit,
+        }
+    }
+
+    pub fn to_db(self) -> Option<i64> {
+        match self {
+            Self::Inherit => None,
+            Self::On => Some(1),
+            Self::Off => Some(0),
+        }
+    }
+}
+
+/// Resolve whether logging is active for a connect attempt.
+pub fn effective_enabled(global: bool, host_override: SessionLoggingOverride) -> bool {
+    match host_override {
+        SessionLoggingOverride::Inherit => global,
+        SessionLoggingOverride::On => true,
+        SessionLoggingOverride::Off => false,
+    }
+}
+
+/// Sanitize a host name for use as a single path segment.
+pub fn sanitize_host_dir(name: &str) -> String {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return "_unknown".to_string();
+    }
+    let mut out = String::with_capacity(trimmed.len());
+    for ch in trimmed.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() || out == "." || out == ".." {
+        "_unknown".to_string()
+    } else {
+        out
+    }
+}
+
+fn timestamp_filename(serial: u32) -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    if serial == 0 {
+        format!("{secs}.log")
+    } else {
+        format!("{secs}-{serial}.log")
+    }
+}
+
+/// Append-only session log writer with size-based rotation and retention pruning.
+pub struct SessionLogWriter {
+    host_dir: PathBuf,
+    current_path: PathBuf,
+    writer: BufWriter<File>,
+    bytes_written: u64,
+    max_file_bytes: u64,
+    retention_files: usize,
+    file_serial: u32,
+}
+
+impl SessionLogWriter {
+    pub fn open(
+        base_dir: impl AsRef<Path>,
+        host_name: &str,
+        max_file_bytes: u64,
+        retention_files: usize,
+    ) -> Result<Self> {
+        let base_dir = base_dir.as_ref().to_path_buf();
+        let logs_root = base_dir.join("logs");
+        fs::create_dir_all(&logs_root)
+            .with_context(|| format!("create session logs dir {}", logs_root.display()))?;
+        secure_fs::restrict_dir(&logs_root);
+
+        let host_dir = logs_root.join(sanitize_host_dir(host_name));
+        fs::create_dir_all(&host_dir)
+            .with_context(|| format!("create host log dir {}", host_dir.display()))?;
+        secure_fs::restrict_dir(&host_dir);
+
+        let current_path = host_dir.join(timestamp_filename(0));
+        let file = File::create(&current_path)
+            .with_context(|| format!("create session log {}", current_path.display()))?;
+        secure_fs::restrict_file(&current_path);
+
+        Ok(Self {
+            host_dir,
+            current_path,
+            writer: BufWriter::new(file),
+            bytes_written: 0,
+            max_file_bytes,
+            retention_files,
+            file_serial: 0,
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.current_path
+    }
+
+    pub fn append(&mut self, bytes: &[u8]) -> Result<()> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        self.writer.write_all(bytes)?;
+        self.bytes_written += bytes.len() as u64;
+        if self.bytes_written >= self.max_file_bytes {
+            self.rotate()?;
+        }
+        Ok(())
+    }
+
+    fn rotate(&mut self) -> Result<()> {
+        self.writer.flush()?;
+
+        self.file_serial += 1;
+        let new_path = self.host_dir.join(timestamp_filename(self.file_serial));
+        let file = File::create(&new_path)
+            .with_context(|| format!("rotate session log {}", new_path.display()))?;
+        secure_fs::restrict_file(&new_path);
+        self.current_path = new_path;
+        self.writer = BufWriter::new(file);
+        self.bytes_written = 0;
+        Ok(())
+    }
+
+    pub fn close(mut self) -> Result<()> {
+        self.writer.flush()?;
+        drop(self.writer);
+        prune_retention(&self.host_dir, self.retention_files)?;
+        Ok(())
+    }
+}
+
+/// Delete oldest `.log` files beyond `retention_files` in `host_dir`.
+pub fn prune_retention(host_dir: &Path, retention_files: usize) -> Result<()> {
+    if retention_files == 0 {
+        return Ok(());
+    }
+    let mut logs: Vec<(PathBuf, std::time::SystemTime)> = fs::read_dir(host_dir)?
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|ext| ext == "log")
+        })
+        .filter_map(|e| {
+            let mtime = e.metadata().ok()?.modified().ok()?;
+            Some((e.path(), mtime))
+        })
+        .collect();
+    if logs.len() <= retention_files {
+        return Ok(());
+    }
+    logs.sort_by_key(|(_, mtime)| *mtime);
+    let excess = logs.len().saturating_sub(retention_files);
+    for (path, _) in logs.into_iter().take(excess) {
+        let _ = fs::remove_file(path);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_host_dir_replaces_unsafe_chars() {
+        assert_eq!(sanitize_host_dir("web/prod"), "web_prod");
+        assert_eq!(sanitize_host_dir("  my-host  "), "my-host");
+        assert_eq!(sanitize_host_dir(".."), "_unknown");
+    }
+
+    #[test]
+    fn effective_enabled_respects_override() {
+        assert!(effective_enabled(true, SessionLoggingOverride::Inherit));
+        assert!(!effective_enabled(false, SessionLoggingOverride::Inherit));
+        assert!(effective_enabled(false, SessionLoggingOverride::On));
+        assert!(!effective_enabled(true, SessionLoggingOverride::Off));
+    }
+
+    #[test]
+    fn override_db_roundtrip() {
+        assert_eq!(
+            SessionLoggingOverride::from_db(SessionLoggingOverride::On.to_db()),
+            SessionLoggingOverride::On
+        );
+        assert_eq!(
+            SessionLoggingOverride::from_db(SessionLoggingOverride::Inherit.to_db()),
+            SessionLoggingOverride::Inherit
+        );
+    }
+
+    #[test]
+    fn writer_appends_and_prunes_old_logs() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let mut w = SessionLogWriter::open(tmp.path(), "web", 1024, 2)?;
+        w.append(b"hello")?;
+        let first = w.path().to_path_buf();
+        w.close()?;
+
+        // Seed two stale files so retention keeps only the newest two.
+        let host_dir = tmp.path().join("logs").join("web");
+        fs::write(host_dir.join("old1.log"), b"x")?;
+        fs::write(host_dir.join("old2.log"), b"x")?;
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        let mut w2 = SessionLogWriter::open(tmp.path(), "web", 1024, 2)?;
+        w2.append(b"world")?;
+        w2.close()?;
+
+        let count = fs::read_dir(&host_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "log"))
+            .count();
+        assert!(count <= 2, "retention should cap at 2 files");
+        assert!(first.exists() || count >= 1);
+        Ok(())
+    }
+
+    #[test]
+    fn rotate_on_size_limit() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let mut w = SessionLogWriter::open(tmp.path(), "db", 8, 10)?;
+        let first = w.path().to_path_buf();
+        w.append(b"12345678")?;
+        w.append(b"X")?;
+        let second = w.path().to_path_buf();
+        assert_ne!(first, second);
+        w.close()?;
+        Ok(())
+    }
+}

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -63,6 +63,18 @@ pub fn effective_enabled(global: bool, host_override: SessionLoggingOverride) ->
     }
 }
 
+/// Build the per-host log directory segment under `logs/`.
+///
+/// Managed hosts include a stable id so colliding sanitized names (e.g.
+/// `web/prod` and `web_prod` both → `web_prod`) stay in separate dirs.
+pub fn host_log_dir_name(host_name: &str, host_id: Option<i64>) -> String {
+    let sanitized = sanitize_host_dir(host_name);
+    match host_id {
+        Some(id) => format!("{sanitized}-{id}"),
+        None => sanitized,
+    }
+}
+
 /// Sanitize a host name for use as a single path segment.
 pub fn sanitize_host_dir(name: &str) -> String {
     let trimmed = name.trim();
@@ -145,6 +157,7 @@ impl SessionLogWriter {
     pub fn open(
         base_dir: impl AsRef<Path>,
         host_name: &str,
+        host_id: Option<i64>,
         max_file_bytes: u64,
         retention_files: usize,
     ) -> Result<Self> {
@@ -154,7 +167,7 @@ impl SessionLogWriter {
             .with_context(|| format!("create session logs dir {}", logs_root.display()))?;
         secure_fs::restrict_dir(&logs_root);
 
-        let host_dir = logs_root.join(sanitize_host_dir(host_name));
+        let host_dir = logs_root.join(host_log_dir_name(host_name, host_id));
         fs::create_dir_all(&host_dir)
             .with_context(|| format!("create host log dir {}", host_dir.display()))?;
         secure_fs::restrict_dir(&host_dir);
@@ -174,6 +187,11 @@ impl SessionLogWriter {
 
     pub fn path(&self) -> &Path {
         &self.current_path
+    }
+
+    /// Directory holding this host's rotated log segments.
+    pub fn host_dir(&self) -> &Path {
+        &self.host_dir
     }
 
     pub fn append(&mut self, bytes: &[u8]) -> Result<()> {
@@ -244,6 +262,17 @@ mod tests {
     use super::*;
 
     #[test]
+    fn host_log_dir_name_distinct_for_colliding_sanitized_names() {
+        assert_eq!(host_log_dir_name("web/prod", Some(1)), "web_prod-1");
+        assert_eq!(host_log_dir_name("web_prod", Some(2)), "web_prod-2");
+        assert_ne!(
+            host_log_dir_name("web/prod", Some(1)),
+            host_log_dir_name("web_prod", Some(2))
+        );
+        assert_eq!(host_log_dir_name("legacy", None), "legacy");
+    }
+
+    #[test]
     fn sanitize_host_dir_replaces_unsafe_chars() {
         assert_eq!(sanitize_host_dir("web/prod"), "web_prod");
         assert_eq!(sanitize_host_dir("  my-host  "), "my-host");
@@ -273,7 +302,7 @@ mod tests {
     #[test]
     fn writer_appends_and_prunes_old_logs() -> Result<()> {
         let tmp = tempfile::tempdir()?;
-        let mut w = SessionLogWriter::open(tmp.path(), "web", 1024, 2)?;
+        let mut w = SessionLogWriter::open(tmp.path(), "web", None, 1024, 2)?;
         w.append(b"hello")?;
         let first = w.path().to_path_buf();
         w.close()?;
@@ -284,7 +313,7 @@ mod tests {
         fs::write(host_dir.join("old2.log"), b"x")?;
         std::thread::sleep(std::time::Duration::from_millis(5));
 
-        let mut w2 = SessionLogWriter::open(tmp.path(), "web", 1024, 2)?;
+        let mut w2 = SessionLogWriter::open(tmp.path(), "web", None, 1024, 2)?;
         w2.append(b"world")?;
         w2.close()?;
 
@@ -300,7 +329,7 @@ mod tests {
     #[test]
     fn rotate_on_size_limit() -> Result<()> {
         let tmp = tempfile::tempdir()?;
-        let mut w = SessionLogWriter::open(tmp.path(), "db", 8, 10)?;
+        let mut w = SessionLogWriter::open(tmp.path(), "db", None, 8, 10)?;
         let first = w.path().to_path_buf();
         w.append(b"12345678")?;
         w.append(b"X")?;
@@ -313,9 +342,20 @@ mod tests {
     #[test]
     fn concurrent_opens_get_distinct_files_same_second() -> Result<()> {
         let tmp = tempfile::tempdir()?;
-        let w1 = SessionLogWriter::open(tmp.path(), "web", 1024, 10)?;
-        let w2 = SessionLogWriter::open(tmp.path(), "web", 1024, 10)?;
+        let w1 = SessionLogWriter::open(tmp.path(), "web", None, 1024, 10)?;
+        let w2 = SessionLogWriter::open(tmp.path(), "web", None, 1024, 10)?;
         assert_ne!(w1.path(), w2.path());
+        drop(w1);
+        drop(w2);
+        Ok(())
+    }
+
+    #[test]
+    fn managed_hosts_with_colliding_names_use_distinct_dirs() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let w1 = SessionLogWriter::open(tmp.path(), "web/prod", Some(1), 1024, 10)?;
+        let w2 = SessionLogWriter::open(tmp.path(), "web_prod", Some(2), 1024, 10)?;
+        assert_ne!(w1.host_dir(), w2.host_dir());
         drop(w1);
         drop(w2);
         Ok(())

--- a/src/ssh/export.rs
+++ b/src/ssh/export.rs
@@ -227,6 +227,7 @@ mod tests {
                 environment: None,
                 favorite: false,
                 last_connected: None,
+                ..Default::default()
             })
             .unwrap();
 

--- a/src/ssh/import.rs
+++ b/src/ssh/import.rs
@@ -380,6 +380,7 @@ mod tests {
                 environment: None,
                 favorite: true,
                 last_connected: Some(42),
+                ..Default::default()
             })
             .unwrap();
 

--- a/src/ssh/import.rs
+++ b/src/ssh/import.rs
@@ -100,6 +100,7 @@ fn build_sync_import(
         environment: existing.environment.clone(),
         favorite: existing.favorite,
         last_connected: existing.last_connected,
+        session_logging: existing.session_logging,
     }
 }
 
@@ -135,15 +136,23 @@ fn build_import_row(
     let port = resolved.port.unwrap_or(22);
 
     let meta = metadata.get(name)?;
-    let (tags, notes, environment, favorite, last_connected) = match meta {
+    let (tags, notes, environment, favorite, last_connected, session_logging) = match meta {
         Some(m) => (
             m.tags,
             m.description,
             m.environment,
             m.favorite,
             m.last_connected,
+            m.session_logging,
         ),
-        None => (Vec::new(), None, None, false, None),
+        None => (
+            Vec::new(),
+            None,
+            None,
+            false,
+            None,
+            crate::session_log::SessionLoggingOverride::Inherit,
+        ),
     };
 
     Ok(SshConfigHostImport {
@@ -159,6 +168,7 @@ fn build_import_row(
         environment,
         favorite,
         last_connected,
+        session_logging,
     })
 }
 
@@ -380,7 +390,7 @@ mod tests {
                 environment: None,
                 favorite: true,
                 last_connected: Some(42),
-                ..Default::default()
+                session_logging: crate::session_log::SessionLoggingOverride::On,
             })
             .unwrap();
 
@@ -395,5 +405,9 @@ mod tests {
         assert_eq!(imported.notes.as_deref(), Some("Primary"));
         assert!(imported.favorite);
         assert_eq!(imported.last_connected, Some(42));
+        assert_eq!(
+            imported.session_logging,
+            crate::session_log::SessionLoggingOverride::On
+        );
     }
 }

--- a/src/store/hosts.rs
+++ b/src/store/hosts.rs
@@ -543,8 +543,8 @@ impl LauncherStore {
                 "INSERT INTO hosts
                     (name, label, address, port, tags, notes, environment, proxy_jump, forward_agent,
                      remote_command, favorite, last_connected, source, ssh_config_hash,
-                     created_at, updated_at)
-                 VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?13, ?6, ?7, ?8, ?9, ?10, 'ssh_config', ?11, ?12, ?12)",
+                     session_logging, created_at, updated_at)
+                 VALUES (?1, NULL, ?2, ?3, ?4, ?5, ?13, ?6, ?7, ?8, ?9, ?10, 'ssh_config', ?11, ?14, ?12, ?12)",
                 params![
                     import.name,
                     import.address,
@@ -559,6 +559,7 @@ impl LauncherStore {
                     import.ssh_config_hash,
                     now,
                     import.environment,
+                    import.session_logging.to_db(),
                 ],
             )?;
             if import.favorite {

--- a/src/store/hosts.rs
+++ b/src/store/hosts.rs
@@ -7,6 +7,7 @@ use super::types::{
     NewHost, NewHostGroup, SshConfigHostImport, UpsertSshConfigOutcome,
 };
 use super::LauncherStore;
+use crate::session_log::SessionLoggingOverride;
 
 impl LauncherStore {
     // --- host groups ---
@@ -213,9 +214,10 @@ impl LauncherStore {
                 "INSERT INTO hosts
                     (name, label, address, port, group_id, identity_id, os_icon, tags, notes,
                      proxy_jump, forward_agent, remote_command, source, has_password, username,
-                     sort_order, created_at, updated_at)
+                     session_logging, sort_order, created_at, updated_at)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
-                     (SELECT COALESCE(MAX(sort_order), 0) + 1 FROM hosts), ?16, ?16)",
+                     ?16,
+                     (SELECT COALESCE(MAX(sort_order), 0) + 1 FROM hosts), ?17, ?17)",
                 params![
                     host.name,
                     host.label,
@@ -232,6 +234,7 @@ impl LauncherStore {
                     source,
                     i64::from(host.has_password),
                     host.username,
+                    host.session_logging.to_db(),
                     now,
                 ],
             )?;
@@ -358,6 +361,9 @@ impl LauncherStore {
                 Some(v) => v.clone(),
                 None => current.username.clone(),
             };
+            let session_logging = update
+                .session_logging
+                .unwrap_or(current.session_logging);
             let tags_json = tags_to_json(&tags)?;
             let now = now_ts();
 
@@ -366,7 +372,7 @@ impl LauncherStore {
                  SET name = ?1, label = ?2, address = ?3, port = ?4, group_id = ?5, identity_id = ?6,
                      os_icon = ?7, tags = ?8, notes = ?9, proxy_jump = ?10, forward_agent = ?11,
                      remote_command = ?12, favorite = ?13, sort_order = ?14, has_password = ?15, username = ?16, updated_at = ?17,
-                     environment = ?19
+                     environment = ?19, session_logging = ?20
                  WHERE id = ?18",
                 params![
                     name,
@@ -388,6 +394,7 @@ impl LauncherStore {
                     now,
                     id,
                     environment,
+                    session_logging.to_db(),
                 ],
             )?;
 
@@ -616,6 +623,7 @@ impl LauncherStore {
             source: HostSource::Launcher,
             has_password: false,
             username: current.username.clone(),
+            session_logging: current.session_logging,
         })
         .map(Some)
     }
@@ -629,13 +637,14 @@ impl LauncherStore {
         via: &str,
         status: &str,
         note: &str,
+        log_path: Option<&str>,
     ) -> Result<()> {
         let now = now_ts();
         self.with_conn(|conn| {
             conn.execute(
-                "INSERT INTO auth_events (host_name, username, via, status, note, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                params![host_name, username, via, status, note, now],
+                "INSERT INTO auth_events (host_name, username, via, status, note, log_path, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![host_name, username, via, status, note, log_path, now],
             )?;
             Ok(())
         })
@@ -644,7 +653,7 @@ impl LauncherStore {
     pub fn list_auth_events(&self, limit: usize) -> Result<Vec<AuthEvent>> {
         self.with_conn(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT id, host_name, username, via, status, note, created_at
+                "SELECT id, host_name, username, via, status, note, log_path, created_at
                  FROM auth_events ORDER BY created_at DESC LIMIT ?1",
             )?;
             let rows = stmt.query_map(params![limit as i64], |row| {
@@ -655,7 +664,8 @@ impl LauncherStore {
                     via: row.get(3)?,
                     status: row.get(4)?,
                     note: row.get(5)?,
-                    created_at: row.get(6)?,
+                    log_path: row.get(6)?,
+                    created_at: row.get(7)?,
                 })
             })?;
             rows.collect::<rusqlite::Result<Vec<_>>>()
@@ -671,7 +681,7 @@ impl LauncherStore {
     ) -> Result<Vec<AuthEvent>> {
         self.with_conn(|conn| {
             let mut sql = String::from(
-                "SELECT id, host_name, username, via, status, note, created_at FROM auth_events",
+                "SELECT id, host_name, username, via, status, note, log_path, created_at FROM auth_events",
             );
             let mut conditions = Vec::new();
             if status_filter.is_some() {
@@ -719,7 +729,8 @@ impl LauncherStore {
                     via: row.get(3)?,
                     status: row.get(4)?,
                     note: row.get(5)?,
-                    created_at: row.get(6)?,
+                    log_path: row.get(6)?,
+                    created_at: row.get(7)?,
                 })
             })?;
             rows.collect::<rusqlite::Result<Vec<_>>>()
@@ -759,7 +770,7 @@ fn load_host_by_id(conn: &rusqlite::Connection, id: i64) -> Result<Option<Manage
                 h.has_password, h.created_at, h.updated_at, h.username,
                 g.id, g.name, g.sort_order,
                 i.id, i.name, i.username, i.private_key, i.certificate, i.has_password,
-                h.environment
+                h.environment, h.session_logging
          FROM hosts h
          LEFT JOIN host_groups g ON g.id = h.group_id
          LEFT JOIN identities i ON i.id = h.identity_id
@@ -994,6 +1005,7 @@ fn row_to_managed_host(row: &rusqlite::Row<'_>) -> rusqlite::Result<ManagedHost>
         ssh_config_hash: row.get(17)?,
         has_password: row.get::<_, i64>(18).unwrap_or(0) != 0,
         username: row.get(21)?,
+        session_logging: SessionLoggingOverride::from_db(row.get(32).ok()),
         created_at: row.get(19)?,
         updated_at: row.get(20)?,
     })
@@ -1079,18 +1091,50 @@ mod tests {
     fn auth_stats_count_launched_as_success() {
         let store = LauncherStore::open_in_memory().unwrap();
         store
-            .log_auth_event("h1", Some("root"), "direct", "launched", "session started")
+            .log_auth_event(
+                "h1",
+                Some("root"),
+                "direct",
+                "launched",
+                "session started",
+                None,
+            )
             .unwrap();
         store
-            .log_auth_event("h2", Some("root"), "direct", "launched", "session started")
+            .log_auth_event(
+                "h2",
+                Some("root"),
+                "direct",
+                "launched",
+                "session started",
+                None,
+            )
             .unwrap();
         store
-            .log_auth_event("h3", None, "direct", "fail", "spawn failed")
+            .log_auth_event("h3", None, "direct", "fail", "spawn failed", None)
             .unwrap();
 
         let (ok, fail) = store.auth_event_stats(7).unwrap();
         assert_eq!(ok, 2, "launched connects must count as ok");
         assert_eq!(fail, 1);
+    }
+
+    #[test]
+    fn auth_event_log_path_roundtrip() {
+        let store = LauncherStore::open_in_memory().unwrap();
+        let path = "/tmp/sshub/logs/web/123.log";
+        store
+            .log_auth_event(
+                "web",
+                Some("root"),
+                "direct",
+                "launched",
+                "session started",
+                Some(path),
+            )
+            .unwrap();
+        let events = store.list_auth_events(1).unwrap();
+        assert_eq!(events[0].log_path.as_deref(), Some(path));
     }
 
     #[cfg(unix)]

--- a/src/store/hosts.rs
+++ b/src/store/hosts.rs
@@ -1123,7 +1123,7 @@ mod tests {
     #[test]
     fn auth_event_log_path_roundtrip() {
         let store = LauncherStore::open_in_memory().unwrap();
-        let path = "/tmp/sshub/logs/web/123.log";
+        let path = "/tmp/sshub/logs/web/";
         store
             .log_auth_event(
                 "web",
@@ -1136,6 +1136,24 @@ mod tests {
             .unwrap();
         let events = store.list_auth_events(1).unwrap();
         assert_eq!(events[0].log_path.as_deref(), Some(path));
+    }
+
+    #[test]
+    fn auth_event_log_dir_note_format() {
+        let store = LauncherStore::open_in_memory().unwrap();
+        let dir = "/home/user/.local/share/sshub/logs/web_prod-42";
+        store
+            .log_auth_event(
+                "web/prod",
+                Some("deploy"),
+                "direct",
+                "launched",
+                "session started",
+                Some(dir),
+            )
+            .unwrap();
+        let events = store.list_auth_events(1).unwrap();
+        assert_eq!(events[0].log_path.as_deref(), Some(dir));
     }
 
     #[cfg(unix)]

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -3,7 +3,7 @@ use rusqlite::{params, Connection};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const SCHEMA_VERSION: i64 = 11;
+const SCHEMA_VERSION: i64 = 12;
 
 /// Name of the reserved, auto-created "Favorites" group. Membership in it is the
 /// source of truth for a host's favourite status.
@@ -117,6 +117,10 @@ pub(crate) fn run_migrations(conn: &Connection, launcher_path: &Path) -> Result<
 
     if current < 11 {
         migrate_v10_to_v11(conn)?;
+    }
+
+    if current < 12 {
+        migrate_v11_to_v12(conn)?;
     }
 
     // Runs last so all columns it writes to (e.g. environment) already exist.
@@ -446,6 +450,26 @@ fn migrate_v10_to_v11(conn: &Connection) -> Result<()> {
              SELECT id, ?1 FROM hosts WHERE favorite = 1",
         params![fav_id],
     )?;
+
+    Ok(())
+}
+
+fn migrate_v11_to_v12(conn: &Connection) -> Result<()> {
+    let has_hosts_col: bool = conn
+        .prepare("SELECT COUNT(*) FROM pragma_table_info('hosts') WHERE name = 'session_logging'")?
+        .query_row([], |row| row.get::<_, i64>(0))
+        .map(|c| c > 0)?;
+    if !has_hosts_col {
+        conn.execute_batch("ALTER TABLE hosts ADD COLUMN session_logging INTEGER;")?;
+    }
+
+    let has_log_path: bool = conn
+        .prepare("SELECT COUNT(*) FROM pragma_table_info('auth_events') WHERE name = 'log_path'")?
+        .query_row([], |row| row.get::<_, i64>(0))
+        .map(|c| c > 0)?;
+    if !has_log_path {
+        conn.execute_batch("ALTER TABLE auth_events ADD COLUMN log_path TEXT;")?;
+    }
 
     Ok(())
 }

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use crate::session_log::SessionLoggingOverride;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HostGroup {
     pub id: i64,
@@ -75,6 +77,7 @@ pub struct ManagedHost {
     pub ssh_config_hash: Option<String>,
     pub has_password: bool,
     pub username: Option<String>,
+    pub session_logging: SessionLoggingOverride,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -97,6 +100,7 @@ pub struct NewHost {
     pub source: HostSource,
     pub has_password: bool,
     pub username: Option<String>,
+    pub session_logging: SessionLoggingOverride,
 }
 
 impl Default for NewHost {
@@ -123,6 +127,7 @@ impl NewHost {
             source: HostSource::Launcher,
             has_password: false,
             username: None,
+            session_logging: SessionLoggingOverride::Inherit,
         }
     }
 }
@@ -147,6 +152,7 @@ pub struct HostUpdate {
     pub sort_order: Option<i32>,
     pub has_password: Option<bool>,
     pub username: Option<Option<String>>,
+    pub session_logging: Option<SessionLoggingOverride>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -237,6 +243,7 @@ pub struct AuthEvent {
     pub via: Option<String>,
     pub status: String,
     pub note: Option<String>,
+    pub log_path: Option<String>,
     pub created_at: i64,
 }
 

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -224,6 +224,7 @@ pub struct SshConfigHostImport {
     pub environment: Option<String>,
     pub favorite: bool,
     pub last_connected: Option<i64>,
+    pub session_logging: SessionLoggingOverride,
 }
 
 /// Outcome of upserting one imported ssh config host.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1101,7 +1101,7 @@ mod tests {
             },
             pending_secret: None,
         };
-        let session = crate::session::Session::spawn(config, 24, 80).unwrap();
+        let session = crate::session::Session::spawn(config, 24, 80, None).unwrap();
         app.sessions.push(session);
         app.active_session = Some(0);
         app.mode = AppMode::Connecting;
@@ -1138,7 +1138,7 @@ mod tests {
             },
             pending_secret: None,
         };
-        let session = crate::session::Session::spawn(config, 24, 80).unwrap();
+        let session = crate::session::Session::spawn(config, 24, 80, None).unwrap();
         app.sessions.push(session);
         app.active_session = Some(0);
         app.mode = AppMode::Connecting;
@@ -1157,7 +1157,7 @@ mod tests {
             meta: crate::session::SessionMeta::default(),
             pending_secret: None,
         };
-        let session = crate::session::Session::spawn(config, 24, 80).unwrap();
+        let session = crate::session::Session::spawn(config, 24, 80, None).unwrap();
         app.sessions.push(session);
         app.active_session = Some(0);
         // Stays on the dashboard (Normal), so the strip is what makes the

--- a/src/tui/screens/audit.rs
+++ b/src/tui/screens/audit.rs
@@ -282,3 +282,45 @@ fn truncate(s: &str, max: usize) -> &str {
         &s[..end]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::AuthEvent;
+
+    fn sample_event(note: Option<&str>, log_path: Option<&str>) -> AuthEvent {
+        AuthEvent {
+            id: 1,
+            host_name: "web".into(),
+            username: Some("deploy".into()),
+            via: Some("direct".into()),
+            status: "launched".into(),
+            note: note.map(str::to_string),
+            log_path: log_path.map(str::to_string),
+            created_at: 0,
+        }
+    }
+
+    #[test]
+    fn audit_note_appends_log_dir_to_session_started() {
+        let dir = "/home/user/.local/share/sshub/logs/web_prod-42";
+        let event = sample_event(Some("session started"), Some(dir));
+        assert_eq!(
+            audit_note(&event),
+            format!("session started (logs in {dir})")
+        );
+    }
+
+    #[test]
+    fn audit_note_uses_path_when_note_empty() {
+        let dir = "/tmp/sshub/logs/web/";
+        let event = sample_event(Some(""), Some(dir));
+        assert_eq!(audit_note(&event), dir);
+    }
+
+    #[test]
+    fn audit_note_note_only_without_log_path() {
+        let event = sample_event(Some("spawn failed"), None);
+        assert_eq!(audit_note(&event), "spawn failed");
+    }
+}

--- a/src/tui/screens/audit.rs
+++ b/src/tui/screens/audit.rs
@@ -258,7 +258,7 @@ fn table_columns(total_w: u16) -> Vec<(&'static str, u16)> {
 fn audit_note(event: &crate::store::AuthEvent) -> String {
     match (&event.note, &event.log_path) {
         (Some(note), Some(path)) if note.is_empty() => path.clone(),
-        (Some(note), Some(path)) => format!("{note} -> {path}"),
+        (Some(note), Some(path)) => format!("{note} (logs in {path})"),
         (Some(note), None) => note.clone(),
         (None, Some(path)) => path.clone(),
         (None, None) => String::new(),

--- a/src/tui/screens/audit.rs
+++ b/src/tui/screens/audit.rs
@@ -223,12 +223,12 @@ fn render_event_row(
     cx += result_w - 2;
 
     // NOTE
-    let note = event.note.as_deref().unwrap_or("");
+    let note = audit_note(event);
     let remaining = (x + w).saturating_sub(cx) as usize;
     buf.set_string(
         cx,
         y,
-        truncate(note, remaining),
+        truncate(&note, remaining),
         if selected { base_style } else { theme::dim() },
     );
 }
@@ -252,6 +252,16 @@ fn table_columns(total_w: u16) -> Vec<(&'static str, u16)> {
             ("RESULT", 8),
             ("NOTE", total_w.saturating_sub(56)),
         ]
+    }
+}
+
+fn audit_note(event: &crate::store::AuthEvent) -> String {
+    match (&event.note, &event.log_path) {
+        (Some(note), Some(path)) if note.is_empty() => path.clone(),
+        (Some(note), Some(path)) => format!("{note} -> {path}"),
+        (Some(note), None) => note.clone(),
+        (None, Some(path)) => path.clone(),
+        (None, None) => String::new(),
     }
 }
 

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -116,7 +116,7 @@ fn help_lines() -> Vec<Line<'static>> {
         Line::from(""),
         section("tools"),
         entry("", ""),
-        entry("Ctrl+H", "Settings (opaque background, OS logos, …)"),
+        entry("Ctrl+H", "Settings (session logging, opaque background, …)"),
         entry(
             "Ctrl+K",
             "Edit all keybindings (navigation, tabs, session, …)",
@@ -137,6 +137,10 @@ fn help_lines() -> Vec<Line<'static>> {
         entry("Ctrl+PgUp/PgDn", "Previous / next session tab (alternate)"),
         entry("Ctrl+Shift+S", "Focus session from dashboard"),
         entry("PgUp/PgDn", "Scroll session history"),
+        entry(
+            "",
+            "Session logs (opt-in): ~/.local/share/sshub/logs/<host>/ — captures all PTY output including secrets echoed on screen.",
+        ),
         entry("", ""),
         entry("[sftp]", ""),
         entry("2", "Open the SFTP tab"),

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -139,7 +139,7 @@ fn help_lines() -> Vec<Line<'static>> {
         entry("PgUp/PgDn", "Scroll session history"),
         entry(
             "",
-            "Session logs (opt-in): ~/.local/share/sshub/logs/<host>/ — captures all PTY output including secrets echoed on screen.",
+            "Session logs (opt-in): ~/.local/share/sshub/logs/<host-dir>/ — managed hosts use {name}-{id}; pure ssh_config aliases may share a dir when names sanitize the same. Captures all PTY output including secrets echoed on screen.",
         ),
         entry("", ""),
         entry("[sftp]", ""),

--- a/src/tui/screens/host_form.rs
+++ b/src/tui/screens/host_form.rs
@@ -110,6 +110,13 @@ pub fn render_host_form(
                     display_text(&form.remote_command)
                 },
             ),
+            HostFormField::SessionLogging => (
+                "Session log",
+                format!(
+                    "{} (Space or arrows to cycle)",
+                    form.session_logging.label()
+                ),
+            ),
             HostFormField::OsIcon => ("OS icon", os_icon_label(form.os_icon_index)),
             HostFormField::Password => (
                 "Password",

--- a/src/tui/widgets/detail_panel.rs
+++ b/src/tui/widgets/detail_panel.rs
@@ -89,6 +89,11 @@ fn detail_fav_line(fav: bool) -> Line<'static> {
     }
 }
 
+fn tri_state_line(label: &str, value: &str, active: bool) -> String {
+    let prefix = if active { "> " } else { "  " };
+    format!("{prefix}{label}: {value} (Space or arrows to cycle)")
+}
+
 fn host_detail_view(app: &App, entry: &HostEntry, _host_idx: usize) -> Vec<Line<'static>> {
     let ssh = entry.ssh_host();
     let last = entry
@@ -140,6 +145,16 @@ fn host_detail_view(app: &App, entry: &HostEntry, _host_idx: usize) -> Vec<Line<
         ),
         detail_fav_line(entry.favorite()),
         detail_line("Last connected", last),
+    ];
+
+    if !entry.is_launcher() {
+        lines.push(detail_line(
+            "Session log",
+            entry.session_logging_override().label().to_string(),
+        ));
+    }
+
+    lines.extend([
         Line::from(""),
         Line::from(Span::styled(
             if entry.is_launcher() {
@@ -150,7 +165,7 @@ fn host_detail_view(app: &App, entry: &HostEntry, _host_idx: usize) -> Vec<Line<
             hint_style,
         )),
         Line::from(Span::styled("[f] toggle favourite", hint_style)),
-    ];
+    ]);
 
     // Prepend the detected OS logo (colored ASCII art) when enabled and the
     // host's os_icon resolves to a known logo. render_detail_panel returns a
@@ -197,6 +212,11 @@ fn host_detail_edit(app: &App, entry: &HostEntry, _host_idx: usize) -> Vec<Line<
         edit.cursor,
         edit.field == DetailEditField::Environment,
     );
+    let session_log_line = tri_state_line(
+        "Session log",
+        edit.session_logging.label(),
+        edit.field == DetailEditField::SessionLogging,
+    );
 
     let hint_style = Style::default().fg(Color::DarkGray);
 
@@ -211,6 +231,7 @@ fn host_detail_edit(app: &App, entry: &HostEntry, _host_idx: usize) -> Vec<Line<
         Line::from(tags_line),
         Line::from(desc_line),
         Line::from(env_line),
+        Line::from(session_log_line),
         detail_fav_line(entry.favorite()),
         Line::from(""),
         Line::from(Span::styled("[Enter] save", hint_style)),
@@ -298,6 +319,7 @@ mod tests {
             tags: "prod".into(),
             description: String::new(),
             environment: String::new(),
+            session_logging: crate::session_log::SessionLoggingOverride::Inherit,
             field: DetailEditField::Tags,
             cursor: 4,
         });

--- a/src/tui/widgets/detail_panel.rs
+++ b/src/tui/widgets/detail_panel.rs
@@ -147,12 +147,10 @@ fn host_detail_view(app: &App, entry: &HostEntry, _host_idx: usize) -> Vec<Line<
         detail_line("Last connected", last),
     ];
 
-    if !entry.is_launcher() {
-        lines.push(detail_line(
-            "Session log",
-            entry.session_logging_override().label().to_string(),
-        ));
-    }
+    lines.push(detail_line(
+        "Session log",
+        entry.session_logging_override().label().to_string(),
+    ));
 
     lines.extend([
         Line::from(""),

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -110,6 +110,21 @@ mod tests {
     use std::sync::mpsc::RecvTimeoutError;
     use tempfile::NamedTempFile;
 
+    /// How long to wait for a debounced `ConfigChanged` after config writes.
+    fn watcher_event_timeout() -> Duration {
+        WATCHER_DEBOUNCE + Duration::from_secs(2)
+    }
+
+    /// After a burst of rapid writes, FSEvents on macOS CI can deliver notifications
+    /// seconds later; each delivery resets debounce, so use a generous bound.
+    fn debounce_burst_timeout() -> Duration {
+        if cfg!(target_os = "macos") {
+            Duration::from_secs(15)
+        } else {
+            watcher_event_timeout()
+        }
+    }
+
     #[test]
     fn spawn_config_watcher_emits_after_write() {
         let mut file = NamedTempFile::new().unwrap();
@@ -120,7 +135,7 @@ mod tests {
         writeln!(file, "Host beta").unwrap();
         file.flush().unwrap();
 
-        match rx.recv_timeout(WATCHER_DEBOUNCE + Duration::from_secs(2)) {
+        match rx.recv_timeout(watcher_event_timeout()) {
             Ok(WatchEvent::ConfigChanged) => {}
             other => panic!("expected ConfigChanged, got {other:?}"),
         }
@@ -133,18 +148,26 @@ mod tests {
         file.flush().unwrap();
 
         let rx = spawn_config_watcher(file.path()).unwrap();
+        // Let the watcher thread subscribe before the write burst.
+        thread::sleep(Duration::from_millis(100));
         for i in 0..5 {
             writeln!(file, "Host line-{i}").unwrap();
             file.flush().unwrap();
+            let _ = file.as_file().sync_all();
             thread::sleep(Duration::from_millis(20));
         }
 
         let first = rx
-            .recv_timeout(WATCHER_DEBOUNCE + Duration::from_secs(2))
+            .recv_timeout(debounce_burst_timeout())
             .expect("first debounced event");
         assert_eq!(first, WatchEvent::ConfigChanged);
 
-        match rx.recv_timeout(WATCHER_DEBOUNCE) {
+        let silence = if cfg!(target_os = "macos") {
+            WATCHER_DEBOUNCE * 2
+        } else {
+            WATCHER_DEBOUNCE
+        };
+        match rx.recv_timeout(silence) {
             Err(RecvTimeoutError::Timeout) => {}
             other => panic!("expected single debounced event, got {other:?}"),
         }

--- a/tests/e2e/connect_managed.rs
+++ b/tests/e2e/connect_managed.rs
@@ -131,6 +131,7 @@ fn connect_ssh_config_host_uses_alias_mode() {
             environment: None,
             favorite: false,
             last_connected: None,
+            ..Default::default()
         })
         .unwrap();
 

--- a/tests/e2e/metadata_persist.rs
+++ b/tests/e2e/metadata_persist.rs
@@ -13,6 +13,7 @@ fn upsert_persists_across_reopen() {
         environment: Some("prod".into()),
         favorite: true,
         last_connected: Some(1_700_000_000),
+        ..Default::default()
     };
 
     {


### PR DESCRIPTION
## Summary

Closes #4.

- Opt-in capture of embedded SSH PTY output to plain-text log files under `~/.local/share/sshub/logs/<host-dir>/`
- Global toggle in Settings (`Ctrl+H`) plus per-host tri-state override (`inherit` / `on` / `off`) in host form and legacy HostDetail
- Size-based rotation, per-host retention cap, schema v12 (`hosts.session_logging`, `auth_events.log_path`)
- Audit tab records the log **directory** on connect (`session started (logs in …)`)
- Managed hosts use `{sanitized-name}-{id}` log dirs to avoid name collisions

**Security note:** logs capture everything echoed to the terminal, including passwords if they appear on screen. Log dirs/files are owner-restricted via `secure_fs`.

## Post-review hardening (this branch)

- Fix FD leak when closing `SessionLogWriter` (`mem::forget` removed)
- Open log writer only after successful PTY spawn (no orphan empty files on spawn failure)
- Preserve `session_logging` on legacy duplicate and managed HostDetail save
- Show session log override in detail panel for managed hosts
- Tests for `audit_note`, duplicate legacy, managed detail save
- Docs aligned with directory layout and legacy-only sanitize collision caveat

## Test plan

- [x] `just test` — 355 unit + 58 e2e + smoke/config, all green
- [x] `cargo fmt` / `cargo clippy --all-targets`
- [x] Manual: enable logging in Settings, connect to a host, confirm `logs/<host-dir>/` and audit NOTE
- [x] Manual: per-host `off` override with global `on`


Made with [Cursor](https://cursor.com)