### PR TITLE
docs: implementation flow + GitHub agent comment rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ This repository uses OpenWiki for recurring code documentation. Start with `open
 
 Implementation flow (issue → PR → merge): [docs/implementation-flow.md](docs/implementation-flow.md).
 
+When posting GitHub issue/PR comments, identify the model and platform (`_Written by … on behalf of the maintainer._`). See implementation-flow § GitHub comments.
+
 The scheduled OpenWiki GitHub Actions workflow regenerates this wiki by default. After each automated or manual update, validate and correct pages against the codebase before merge — automated output is a starting point, not the source of truth.
 
 <!-- OPENWIKI:END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 
 This repository uses OpenWiki for recurring code documentation. Start with `openwiki/quickstart.md`, then follow its links to architecture, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
 
+Implementation flow (issue → PR → merge): [docs/implementation-flow.md](docs/implementation-flow.md).
+
 The scheduled OpenWiki GitHub Actions workflow regenerates this wiki by default. After each automated or manual update, validate and correct pages against the codebase before merge — automated output is a starting point, not the source of truth.
 
 <!-- OPENWIKI:END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository uses OpenWiki for recurring code documentation. Start with `open
 
 Implementation flow (issue → PR → merge): [docs/implementation-flow.md](docs/implementation-flow.md).
 
-When posting GitHub issue/PR comments, identify the model and platform (`_Written by … on behalf of the maintainer._`). See implementation-flow § GitHub comments.
+When posting GitHub issue/PR comments, always end with `_Written by {Model} ({Platform}) on behalf of the maintainer._` See the [GitHub comments section](docs/implementation-flow.md#github-comments-ai-agents) in implementation-flow.
 
 The scheduled OpenWiki GitHub Actions workflow regenerates this wiki by default. After each automated or manual update, validate and correct pages against the codebase before merge — automated output is a starting point, not the source of truth.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Pinned implementation flow: [docs/implementation-flow.md](docs/implementation-flow.md) (issue → claim → branch → verify → adversarial review → PR → merge).
 
-- **GitHub comments from agents must name model + platform** — see implementation-flow § GitHub comments. No unsigned agent comments on issues/PRs.
+- **GitHub comments from agents** must always end with `_Written by {Model} ({Platform}) on behalf of the maintainer._` — see [implementation-flow § GitHub comments](docs/implementation-flow.md#github-comments-ai-agents).
 
 - **Commit frequently.** After completing each logical unit of work (a bug fix, a feature, a refactor pass), create a commit immediately. Do not accumulate large uncommitted diffs across multiple tasks.
 - **Branch model.** `main` is stable (releases + tags); `development` is the integration branch; features go on `feature/*` branches cut from `development`. Flow: `feature/* → development → main`. Releases merge `development` into `main` with a `--no-ff` merge commit `chore: release vX.Y.Z` (so `git log --first-parent main` shows one entry per release), bump the version + CHANGELOG, and push a `vX.Y.Z` tag (the release workflow builds binaries and publishes to crates.io). `main` and `development` converge at every release — see the Releasing section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Pinned implementation flow: [docs/implementation-flow.md](docs/implementation-flow.md) (issue → claim → branch → verify → adversarial review → PR → merge).
 
+- **GitHub comments from agents must name model + platform** — see implementation-flow § GitHub comments. No unsigned agent comments on issues/PRs.
+
 - **Commit frequently.** After completing each logical unit of work (a bug fix, a feature, a refactor pass), create a commit immediately. Do not accumulate large uncommitted diffs across multiple tasks.
 - **Branch model.** `main` is stable (releases + tags); `development` is the integration branch; features go on `feature/*` branches cut from `development`. Flow: `feature/* → development → main`. Releases merge `development` into `main` with a `--no-ff` merge commit `chore: release vX.Y.Z` (so `git log --first-parent main` shows one entry per release), bump the version + CHANGELOG, and push a `vX.Y.Z` tag (the release workflow builds binaries and publishes to crates.io). `main` and `development` converge at every release — see the Releasing section.
 - **Delete merged branches.** The repo has "Automatically delete head branches" enabled, so merging a PR on GitHub removes the branch (keep the "Delete branch" box checked). For a local/CLI merge, delete it yourself right after: `git branch -d <branch>` and `git push origin --delete <branch>`. Never leave merged branches lingering.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Workflow rules
 
+Pinned implementation flow: [docs/implementation-flow.md](docs/implementation-flow.md) (issue → claim → branch → verify → adversarial review → PR → merge).
+
 - **Commit frequently.** After completing each logical unit of work (a bug fix, a feature, a refactor pass), create a commit immediately. Do not accumulate large uncommitted diffs across multiple tasks.
 - **Branch model.** `main` is stable (releases + tags); `development` is the integration branch; features go on `feature/*` branches cut from `development`. Flow: `feature/* → development → main`. Releases merge `development` into `main` with a `--no-ff` merge commit `chore: release vX.Y.Z` (so `git log --first-parent main` shows one entry per release), bump the version + CHANGELOG, and push a `vX.Y.Z` tag (the release workflow builds binaries and publishes to crates.io). `main` and `development` converge at every release — see the Releasing section.
 - **Delete merged branches.** The repo has "Automatically delete head branches" enabled, so merging a PR on GitHub removes the branch (keep the "Delete branch" box checked). For a local/CLI merge, delete it yourself right after: `git branch -d <branch>` and `git push origin --delete <branch>`. Never leave merged branches lingering.
@@ -65,6 +67,8 @@ For current architecture details (tabs, schema, event loop, modules), see `openw
 ## OpenWiki
 
 This repository uses OpenWiki for recurring code documentation. Start with `openwiki/quickstart.md`, then follow its links to architecture, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+Implementation flow: [docs/implementation-flow.md](../docs/implementation-flow.md).
 
 The scheduled OpenWiki GitHub Actions workflow regenerates this wiki by default. After each automated or manual update, validate and correct pages against the codebase before merge — automated output is a starting point, not the source of truth.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ Thanks for your interest in contributing. Here's how to get started.
 
 Flow: `feature/* → development → main (release, maintainer-only)`.
 
+**Full checklist:** [docs/implementation-flow.md](docs/implementation-flow.md) — issue → claim → branch → verify → adversarial review → PR → merge.
+
 ## Claiming an issue
 
 Before implementing an existing issue (roadmap items in #14 included), claim
@@ -40,7 +42,9 @@ considered free again.
 6. Update `README.md` / the in-app help if behaviour or requirements change
 7. Do **not** bump the version in `Cargo.toml` — versioning is automated
    (a pre-commit hook on `development` plus the release process)
-8. Open a pull request against `development`
+8. Run adversarial review on non-trivial changes before opening the PR (see
+   [docs/implementation-flow.md](docs/implementation-flow.md))
+9. Open a pull request against `development`
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,8 +67,13 @@ review PRs together.
 
 ### GitHub comments — **required for agents**
 
-Any comment on an **issue or pull request** written by a coding agent **must**
-identify the **model and platform**. Examples:
+Any comment on an **issue or pull request** written by a coding agent **must** end with:
+
+```text
+_Written by {Model} ({Platform}) on behalf of the maintainer._
+```
+
+Example:
 
 ```text
 Taking this — working on `feature/foo`.
@@ -76,13 +81,9 @@ Taking this — working on `feature/foo`.
 _Written by Composer (Cursor) on behalf of the maintainer._
 ```
 
-```text
-Taking this issue — implementing tunnel auto-reconnect (Composer / Cursor).
-```
-
-- Use a real model name (`Claude Opus 4.8`, `Claude Fable 5`, `Composer`, …),
-  not “AI” or “the assistant”.
-- Add the tool when relevant (`Cursor`, `Claude Code`, …).
+- Use a real **model** name (`Claude Opus 4.8`, `Claude Fable 5`, `Composer`, …).
+- Use a real **platform** (`Cursor`, `Claude Code`, `Codex`, …).
+- Signature on its own line at the **end** of the comment — always, including short claims.
 - Human comments do not need a signature.
 
 Full rules: [docs/implementation-flow.md](docs/implementation-flow.md#github-comments-ai-agents).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,9 @@ unannounced parallel work has already produced duplicate implementations of
 the same feature. A claimed issue with no visible activity for two weeks is
 considered free again.
 
+If an **AI agent** leaves the claim comment, it **must** name the model and
+platform — see [docs/implementation-flow.md § GitHub comments](docs/implementation-flow.md#github-comments-ai-agents).
+
 ## Making changes
 
 1. Create a branch from `development` (not `main`)
@@ -59,9 +62,33 @@ considered free again.
 
 ## AI involvement
 
-All pull requests and issues in this repo are reviewed and triaged through
-Claude (Opus 4.8 or Fable 5). Comments signed by Claude are written by the
-model on behalf of the maintainer.
+This repo is heavily agent-assisted. Maintainers and agents triage issues and
+review PRs together.
+
+### GitHub comments — **required for agents**
+
+Any comment on an **issue or pull request** written by a coding agent **must**
+identify the **model and platform**. Examples:
+
+```text
+Taking this — working on `feature/foo`.
+
+_Written by Composer (Cursor) on behalf of the maintainer._
+```
+
+```text
+Taking this issue — implementing tunnel auto-reconnect (Composer / Cursor).
+```
+
+- Use a real model name (`Claude Opus 4.8`, `Claude Fable 5`, `Composer`, …),
+  not “AI” or “the assistant”.
+- Add the tool when relevant (`Cursor`, `Claude Code`, …).
+- Human comments do not need a signature.
+
+Full rules: [docs/implementation-flow.md](docs/implementation-flow.md#github-comments-ai-agents).
+
+PR descriptions may note agent involvement but are not a substitute for signed
+issue/PR **comments** when an agent posts them.
 
 ## Code style
 

--- a/docs/implementation-flow.md
+++ b/docs/implementation-flow.md
@@ -1,6 +1,6 @@
 # Implementation flow
 
-Canonical checklist for landing work in SSHub. Humans and coding agents should follow this end-to-end.
+Canonical checklist for landing work in SSHub. Lives on **`development`** at [`docs/implementation-flow.md`](implementation-flow.md) — not on a feature branch. Humans and coding agents should follow this end-to-end.
 
 **Related:** [CONTRIBUTING.md](../CONTRIBUTING.md) (basics), [CLAUDE.md](../CLAUDE.md) (versioning/releases), roadmap [#14](https://github.com/Petyok/SSHub/issues/14), code wiki [openwiki/quickstart.md](../openwiki/quickstart.md).
 
@@ -24,7 +24,32 @@ flowchart LR
 |------|--------|
 | Pick or open an issue | New features should appear on the [roadmap (#14)](https://github.com/Petyok/SSHub/issues/14). Open an issue if none exists; maintainer triages it into the roadmap. |
 | Claim before coding | Assign yourself or comment that you are taking it. Unclaimed roadmap items are assumed free ([CONTRIBUTING.md](../CONTRIBUTING.md)). |
+| GitHub comments (AI) | **Required:** every issue/PR comment written by an agent must name the **model and platform** (see [§ GitHub comments](#github-comments-ai-agents) below). |
 | Link PR to issue | PR body must include `Closes #N` so the issue and roadmap checkbox update on merge. |
+
+### GitHub comments (AI agents)
+
+If **you** (a coding agent) post on GitHub — issue claims, status updates, PR reviews, triage — you **must** identify which model you are. No anonymous agent comments.
+
+Use one of these forms (pick one per comment):
+
+1. **Footer signature** (preferred for longer comments):
+
+   ```text
+   _Written by Composer (Cursor) on behalf of the maintainer._
+   ```
+
+2. **Inline on short claims** (e.g. taking an issue):
+
+   ```text
+   Taking this — working on `feature/session-logging` (Composer / Cursor).
+   ```
+
+**Model name must be specific** — e.g. `Claude Opus 4.8`, `Claude Fable 5`, `Composer`, `GPT-5.4`, not just “AI” or “Claude”. Include the **platform** when relevant: `Cursor`, `Claude Code`, `Codex`, etc.
+
+Examples from this repo: issue [#4](https://github.com/Petyok/SSHub/issues/4) (claim + footer signature), [#8](https://github.com/Petyok/SSHub/issues/8) (inline model on claim).
+
+Human contributors do not need a model line.
 
 ## 2. Branch
 

--- a/docs/implementation-flow.md
+++ b/docs/implementation-flow.md
@@ -24,32 +24,38 @@ flowchart LR
 |------|--------|
 | Pick or open an issue | New features should appear on the [roadmap (#14)](https://github.com/Petyok/SSHub/issues/14). Open an issue if none exists; maintainer triages it into the roadmap. |
 | Claim before coding | Assign yourself or comment that you are taking it. Unclaimed roadmap items are assumed free ([CONTRIBUTING.md](../CONTRIBUTING.md)). |
-| GitHub comments (AI) | **Required:** every issue/PR comment written by an agent must name the **model and platform** (see [§ GitHub comments](#github-comments-ai-agents) below). |
+| GitHub comments (AI) | **Required:** every issue/PR comment ends with `_Written by {Model} ({Platform}) on behalf of the maintainer._` (see [§ GitHub comments](#github-comments-ai-agents)). |
 | Link PR to issue | PR body must include `Closes #N` so the issue and roadmap checkbox update on merge. |
 
 ### GitHub comments (AI agents)
 
-If **you** (a coding agent) post on GitHub — issue claims, status updates, PR reviews, triage — you **must** identify which model you are. No anonymous agent comments.
+If **you** (a coding agent) post on GitHub — issue claims, status updates, PR reviews, triage — you **must** sign the comment. No anonymous agent comments. No inline-only model mentions.
 
-Use one of these forms (pick one per comment):
+**Always** end the comment with this exact form (model and platform filled in):
 
-1. **Footer signature** (preferred for longer comments):
+```text
+_Written by {Model} ({Platform}) on behalf of the maintainer._
+```
 
-   ```text
-   _Written by Composer (Cursor) on behalf of the maintainer._
-   ```
+Examples:
 
-2. **Inline on short claims** (e.g. taking an issue):
+```text
+Taking this — working on `feature/session-logging`.
 
-   ```text
-   Taking this — working on `feature/session-logging` (Composer / Cursor).
-   ```
+_Written by Composer (Cursor) on behalf of the maintainer._
+```
 
-**Model name must be specific** — e.g. `Claude Opus 4.8`, `Claude Fable 5`, `Composer`, `GPT-5.4`, not just “AI” or “Claude”. Include the **platform** when relevant: `Cursor`, `Claude Code`, `Codex`, etc.
+```text
+_Written by Claude Opus 4.8 (Claude Code) on behalf of the maintainer._
+```
 
-Examples from this repo: issue [#4](https://github.com/Petyok/SSHub/issues/4) (claim + footer signature), [#8](https://github.com/Petyok/SSHub/issues/8) (inline model on claim).
+- **Model** must be specific — `Claude Opus 4.8`, `Claude Fable 5`, `Composer`, `GPT-5.4`, not “AI” or “Claude” alone.
+- **Platform** is the tool or runtime — `Cursor`, `Claude Code`, `Codex`, etc.
+- Put the signature on its **own line** at the **end** of every agent comment, including one-line claims.
 
-Human contributors do not need a model line.
+Reference: issue [#4](https://github.com/Petyok/SSHub/issues/4).
+
+Human contributors do not need a signature.
 
 ## 2. Branch
 

--- a/docs/implementation-flow.md
+++ b/docs/implementation-flow.md
@@ -1,0 +1,120 @@
+# Implementation flow
+
+Canonical checklist for landing work in SSHub. Humans and coding agents should follow this end-to-end.
+
+**Related:** [CONTRIBUTING.md](../CONTRIBUTING.md) (basics), [CLAUDE.md](../CLAUDE.md) (versioning/releases), roadmap [#14](https://github.com/Petyok/SSHub/issues/14), code wiki [openwiki/quickstart.md](../openwiki/quickstart.md).
+
+## Overview
+
+```mermaid
+flowchart LR
+  issue[Issue / roadmap] --> claim[Claim]
+  claim --> branch[feature/* from development]
+  branch --> impl[Implement + tests]
+  impl --> verify[just test + fmt + clippy]
+  verify --> review[Adversarial review]
+  review --> pr[PR → development]
+  pr --> merge[Merge]
+  merge --> release[Ride next release → main]
+```
+
+## 1. Track work
+
+| Step | Action |
+|------|--------|
+| Pick or open an issue | New features should appear on the [roadmap (#14)](https://github.com/Petyok/SSHub/issues/14). Open an issue if none exists; maintainer triages it into the roadmap. |
+| Claim before coding | Assign yourself or comment that you are taking it. Unclaimed roadmap items are assumed free ([CONTRIBUTING.md](../CONTRIBUTING.md)). |
+| Link PR to issue | PR body must include `Closes #N` so the issue and roadmap checkbox update on merge. |
+
+## 2. Branch
+
+```bash
+git fetch origin
+git checkout development
+git pull origin development
+git checkout -b feature/short-description
+```
+
+- **Base:** always `development`, never `main`.
+- **Name:** `feature/*` for features; `fix/*` for bugfixes is fine.
+- **Do not** bump `Cargo.toml` version on the feature branch — versioning is automated on `development` and at release.
+
+## 3. Implement
+
+- Keep PRs focused: one feature or fix per PR.
+- Prefer small, logical commits on the feature branch.
+- Update docs when behaviour changes:
+  - `CHANGELOG.md` under `[Unreleased]` for user-visible changes
+  - `README.md` and in-app help (`src/tui/screens/help.rs`) when UX or keybindings change
+  - `openwiki/` when architecture or operational behaviour changes (see below)
+- Match existing code patterns; no drive-by refactors.
+
+## 4. Verify (required before PR)
+
+```bash
+just test
+cargo fmt
+cargo clippy --all-targets
+```
+
+All must pass. CI runs the same test suite plus `cargo fmt --check` and `cargo clippy --all-targets` on Ubuntu and macOS.
+
+**Tests:** use fixtures and `tempfile`; never touch real `~/.ssh`, keyring, or user config dirs. See [CONTRIBUTING.md § Tests](../CONTRIBUTING.md#tests).
+
+## 5. Security review (when applicable)
+
+If the change touches **auth, credentials, file I/O, network calls, env vars, secrets, user input, or file permissions**, run a structured security review before opening the PR. Call out security-sensitive changes explicitly in the PR description.
+
+## 6. OpenWiki (when applicable)
+
+If you add or change `openwiki/` pages (or merge an OpenWiki bot PR):
+
+1. Validate against `src/` — use the checklist in [openwiki/INSTRUCTIONS.md](../openwiki/INSTRUCTIONS.md).
+2. Update [openwiki/.last-update.json](../openwiki/.last-update.json) (`gitHead`, `validatedAt`) after manual correction.
+3. Keep `CLAUDE.md` / `AGENTS.md` architecture pointers in sync (prefer linking to OpenWiki over duplicating tables).
+
+Automated regen is a starting point, not source of truth. Scheduled workflow needs repo secret `OPENROUTER_API_KEY` ([runbook](../openwiki/operations/runbook.md)).
+
+## 7. Adversarial review (before merge)
+
+After implementation is green locally, run an **independent adversarial multimodel review** on the diff (implementation agents must not skip this):
+
+- Reconstruct task + acceptance criteria.
+- Verify findings against code and test output — do not trust critic summaries blindly.
+- Fix **verified** blockers and high-severity issues before merge.
+- Verdict must be `SAFE TO COMMIT` or equivalent with no open blockers.
+
+This catches doc drift, wrong API names, regressions, and scope creep that unit tests miss.
+
+## 8. Open pull request
+
+| Field | Rule |
+|-------|------|
+| **Target** | `development` only |
+| **Title** | Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:` |
+| **Body** | What changed and why; how you tested; `Closes #N`; security notes if relevant |
+| **Scope** | One logical change set |
+
+Example test plan bullets:
+
+- [ ] `just test` green
+- [ ] `cargo fmt` / `clippy` clean
+- [ ] Adversarial review passed
+- [ ] Manual smoke (if TUI behaviour changed)
+
+## 9. After merge
+
+- GitHub deletes the head branch automatically (keep “Delete branch” checked).
+- Issue closes; roadmap checkbox on #14 ticks when `Closes #N` matched.
+- Work rides the next release to `main` via `just release` (maintainer). See [CLAUDE.md § Versioning](../CLAUDE.md#versioning-vxyz).
+
+## Quick reference
+
+| Question | Answer |
+|----------|--------|
+| Where do PRs go? | `development` |
+| Where do releases go? | `main` (tags `vX.Y.Z`) |
+| Full test command? | `just test` |
+| Roadmap? | [Issue #14](https://github.com/Petyok/SSHub/issues/14) |
+| Architecture docs? | [openwiki/quickstart.md](../openwiki/quickstart.md) |
+| Agent workflow rules? | [CLAUDE.md](../CLAUDE.md), [AGENTS.md](../AGENTS.md) |

--- a/openwiki/operations/runbook.md
+++ b/openwiki/operations/runbook.md
@@ -2,6 +2,8 @@
 
 Day-to-day operations for SSHub users and operators.
 
+**Contributor workflow** (issue → PR → merge, GitHub comment rules): [docs/implementation-flow.md](../../docs/implementation-flow.md) on `development`.
+
 ## Data paths
 
 | Resource      | Default path                                              |

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -46,6 +46,7 @@ This wiki is a practical map for engineers working on the codebase. Start here, 
 │   ├── support/            # FixtureResolver, MockLauncher
 │   └── fixtures/           # ssh_config / ssh -G fixtures
 └── docs/
+    ├── implementation-flow.md # canonical dev checklist (issue → PR → merge)
     ├── host-sync-design.md # planned P2P sync feature (not implemented)
     └── termius-export-format.md
 ```


### PR DESCRIPTION
## Summary

- Land `docs/implementation-flow.md` on `development` (was committed to `feature/openwiki` after #21 merged).
- Add **strict rule**: AI agents must identify model + platform on every GitHub issue/PR comment (see #4, #8 for examples).
- Link from CONTRIBUTING, CLAUDE, AGENTS, openwiki runbook.

## Test plan

- [x] Doc links resolve on GitHub
- [x] Review comment signature examples match maintainer convention

Made with [Cursor](https://cursor.com)