### PR TITLE
feat: headless CLI (Closes #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to SSHub are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Headless CLI** - drive the whole launcher without opening the TUI. New
+  subcommands cover hosts (`list` / `show` / `connect` / `resolve` / `search` /
+  `add` / `edit` / `rename` / `delete` / `duplicate`, with top-level `connect`,
+  `list`, and `groups` aliases), group CRUD, identity CRUD plus `agent-remove`,
+  tunnels (`list` / `show` / `create` / `delete` / `start` / `stop`, and
+  `start --foreground`), one-shot SFTP (`ls` / `get` / `put` / `rm` / `mkdir` /
+  `rename` / `chmod`), the audit log (`list` / `stats`), `tags`, and
+  `sync` / `import` / `export`. Machine-readable output with `--format json`
+  where applicable (plain text stays the default). Exit codes follow a fixed
+  convention: `0` success, `1` operational failure, `2` usage or bad flags.
+  Destructive commands refuse to run without `--yes` (`db purge` keeps its
+  `--yes-i-am-stupid` guard). `sshub completions bash|zsh|fish` emits a shell
+  completion script, optionally caching the host-name list to a file with
+  `--cache PATH` so completion stays fast on large inventories.
+
 ## [0.9.0] - 2026-07-16
 
 ### Added

--- a/Justfile
+++ b/Justfile
@@ -27,31 +27,40 @@ dry-run:
 man:
     man -l man/sshub.1
 
-# Generate and install shell completions for bash, zsh, and fish into standard
-# user locations. Runs `just build` first.
+# Install shell completions so they work with no manual setup. bash and fish
+# files drop into auto-loaded dirs; zsh gets a sourced line appended to
+# ~/.zshrc (idempotent, marked, removed by `just uninstall`). Included by
+# `just install`; run standalone to (re)install just the completions.
 install-completions: build
     #!/usr/bin/env bash
     set -euo pipefail
     bin=target/release/sshub
     bash_dir="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions"
-    zsh_dir="${XDG_DATA_HOME:-$HOME/.local/share}/zsh/site-functions"
     fish_dir="${XDG_CONFIG_HOME:-$HOME/.config}/fish/completions"
-    install -d "$bash_dir" "$zsh_dir" "$fish_dir"
+    install -d "$bash_dir" "$fish_dir"
     "$bin" completions bash > "$bash_dir/sshub"
-    "$bin" completions zsh  > "$zsh_dir/_sshub"
     "$bin" completions fish > "$fish_dir/sshub.fish"
-    echo "Installed completions:"
-    echo "  bash -> $bash_dir/sshub"
-    echo "  zsh  -> $zsh_dir/_sshub"
-    echo "  fish -> $fish_dir/sshub.fish"
-    echo
-    echo "bash: works if bash-completion is enabled (it loads the user dir above)."
-    echo "zsh:  simplest is to add this to ~/.zshrc (after compinit runs):"
-    echo "        source <(sshub completions zsh)"
-    echo "      or use the fpath file installed above:"
-    echo "        fpath=($zsh_dir \$fpath)   # before compinit"
-    echo "      then: rm -f ~/.zcompdump*; exec zsh"
-    echo "fish: loaded automatically in a new shell."
+    echo "completions: bash -> $bash_dir/sshub"
+    echo "completions: fish -> $fish_dir/sshub.fish"
+    # zsh has no user dir on the default fpath, so source the completion from
+    # ~/.zshrc (only if it exists) instead. compinit is ensured before compdef.
+    zshrc="$HOME/.zshrc"
+    marker="# >>> sshub completions >>>"
+    if [ -f "$zshrc" ] && grep -qF "$marker" "$zshrc"; then
+      echo "completions: zsh -> ~/.zshrc already wired"
+    elif [ -f "$zshrc" ]; then
+      {
+        echo ""
+        echo "$marker"
+        echo '(( $+functions[compdef] )) || { autoload -Uz compinit && compinit -u; }'
+        echo 'source <(command sshub completions zsh)'
+        echo "# <<< sshub completions <<<"
+      } >> "$zshrc"
+      echo "completions: zsh -> appended sourcing to ~/.zshrc (run: exec zsh)"
+    else
+      echo "completions: zsh -> no ~/.zshrc found; add: source <(sshub completions zsh)"
+    fi
+    echo "bash and fish auto-load in a new shell."
 
 # Bump the version (odometer, each field 0-9; see CLAUDE.md "Versioning").
 #   just bump patch       # every commit to development
@@ -199,7 +208,7 @@ sync:
 # Install the release binary to ~/.local/bin and a launcher entry so sshub
 # shows up in your application launcher (GNOME, rofi, etc). Uses kitty if
 # available, otherwise falls back to xterm. Runs `just build` first.
-install: build
+install: build install-completions
     #!/usr/bin/env bash
     set -euo pipefail
     bin="$HOME/.local/bin/sshub"
@@ -215,8 +224,10 @@ install: build
     echo "Installed $bin, man page, icon and launcher entry (terminal: $term)."
     echo "If it doesn't show up, log out/in or run: update-desktop-database ~/.local/share/applications"
 
-# Remove the installed binary and launcher entry.
+# Remove the installed binary, man page, completions, icon and launcher entry.
 uninstall:
+    #!/usr/bin/env bash
+    set -euo pipefail
     rm -f "$HOME/.local/bin/sshub" \
           "$HOME/.local/share/man/man1/sshub.1" \
           "${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/sshub" \
@@ -224,4 +235,10 @@ uninstall:
           "${XDG_CONFIG_HOME:-$HOME/.config}/fish/completions/sshub.fish" \
           "$HOME/.local/share/applications/sshub.desktop" \
           "$HOME/.local/share/icons/hicolor/scalable/apps/sshub.svg"
-    @echo "Removed sshub binary, man page, completions, icon and launcher entry."
+    # Strip the sshub completions block from ~/.zshrc if we added it.
+    zshrc="$HOME/.zshrc"
+    if [ -f "$zshrc" ] && grep -qF '# >>> sshub completions >>>' "$zshrc"; then
+      sed -i '/# >>> sshub completions >>>/,/# <<< sshub completions <<</d' "$zshrc"
+      echo "Removed sshub completions block from ~/.zshrc"
+    fi
+    echo "Removed sshub binary, man page, completions, icon and launcher entry."

--- a/Justfile
+++ b/Justfile
@@ -46,9 +46,11 @@ install-completions: build
     echo "  fish -> $fish_dir/sshub.fish"
     echo
     echo "bash: works if bash-completion is enabled (it loads the user dir above)."
-    echo "zsh:  ensure the dir is on fpath, e.g. in ~/.zshrc before compinit:"
-    echo "        fpath=($zsh_dir \$fpath)"
-    echo "        autoload -Uz compinit && compinit"
+    echo "zsh:  simplest is to add this to ~/.zshrc (after compinit runs):"
+    echo "        source <(sshub completions zsh)"
+    echo "      or use the fpath file installed above:"
+    echo "        fpath=($zsh_dir \$fpath)   # before compinit"
+    echo "      then: rm -f ~/.zcompdump*; exec zsh"
     echo "fish: loaded automatically in a new shell."
 
 # Bump the version (odometer, each field 0-9; see CLAUDE.md "Versioning").

--- a/Justfile
+++ b/Justfile
@@ -27,6 +27,30 @@ dry-run:
 man:
     man -l man/sshub.1
 
+# Generate and install shell completions for bash, zsh, and fish into standard
+# user locations. Runs `just build` first.
+install-completions: build
+    #!/usr/bin/env bash
+    set -euo pipefail
+    bin=target/release/sshub
+    bash_dir="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions"
+    zsh_dir="${XDG_DATA_HOME:-$HOME/.local/share}/zsh/site-functions"
+    fish_dir="${XDG_CONFIG_HOME:-$HOME/.config}/fish/completions"
+    install -d "$bash_dir" "$zsh_dir" "$fish_dir"
+    "$bin" completions bash > "$bash_dir/sshub"
+    "$bin" completions zsh  > "$zsh_dir/_sshub"
+    "$bin" completions fish > "$fish_dir/sshub.fish"
+    echo "Installed completions:"
+    echo "  bash -> $bash_dir/sshub"
+    echo "  zsh  -> $zsh_dir/_sshub"
+    echo "  fish -> $fish_dir/sshub.fish"
+    echo
+    echo "bash: works if bash-completion is enabled (it loads the user dir above)."
+    echo "zsh:  ensure the dir is on fpath, e.g. in ~/.zshrc before compinit:"
+    echo "        fpath=($zsh_dir \$fpath)"
+    echo "        autoload -Uz compinit && compinit"
+    echo "fish: loaded automatically in a new shell."
+
 # Bump the version (odometer, each field 0-9; see CLAUDE.md "Versioning").
 #   just bump patch       # every commit to development
 #   just bump minor       # on release (merge development -> main); resets patch
@@ -193,6 +217,9 @@ install: build
 uninstall:
     rm -f "$HOME/.local/bin/sshub" \
           "$HOME/.local/share/man/man1/sshub.1" \
+          "${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/sshub" \
+          "${XDG_DATA_HOME:-$HOME/.local/share}/zsh/site-functions/_sshub" \
+          "${XDG_CONFIG_HOME:-$HOME/.config}/fish/completions/sshub.fish" \
           "$HOME/.local/share/applications/sshub.desktop" \
           "$HOME/.local/share/icons/hicolor/scalable/apps/sshub.svg"
-    @echo "Removed sshub binary, man page, icon and launcher entry."
+    @echo "Removed sshub binary, man page, completions, icon and launcher entry."

--- a/Justfile
+++ b/Justfile
@@ -23,6 +23,10 @@ record-gifs *tapes: build
 dry-run:
     cargo run -- --dry-run
 
+# Preview the man page (man/sshub.1) without installing it.
+man:
+    man -l man/sshub.1
+
 # Bump the version (odometer, each field 0-9; see CLAUDE.md "Versioning").
 #   just bump patch       # every commit to development
 #   just bump minor       # on release (merge development -> main); resets patch
@@ -175,18 +179,20 @@ install: build
     bin="$HOME/.local/bin/sshub"
     term="$(command -v kitty || command -v ghostty || command -v alacritty || command -v foot || echo xterm)"
     install -Dm755 target/release/sshub "$bin"
+    install -Dm644 man/sshub.1 "$HOME/.local/share/man/man1/sshub.1"
     install -Dm644 assets/sshub.svg "$HOME/.local/share/icons/hicolor/scalable/apps/sshub.svg"
     mkdir -p "$HOME/.local/share/applications"
     sed -e "s|@TERM@|$term|g" -e "s|@BIN@|$bin|g" \
         assets/sshub.desktop > "$HOME/.local/share/applications/sshub.desktop"
     update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
     gtk-update-icon-cache -f -t "$HOME/.local/share/icons/hicolor" 2>/dev/null || true
-    echo "Installed $bin, icon and launcher entry (terminal: $term)."
+    echo "Installed $bin, man page, icon and launcher entry (terminal: $term)."
     echo "If it doesn't show up, log out/in or run: update-desktop-database ~/.local/share/applications"
 
 # Remove the installed binary and launcher entry.
 uninstall:
     rm -f "$HOME/.local/bin/sshub" \
+          "$HOME/.local/share/man/man1/sshub.1" \
           "$HOME/.local/share/applications/sshub.desktop" \
           "$HOME/.local/share/icons/hicolor/scalable/apps/sshub.svg"
-    @echo "Removed sshub binary, icon and launcher entry."
+    @echo "Removed sshub binary, man page, icon and launcher entry."

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ Run `sshub <command> --help` for a per-command usage block, or `man sshub`
 after `just install` (preview the page without installing with `just man`). See
 [openwiki/workflows/cli.md](openwiki/workflows/cli.md) for the full command tree.
 
+Shell completions: `just install-completions` installs bash/zsh/fish
+completions to the standard user locations (or generate one yourself with
+`sshub completions bash|zsh|fish`).
+
 ### Data paths
 
 | Resource   | Default path                          |

--- a/README.md
+++ b/README.md
@@ -181,9 +181,10 @@ Run `sshub <command> --help` for a per-command usage block, or `man sshub`
 after `just install` (preview the page without installing with `just man`). See
 [openwiki/workflows/cli.md](openwiki/workflows/cli.md) for the full command tree.
 
-Shell completions: `just install-completions` installs bash/zsh/fish
-completions to the standard user locations (or generate one yourself with
-`sshub completions bash|zsh|fish`).
+Shell completions are installed automatically by `just install` (bash and fish
+drop into auto-loaded dirs; zsh gets a sourced line appended to `~/.zshrc`).
+Run `just install-completions` to (re)install only the completions, or generate
+one yourself with `sshub completions bash|zsh|fish`.
 
 ### Data paths
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ sshub completions bash
 sshub completions fish
 ```
 
-Run `sshub <command> --help` for a per-command usage block. See
+Run `sshub <command> --help` for a per-command usage block, or `man sshub`
+after `just install` (preview the page without installing with `just man`). See
 [openwiki/workflows/cli.md](openwiki/workflows/cli.md) for the full command tree.
 
 ### Data paths

--- a/README.md
+++ b/README.md
@@ -123,6 +123,63 @@ sshub --help       # show options
 sshub db purge --yes-i-am-stupid
 ```
 
+## Headless CLI
+
+Beyond the TUI, `sshub` exposes a full command-line interface for scripting and
+automation: hosts, groups, identities, tunnels, SFTP, and the audit log, no
+terminal UI required. Add `--format json` to any listing or show command for
+machine-readable output (plain text is the default). Exit codes are stable:
+`0` success, `1` operational failure, `2` usage or bad flags. Destructive
+commands refuse to run without `--yes`.
+
+```bash
+# Hosts
+sshub list                                  # list hosts (alias for `host list`)
+sshub connect prod-web                       # open an SSH session to a host
+sshub host show prod-web --format json       # host details as JSON
+sshub host search web                        # fuzzy search
+sshub host add --name prod-web --address 10.0.0.5 --port 22 \
+    --username deploy --group prod --tags web,prod
+sshub host delete --name prod-web --yes      # destructive: needs --yes
+
+# Groups and identities
+sshub groups                                 # list host groups
+sshub group add --name prod
+sshub identity add --name work --username alice --private-key ~/.ssh/id_ed25519
+sshub identity agent-remove --name work      # ssh-add -d for the identity's key
+
+# Tunnels
+sshub tunnel list
+sshub tunnel create --host prod-web --type local --local-port 8080 \
+    --remote-host localhost --remote-port 80
+sshub tunnel start 3                          # start detached (by id, label, or port)
+sshub tunnel start 3 --foreground             # run in the foreground with keep-alive
+sshub tunnel stop 3
+
+# SFTP (one-shot, over a direct host)
+sshub sftp ls prod-web /var/log
+sshub sftp get prod-web /var/log/app.log ./app.log
+sshub sftp put prod-web ./deploy.tar.gz /tmp/deploy.tar.gz
+sshub sftp rm prod-web /tmp/deploy.tar.gz --yes
+
+# Audit log
+sshub audit list --status fail --days 7
+sshub audit stats --days 7
+
+# Inventory sync with ~/.ssh/config
+sshub import                                  # import hosts from ssh config
+sshub sync                                    # refresh ssh_config rows
+sshub export --stdout                         # print an ssh_config snippet
+
+# Shell completions
+sshub completions zsh > ~/.zsh/completions/_sshub
+sshub completions bash
+sshub completions fish
+```
+
+Run `sshub <command> --help` for a per-command usage block. See
+[openwiki/workflows/cli.md](openwiki/workflows/cli.md) for the full command tree.
+
 ### Data paths
 
 | Resource   | Default path                          |

--- a/man/sshub.1
+++ b/man/sshub.1
@@ -1,0 +1,264 @@
+.\" Manpage for sshub.
+.\" Contributions and corrections welcome at https://github.com/Petyok/SSHub
+.TH SSHUB 1 "2026-07-18" "sshub 0.9.2" "User Commands"
+.SH NAME
+sshub \- keyboard-driven TUI SSH host launcher with a headless CLI
+.SH SYNOPSIS
+.B sshub
+.RI [ OPTIONS ]
+.br
+.B sshub
+.I COMMAND
+.RI [ ARGS ...]
+.SH DESCRIPTION
+.B sshub
+is a terminal UI for managing and connecting to SSH hosts. It merges the
+read-only
+.I ~/.ssh/config
+with a launcher-managed SQLite database and provides nested groups, fuzzy
+search, tags, embedded PTY sessions, SFTP transfers, SSH tunnels, identity
+management, and an audit log.
+.PP
+Run with no command to launch the TUI. Any recognized
+.I COMMAND
+runs headless (no TUI) and is scriptable: output honors
+.B \-\-format
+.RB ( plain
+or
+.BR json )
+where applicable, and the exit status follows the convention in
+.BR "EXIT STATUS" .
+.SH OPTIONS
+.TP
+.BR \-h ", " \-\-help
+Print help. After a command
+.RB ( "sshub " "\fICOMMAND\fR \fB\-\-help\fR" )
+it prints help for that command.
+.TP
+.BR \-V ", " \-\-version
+Print the version and exit.
+.TP
+.B \-\-dry\-run
+Exit immediately without launching the TUI (smoke tests / CI).
+.SH COMMANDS
+.SS Host (read)
+.TP
+.B sshub host list \fR[\fB\-\-tag\fR \fITAG\fR]... [\fB\-\-group\fR \fINAME\fR] [\fB\-\-sort\fR \fIMODE\fR] [\fB\-\-format\fR \fIF\fR]
+List hosts.
+.B \-\-tag
+is repeatable and ANDs; \fB\-\-group\fR filters by exact membership (not the
+subtree). \fIMODE\fR is one of
+.BR label ", " last\-connected ", " favorite ", " group ", " manual .
+.TP
+.B sshub host show \fINAME\fR [\fB\-\-format\fR \fIF\fR]
+Show the full fact sheet for a host.
+.TP
+.B sshub host connect \fINAME\fR \fR[\fB\-v\fR|\fB\-\-verbose\fR]
+Connect over SSH (or mosh, per the host transport). Session logging and audit
+apply as configured. The child exit code is propagated.
+.TP
+.B sshub host resolve \fINAME\fR [\fB\-\-format\fR \fIF\fR]
+Print the resolved connection details and the exact
+.I argv
+that would run, plus whether a stored secret exists (never the secret itself).
+.TP
+.B sshub host search \fIQUERY\fR [\fB\-\-format\fR \fIF\fR]
+Fuzzy-search hosts, best match first.
+.SS Host (write)
+.TP
+.B sshub host add \fB\-\-name\fR \fINAME\fR \fB\-\-address\fR \fIADDR\fR [flags]
+Create a launcher host. Flags include
+.BR \-\-port ", " \-\-username ", " \-\-label ", " \-\-identity ", " \-\-group ", "
+.BR \-\-tag ", " \-\-notes ", " \-\-proxy\-jump ", " \-\-remote\-command ", "
+.BR \-\-forward\-agent ", " \-\-os\-icon ", " \-\-transport ", " \-\-session\-log ", "
+.BR \-\-favorite ", " \-\-password\-stdin .
+.TP
+.B sshub host edit \fB\-\-name\fR \fINAME\fR [\fB\-\-set\-*\fR|\fB\-\-clear\-*\fR ...]
+Edit a host. Each field has a
+.BI \-\-set\- FIELD
+and, where nullable, a
+.BI \-\-clear\- FIELD
+form (e.g.
+.BR \-\-set\-username ", " \-\-clear\-username ", " \-\-set\-os\-icon ,
+.BR \-\-set\-tags ", " \-\-set\-group ", " \-\-set\-identity ", " \-\-set\-transport ).
+.TP
+.B sshub host rename \fB\-\-name\fR \fINAME\fR \fB\-\-new\-name\fR \fINEW\fR [\fB\-\-strict\fR]
+Rename a launcher host.
+.B \-\-strict
+fails instead of de-duplicating a clashing name.
+.TP
+.B sshub host delete \fB\-\-name\fR \fINAME\fR \fB\-\-yes\fR
+Delete a launcher host. Requires
+.BR \-\-yes .
+.TP
+.B sshub host duplicate \fINAME\fR
+Duplicate a host (legacy ssh_config hosts are copied into the launcher).
+.SS Aliases
+.TP
+.B sshub connect \fINAME\fR
+Alias for
+.BR "host connect" .
+.TP
+.B sshub list \fR...
+Alias for
+.BR "host list" .
+.TP
+.B sshub groups \fR...
+Alias for
+.BR "group list" " (forwards flags, e.g. " \-\-all ).
+.SS Groups
+.TP
+.B sshub group list \fR[\fB\-\-all\fR] [\fB\-\-format\fR \fIF\fR]
+.TQ
+.B sshub group show \fINAME\fR [\fB\-\-format\fR \fIF\fR]
+.TQ
+.B sshub group add \fB\-\-name\fR \fINAME\fR \fR[\fB\-\-parent\fR \fIG\fR] [\fB\-\-default\-identity\fR \fIN\fR] [\fB\-\-sort\-order\fR \fIN\fR]
+.TQ
+.B sshub group edit \fB\-\-name\fR \fINAME\fR \fR[\fB\-\-set\-name\fR|\fB\-\-set\-parent\fR|\fB\-\-clear\-parent\fR|\fB\-\-set\-default\-identity\fR|\fB\-\-clear\-default\-identity\fR|\fB\-\-set\-sort\-order\fR ...]
+.TQ
+.B sshub group delete \fB\-\-name\fR \fINAME\fR \fB\-\-yes\fR
+Manage host groups.
+.SS Identities
+.TP
+.B sshub identity list\fR|\fBshow\fR|\fBadd\fR|\fBedit\fR|\fBdelete\fR|\fBagent\-remove \fR...
+Manage SSH identities. Passwords are read from stdin with
+.BR \-\-password\-stdin .
+.B agent\-remove \-\-name \fINAME\fR
+runs
+.B ssh\-add \-d
+for the identity's key.
+.SS Tunnels
+.TP
+.B sshub tunnel list\fR|\fBshow \fR[\fB\-\-format\fR \fIF\fR]
+.TQ
+.B sshub tunnel create \fB\-\-host\fR \fINAME\fR \fB\-\-type\fR \fIT\fR \fB\-\-local\-port\fR \fIP\fR \fR[\fB\-\-remote\-host\fR \fIH\fR] [\fB\-\-remote\-port\fR \fIP\fR] [\fB\-\-label\fR \fIL\fR] [\fB\-\-keep\-alive\fR]
+.TQ
+.B sshub tunnel start \fIID\fR \fR[\fB\-\-foreground\fR]
+.TQ
+.B sshub tunnel stop \fIID\fR
+.TQ
+.B sshub tunnel delete \fIID\fR \fB\-\-yes\fR
+Manage SSH tunnels.
+.I T
+is
+.BR local ", " remote ", or " dynamic .
+By default
+.B start
+detaches and records a PID file under the data directory;
+.B \-\-foreground
+runs in-process with the reconnect loop.
+.IP
+Note: CLI-detached tunnels (PID file) and the TUI's in-process tunnel manager
+are mutually invisible.
+.SS SFTP (one-shot)
+.TP
+.B sshub sftp ls \fIHOST\fR \fR[\fIPATH\fR] [\fB\-\-format\fR \fIF\fR]
+.TQ
+.B sshub sftp get \fIHOST\fR \fIREMOTE\fR \fR[\fILOCAL\fR] [\fB\-\-recursive\fR]
+.TQ
+.B sshub sftp put \fIHOST\fR \fILOCAL\fR \fR[\fIREMOTE\fR] [\fB\-\-recursive\fR]
+.TQ
+.B sshub sftp rm \fIHOST\fR \fIREMOTE\fR \fR[\fB\-\-recursive\fR] \fB\-\-yes\fR
+.TQ
+.B sshub sftp mkdir\fR|\fBrename\fR|\fBchmod \fR...
+One-shot SFTP over a direct host (ProxyJump is not supported).
+.B chmod
+takes an octal mode.
+.B rm
+is destructive and requires
+.BR \-\-yes .
+.SS Audit
+.TP
+.B sshub audit list \fR[\fB\-\-status\fR \fIS\fR] [\fB\-\-via\fR \fIV\fR] [\fB\-\-host\fR \fIN\fR] [\fB\-\-limit\fR \fIN\fR] [\fB\-\-days\fR \fIN\fR] [\fB\-\-format\fR \fIF\fR]
+.TQ
+.B sshub audit stats \fR[\fB\-\-days\fR \fIN\fR] [\fB\-\-via\fR \fIV\fR] [\fB\-\-include\-retry\fR] [\fB\-\-format\fR \fIF\fR]
+Inspect the connection audit log.
+.I S
+is
+.BR all ", " ok ", " fail ", or " retry ;
+.I V
+is
+.BR all ", " connect ", " tunnel ", or " agent .
+.SS Inventory and config
+.TP
+.B sshub tags \fR[\fB\-\-format\fR \fIF\fR]
+List every tag in the inventory.
+.TP
+.B sshub sync
+Refresh the ssh_config-derived rows in the database.
+.TP
+.B sshub import
+Import hosts from
+.IR ~/.ssh/config .
+.TP
+.B sshub export \fR[\fB\-\-stdout\fR | \fB\-o\fR \fIPATH\fR]
+Export launcher hosts to an ssh_config snippet.
+.B \-\-stdout
+and
+.B \-o
+are mutually exclusive.
+.TP
+.B sshub completions \fBbash\fR|\fBzsh\fR|\fBfish\fR \fR[\fB\-\-cache\fR \fIPATH\fR]
+Print a shell completion script.
+.B \-\-cache
+writes/reads a host-name cache for faster dynamic completion.
+.TP
+.B sshub db purge \fR[\fB\-\-yes\-i\-am\-stupid\fR]
+Delete the launcher database (hosts, groups, identities, tunnels, audit log).
+Irreversible; requires
+.BR \-\-yes\-i\-am\-stupid .
+Leaves
+.I ~/.ssh/config
+untouched.
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B 1
+Operational failure (not found, a destructive command refused without
+.BR \-\-yes ,
+spawn error, non-zero ssh exit, hard import error).
+.TP
+.B 2
+Usage error, bad flags, deleting a non-launcher host, or deleting an identity
+still in use.
+.SH ENVIRONMENT
+.TP
+.B SSHUB_CONFIG_DIR
+Override the config directory (fallback:
+.BR SSH_LAUNCHER_CONFIG_DIR ).
+.TP
+.B SSHUB_DATA_DIR
+Override the data directory (fallback:
+.BR SSH_LAUNCHER_DATA_DIR ).
+.TP
+.B SSHUB_SSH_CONFIG
+Override the SSH config path (fallback:
+.BR SSH_LAUNCHER_SSH_CONFIG ).
+.TP
+.B SSHUB_DRY_RUN
+Exit immediately (fallback:
+.BR SSH_LAUNCHER_DRY_RUN ).
+.SH FILES
+.TP
+.I ~/.local/share/sshub/launcher.db
+The launcher SQLite database (managed hosts, groups, identities, tunnels, audit
+log). Path honors
+.BR SSHUB_DATA_DIR .
+.TP
+.I ~/.ssh/config
+Read-only source of ssh_config hosts merged into the launcher.
+.SH SEE ALSO
+.BR ssh (1),
+.BR ssh_config (5),
+.BR sftp (1),
+.BR ssh\-add (1)
+.PP
+Project home:
+.UR https://github.com/Petyok/SSHub
+.UE
+.SH BUGS
+Report issues at
+.UR https://github.com/Petyok/SSHub/issues
+.UE .

--- a/openwiki/architecture/source-map.md
+++ b/openwiki/architecture/source-map.md
@@ -11,6 +11,32 @@ Quick reference: where the code for each domain lives. Use this when you need to
 | Config load/save, XDG paths, env overrides | `src/config.rs` | `AppConfig`, `load_config()`, `data_dir()` |
 | Data directory permissions | `src/secure_fs.rs` | `restrict_dir`, `restrict_file` |
 
+## Headless CLI
+
+| Topic | File | Notes |
+|-------|------|-------|
+| Subcommand detection + dispatch | `src/cli/mod.rs` | `is_subcommand`, `run_subcommand` |
+| Shared `CliContext` (store, resolver, config, hosts) | `src/cli/context.rs` | `reload_hosts` |
+| Flag/format parsing, exit-code helpers | `src/cli/parse.rs` | `parse_format`, `usage`, `fail`, `fail_code` |
+| Per-command usage text | `src/cli/help.rs` | mirrors real flags |
+| Plain/JSON output formatting | `src/cli/output.rs` | |
+| Host commands (list/show/connect/resolve/add/edit/...) | `src/cli/host.rs` | script(1) log wrap, audit event |
+| Group commands | `src/cli/group.rs` | |
+| Identity commands | `src/cli/identity.rs` | `agent-remove` |
+| Tunnel commands (list/create/start/stop/...) | `src/cli/tunnel.rs` | detached + `--foreground` |
+| SFTP one-shot commands | `src/cli/sftp.rs` | ls/get/put/rm/mkdir/rename/chmod |
+| Audit list/stats | `src/cli/audit.rs` | |
+| tags / sync / import / export | `src/cli/inventory.rs` | |
+| Shell completions | `src/cli/completions.rs` | static tree + host cache |
+| Shared host filters | `src/cli/filter.rs` | |
+
+## Headless host helpers (shared by TUI + CLI)
+
+| Topic | File | Notes |
+|-------|------|-------|
+| Merged host list loader | `src/hosts/loader.rs` | `load_merged_hosts` (mirrors `App::reload_hosts`) |
+| Legacy-alias -> launcher duplicate, identity match | `src/hosts/crud.rs` | `duplicate_legacy_to_launcher`, `match_identity_for_ssh_host` |
+
 ## Application state & orchestration
 
 | Topic | File | Notes |
@@ -95,7 +121,9 @@ Quick reference: where the code for each domain lives. Use this when you need to
 
 | Topic | File | Notes |
 |-------|------|-------|
-| `TunnelManager`, spawn, reconnect, health | `src/tunnel.rs` | `stop_user`, `check_health`, `tick_reconnect` |
+| `TunnelManager`, reconnect, health, `ReconnectEvent` | `src/tunnel/mod.rs` | `stop_user`, `check_health`, `tick_reconnect` |
+| Tunnel argv build, detached spawn, PID files, runtime state | `src/tunnel/spawn.rs` | `build_tunnel_argv`, `spawn_detached_tunnel`, `tunnel_runtime_state`, `TunnelRuntimeState` |
+| Tunnel reconnect audit logging | `src/tunnel/audit.rs` | `log_tunnel_reconnect_events` |
 | Tunnels tab app logic + event loop hook | `src/app/tunnels.rs`, `src/lib.rs` | `toggle_tunnel`, `tick_tunnels` |
 | Tunnels tab render | `src/tui/screens/tunnels.rs` | |
 | Reconnect settings overlay | `src/tui/screens/tunnel_reconnect.rs` | NEW |

--- a/openwiki/integrations/import-export.md
+++ b/openwiki/integrations/import-export.md
@@ -42,6 +42,19 @@ The resolver output is combined with DB rows in `app/mod.rs::reload_hosts()`. La
 
 `src/ssh/probe.rs` records ssh handshake log lines. If a host key changed, SSHub can prompt the user to purge the stale `known_hosts` entry and reconnect.
 
+## Headless CLI
+
+Import, export, and ssh_config sync are all scriptable:
+
+- `sshub import` imports hosts from `~/.ssh/config` (the `Shift+I` action).
+- `sshub export [--stdout | -o PATH]` writes an ssh_config snippet for managed
+  launcher hosts (the `Shift+E` action); with no flag it writes to the default
+  `exported.conf` in the config dir, `--stdout` prints to stdout, and `-o PATH`
+  targets a file. `--stdout` and `-o` are mutually exclusive.
+- `sshub sync` refreshes the ssh_config rows in the DB without opening the TUI.
+
+See [cli.md](cli.md) for the full command reference.
+
 ## What to watch when changing integration code
 
 - `src/ssh/import.rs` — changes here affect how aliases, `Include` directives, and multi-host blocks are parsed.

--- a/openwiki/integrations/session-logging.md
+++ b/openwiki/integrations/session-logging.md
@@ -51,6 +51,17 @@ When a logged connect succeeds, the audit event stores the log directory in `log
 
 Session logging required database schema v12 (`src/store/migrate.rs`). The `hosts` table gained `session_logging` to persist the per-host override (encoded `None`/`0`/`1` for `Inherit`/`Off`/`On`).
 
+## Headless CLI
+
+`sshub connect <name>` honors the same session-logging configuration as an
+in-TUI connect: the global `[session_logging]` switch and the per-host
+`inherit` / `on` / `off` override are resolved through the same
+`effective_enabled()` path. Because a headless connect has no embedded PTY, the
+CLI captures the transcript by wrapping ssh in `script(1)`. Where `script` is
+unavailable (or for the `mosh` transport, which `script` cannot wrap), logging
+is skipped and a warning is printed instead of failing the connect. See
+[cli.md](cli.md) for the full command reference.
+
 ## What to watch when changing session logging
 
 - `src/session_log.rs` — writer lifecycle, rotation, retention, and directory sanitation are correctness-critical.

--- a/openwiki/workflows/cli.md
+++ b/openwiki/workflows/cli.md
@@ -1,0 +1,210 @@
+# Headless CLI
+
+SSHub ships a full command-line interface alongside the TUI. Every launcher
+resource (hosts, groups, identities, tunnels, the audit log) is reachable from
+scripts without opening the terminal UI, and SFTP file operations run one-shot
+over a direct host. The CLI is hand-rolled (no clap): `main.rs` recognizes a
+subcommand token before bootstrapping a `CliContext`, then dispatches through
+`src/cli/mod.rs::run_subcommand`.
+
+## Invocation model
+
+- `sshub <command> [args]` runs a subcommand and exits; no TUI is drawn.
+- `sshub <command> --help` (or `-h`) prints a per-command usage block from
+  `src/cli/help.rs` instead of the global help.
+- Bare `sshub` with no recognized subcommand launches the TUI as before.
+
+Dispatch lives in `src/cli/mod.rs`. Each family has its own module:
+`host.rs`, `group.rs`, `identity.rs`, `tunnel.rs`, `sftp.rs`, `audit.rs`,
+`inventory.rs` (tags/sync/import/export), and `completions.rs`. Shared argument
+parsing is in `src/cli/parse.rs`; output formatting in `src/cli/output.rs`.
+
+## Command tree
+
+### Hosts (`host`, with aliases)
+
+```
+sshub host list [--tag TAG]... [--group GROUP] [--sort MODE] [--format plain|json]
+sshub host show <name> [--format plain|json]
+sshub host connect <name> [-v|--verbose]
+sshub host resolve <name> [-v|--verbose] [--format plain|json]
+sshub host search <query> [--format plain|json]
+sshub host add --name NAME --address ADDR [--port N] [--username USER]
+              [--group GROUP]... [--identity NAME] [--tags a,b] [--label ...]
+              [--notes ...] [--proxy-jump ...] [--remote-command ...]
+              [--forward-agent|--no-forward-agent] [--transport ssh|mosh]
+              [--session-log inherit|on|off] [--os-icon ...] [--favorite]
+              [--password-stdin]
+sshub host edit --name NAME --set-* ...    (at least one --set-* / --clear-* flag)
+sshub host rename --name NAME --new-name NAME [--strict]
+sshub host delete --name NAME --yes
+sshub host duplicate --name NAME [--new-name NAME] [--format plain|json]
+```
+
+Top-level aliases forward into the `host` family:
+
+- `sshub connect <name>` is `sshub host connect <name>`.
+- `sshub list ...` is `sshub host list ...`.
+- `sshub groups ...` is `sshub group list ...`.
+
+`resolve` prints the effective SSH argv and metadata for a host without
+connecting. `connect` inherits stdio, records an audit event, and returns the
+child ssh exit code.
+
+### Groups (`group`)
+
+```
+sshub group list [--all] [--format plain|json]
+sshub group show <name> [--format plain|json]
+sshub group add --name NAME [--parent GROUP] [--default-identity NAME] [--sort-order N]
+sshub group edit --name NAME [--set-name ...] [--set-parent ...] [--clear-parent]
+                 [--set-default-identity ...] [--clear-default-identity] [--set-sort-order N]
+sshub group delete --name NAME --yes
+```
+
+### Identities (`identity`)
+
+```
+sshub identity list [--format plain|json]
+sshub identity show <name> [--format plain|json]
+sshub identity add --name NAME [--username USER] [--private-key PATH]
+                   [--certificate PATH] [--password-stdin]
+sshub identity edit --name NAME [--set-name ...] [--set-username ...] [--clear-username]
+                    [--set-private-key PATH] [--clear-private-key]
+                    [--set-certificate PATH] [--clear-certificate]
+                    [--password-stdin] [--clear-password]
+sshub identity delete --name NAME --yes
+sshub identity agent-remove --name NAME
+```
+
+`agent-remove` runs `ssh-add -d` for the identity's private key and logs the
+result to the audit log. Deleting an identity still referenced by hosts fails
+with exit code `2`.
+
+### Tunnels (`tunnel`)
+
+```
+sshub tunnel list [--format plain|json]
+sshub tunnel show <token> [--format plain|json]
+sshub tunnel create --host NAME --local-port N [--type local|remote|dynamic]
+                    [--remote-host HOST] [--remote-port N] [--label ...] [--keep-alive]
+sshub tunnel start <token> [--foreground]
+sshub tunnel stop <token>
+sshub tunnel delete <token> --yes
+```
+
+`<token>` resolves a tunnel by id, label, or local port. `start` spawns a
+detached background `ssh -N` by default and prints its pid; `start --foreground`
+runs the tunnel in the current process with the keep-alive reconnect loop and
+blocks until it stops or gives up.
+
+### SFTP (`sftp`)
+
+One-shot file operations over a direct host (ProxyJump hosts are rejected up
+front, since the libssh2 transport cannot chain a jump). Each subcommand drives
+the background SFTP worker synchronously.
+
+```
+sshub sftp ls <host> [remote-path] [--format plain|json]
+sshub sftp get <host> <remote-path> [local-path] [--recursive]
+sshub sftp put <host> <local-path> [remote-path] [--recursive]
+sshub sftp rm <host> <remote-path> [--recursive] --yes
+sshub sftp mkdir <host> <remote-path>
+sshub sftp rename <host> <from> <to>
+sshub sftp chmod <host> <mode> <remote-path>       (mode is octal, e.g. 644)
+```
+
+A local directory passed to `put` is always transferred recursively; `get`
+needs `--recursive` to walk a remote tree.
+
+### Audit log (`audit`)
+
+```
+sshub audit list [--status all|ok|fail|retry] [--via all|connect|tunnel|agent]
+                 [--host HOST] [--limit N] [--days N] [--format plain|json]
+sshub audit stats [--days N] [--via all|connect|tunnel|agent]
+                  [--include-retry] [--format plain|json]
+```
+
+### Inventory (`tags`, `sync`, `import`, `export`)
+
+```
+sshub tags [--format plain|json]
+sshub sync                                  # refresh ssh_config rows in the DB
+sshub import                                # import hosts from ~/.ssh/config
+sshub export [--stdout] [-o PATH]           # write an ssh_config snippet
+```
+
+### Completions (`completions`)
+
+```
+sshub completions bash|zsh|fish [--cache PATH]
+```
+
+Generates a static completion tree (top-level commands, per-family subcommands)
+plus the current host names. `--cache PATH` writes the host-name list to a file
+and reuses it on later runs, so completion stays fast on large inventories.
+Without a cache the generator shells out to `sshub host list --format json`.
+
+### Database (`db`)
+
+```
+sshub db purge --yes-i-am-stupid
+```
+
+Wipes the launcher database (managed hosts, groups, identities, tunnels, audit
+log). Irreversible, so it carries a stronger confirmation flag than the ordinary
+`--yes` guard. `~/.ssh/config` and the hosts imported from it are untouched.
+
+## Output format contract
+
+Commands that produce a listing or a record accept `--format plain|json`:
+
+- `plain` (the default) is line-oriented human-readable text.
+- `json` is pretty-printed JSON, stable enough to pipe into `jq`.
+
+Commands that only report an action (create, delete, sync, import) print a
+short status line and do not take `--format`. `parse_format` in
+`src/cli/parse.rs` is the single source of truth for the flag.
+
+## Exit-code convention
+
+Every subcommand returns one of three process exit codes:
+
+| Code | Meaning                                                        |
+|------|---------------------------------------------------------------|
+| `0`  | Success.                                                       |
+| `1`  | Operational failure (host not found, connect failed, IO error, a refused destructive command without `--yes`). |
+| `2`  | Usage error or bad flags (unknown subcommand, missing required argument, invalid value). |
+
+The helpers `usage()` (exit 2), `fail()` (exit 1), and `fail_code(msg, code)`
+in `src/cli/parse.rs` centralize these. A few semantic conflicts also map to
+`2`, for example deleting an identity that is still in use by hosts.
+
+## Destructive-confirmation rules
+
+Commands that remove data refuse to run unless confirmed:
+
+- `host delete`, `group delete`, `identity delete`, `tunnel delete`, and
+  `sftp rm` require `--yes`. Without it they print a diagnostic and exit `1`.
+- `db purge` requires the stronger `--yes-i-am-stupid` flag, because it wipes
+  the entire launcher database.
+
+The confirmation flag constant is `CONFIRM_YES` (`--yes`) in
+`src/cli/parse.rs`.
+
+## What to watch when changing the CLI
+
+- `src/cli/mod.rs` - `is_subcommand` (the pre-bootstrap string check) and
+  `run_subcommand` must stay in sync with the modules they dispatch to.
+- `src/cli/help.rs` - per-command usage text mirrors the real flags; update it
+  whenever a command's arguments change.
+- `src/cli/parse.rs` - shared flag parsing, format parsing, and the exit-code
+  helpers; keep the `0` / `1` / `2` convention consistent.
+- `src/cli/completions.rs` - the static command tree (`TOP_LEVEL`, `*_SUB`
+  arrays) must list every command and subcommand, or completion drifts from
+  reality.
+
+Relevant tests: the smoke suite exercises `--help` and dry-run; unit tests live
+alongside the CLI modules (for example `completions.rs` cache round-trip and
+`audit.rs` filter validation).

--- a/openwiki/workflows/connecting.md
+++ b/openwiki/workflows/connecting.md
@@ -76,6 +76,17 @@ Session logging is opt-in and was added in the Unreleased development cycle (sch
 
 Per-host `Transport` in the host form (`ssh` or `mosh`, schema v13). When set to `mosh`, embedded sessions exec `mosh` instead of `ssh`. Tunnels and SFTP always use `ssh`. If `mosh` is missing from `PATH`, connect fails with a clear error in the SSH log panel.
 
+## Headless CLI
+
+The same connect path is reachable without the TUI. `sshub connect <name>` (an
+alias for `sshub host connect <name>`) resolves the host, inherits stdio, and
+returns the child ssh exit code. Pass `-v` / `--verbose` (`sshub host connect
+<name> --verbose`) to inject `ssh -v` just like the connect screen does.
+`sshub host resolve <name>` prints the effective argv and metadata without
+connecting. CLI connect records the same audit event as an in-TUI connect, so
+auth history stays consistent across both entry points. See
+[cli.md](cli.md) for the full command reference.
+
 ## What to watch when changing connection code
 
 - `src/app/connect.rs` — secret resolution, argv building, session logging setup, auth event recording.

--- a/openwiki/workflows/sftp.md
+++ b/openwiki/workflows/sftp.md
@@ -57,6 +57,16 @@ The queue shows total bytes and a progress bar during transfers.
 
 The main event loop drains all pending `SftpEvent`s each tick, so UI stays responsive even while large transfers run.
 
+## Headless CLI
+
+One-shot SFTP operations run without the TUI:
+`sshub sftp ls|get|put|rm|mkdir|rename|chmod <host> ...`. Each subcommand drives
+the same background worker synchronously and exits. The direct libssh2 transport
+cannot chain a jump, so ProxyJump hosts are rejected up front. A local directory
+passed to `put` transfers recursively; `get` needs `--recursive` to walk a
+remote tree, and `sftp rm` requires `--yes`. See [cli.md](cli.md) for the full
+command reference.
+
 ## What to watch when changing SFTP
 
 - `src/sftp/transport.rs` — any new remote operation must have a matching command/event and handle errors gracefully.

--- a/openwiki/workflows/tunnels.md
+++ b/openwiki/workflows/tunnels.md
@@ -75,6 +75,23 @@ Tunnels run in the background without a terminal. The askpass dance is identical
 - If a stored credential exists, `SSH_ASKPASS` is wired up.
 - If no credential exists, `BatchMode=yes` is set so the tunnel fails fast with an error instead of prompting on `/dev/tty`.
 
+## Headless CLI
+
+Tunnels are also scriptable: `sshub tunnel list|create|start|stop` (plus `show`
+and `delete`). A `<token>` resolves a tunnel by id, label, or local port.
+`sshub tunnel start <token>` spawns a **detached** background `ssh -N`, writes a
+PID file, and prints the pid; `sshub tunnel start <token> --foreground` runs the
+tunnel in the current process with the keep-alive reconnect loop and blocks
+until it stops or gives up.
+
+**Limitation:** CLI-detached tunnels are tracked only through their PID file
+(`src/tunnel/spawn.rs`), so the in-app `TunnelManager` does not see them. A
+tunnel started by `sshub tunnel start` shows up as running via the CLI (through
+`TunnelRuntimeState`) but the TUI Tunnels tab, which only knows the children it
+spawned itself, will report it as down. Likewise a tunnel started inside the TUI
+is not managed by the CLI PID file. Start and stop a given tunnel from the same
+side to avoid confusion. See [cli.md](cli.md) for the full command reference.
+
 ## What to watch when changing tunnels
 
 - `src/tunnel.rs` — any change to child lifecycle, reconnect math, or askpass is high-risk for orphaned processes or port leaks.

--- a/src/app/host_crud.rs
+++ b/src/app/host_crud.rs
@@ -73,80 +73,13 @@ impl App {
                 };
                 copy.name
             }
-            HostEntry::Legacy { host, meta } => self.duplicate_legacy_to_launcher(host, meta)?,
+            HostEntry::Legacy { host, meta } => {
+                crate::hosts::duplicate_legacy_to_launcher(&self.store, host, meta)?
+            }
         };
 
         self.reload_hosts()?;
         self.restore_selection_by_name(&copy_name);
         Ok(())
-    }
-
-    pub(crate) fn duplicate_legacy_to_launcher(
-        &self,
-        host: &SshHost,
-        meta: &crate::metadata::HostMetadata,
-    ) -> Result<String> {
-        let mut name = format!("{}-copy", host.name);
-        let mut suffix = 2u32;
-        while self.store.get_host_by_name(&name)?.is_some() {
-            name = format!("{}-copy-{}", host.name, suffix);
-            suffix += 1;
-        }
-
-        let address = host.hostname.clone().unwrap_or_else(|| host.name.clone());
-        let port = host.port.unwrap_or(22);
-
-        let mut new_host = NewHost::launcher(name.clone(), address);
-        new_host.port = port;
-        new_host.tags = meta.tags.clone();
-        new_host.notes = meta.description.clone();
-        new_host.proxy_jump = host.proxy_jump.clone();
-        new_host.forward_agent = host.forward_agent.unwrap_or(false);
-        new_host.remote_command = host.remote_command.clone();
-        new_host.session_logging = meta.session_logging;
-        new_host.transport = meta.transport;
-        new_host.identity_id = self.match_identity_for_ssh_host(host)?;
-        self.store.create_host(&new_host)?;
-        Ok(name)
-    }
-
-    pub(crate) fn match_identity_for_ssh_host(&self, host: &SshHost) -> Result<Option<i64>> {
-        let user = host.user.as_deref();
-        let key = host.identity_file.as_deref();
-        if user.is_none() && key.is_none() {
-            return Ok(None);
-        }
-
-        for identity in self.store.list_identities()? {
-            let id_user = identity.username.as_deref();
-            let id_key = identity
-                .private_key
-                .as_ref()
-                .map(|p| p.to_string_lossy().into_owned());
-            let matches = match (user, key) {
-                (Some(u), Some(k)) => id_user == Some(u) && id_key.as_deref() == Some(k),
-                (Some(u), None) => id_user == Some(u),
-                (None, Some(k)) => id_key.as_deref() == Some(k),
-                (None, None) => false,
-            };
-            if matches {
-                return Ok(Some(identity.id));
-            }
-        }
-
-        let mut identity_name = format!("{}-identity", host.name);
-        let mut suffix = 2u32;
-        while self.store.get_identity_by_name(&identity_name)?.is_some() {
-            identity_name = format!("{}-identity-{}", host.name, suffix);
-            suffix += 1;
-        }
-
-        let created = self.store.create_identity(&NewIdentity {
-            name: identity_name,
-            username: host.user.clone(),
-            private_key: key.map(PathBuf::from),
-            ..Default::default()
-        })?;
-        Ok(Some(created.id))
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23,7 +23,6 @@ mod tests;
 pub use types::*;
 pub use util::*;
 
-use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -433,46 +432,11 @@ impl App {
 
         sync_ssh_config_hosts(self.resolver.as_ref(), &self.store)?;
 
-        let launcher_hosts = self.store.list_hosts_filtered(Some(HostSource::Launcher))?;
-        let ssh_config_hosts = self
-            .store
-            .list_hosts_filtered(Some(HostSource::SshConfig))?;
-        let db_names: std::collections::HashSet<String> = launcher_hosts
-            .iter()
-            .chain(ssh_config_hosts.iter())
-            .map(|h| h.name.clone())
-            .collect();
-
-        let mut hosts: Vec<HostEntry> = launcher_hosts
-            .into_iter()
-            .chain(ssh_config_hosts)
-            .map(HostEntry::from_managed)
-            .collect();
-
-        let config_names = self.resolver.list_hosts()?;
-        self.metadata.ensure_defaults(&config_names)?;
-
-        for name in config_names {
-            if db_names.contains(&name) {
-                continue;
-            }
-            let host = match self.resolver.resolve_host(&name) {
-                Ok(host) => host,
-                Err(_) => {
-                    // Can't resolve this alias via `ssh -G`; skip it. We run
-                    // under raw mode, so never write to stderr here (it would
-                    // corrupt the TUI). The host simply won't be listed.
-                    continue;
-                }
-            };
-            let meta = self
-                .metadata
-                .get(&name)?
-                .unwrap_or_else(|| crate::metadata::HostMetadata::new(&name));
-            hosts.push(HostEntry::Legacy { host, meta });
-        }
-
-        self.hosts = hosts;
+        self.hosts = crate::hosts::load_merged_hosts(
+            self.resolver.as_ref(),
+            &self.store,
+            self.metadata.as_ref(),
+        )?;
         self.load_groups()?;
         self.rebuild_filter();
         if let Some(name) = selected_name {

--- a/src/app/tests/host_crud.rs
+++ b/src/app/tests/host_crud.rs
@@ -10,7 +10,8 @@ pub(crate) fn duplicate_legacy_preserves_session_logging_override() {
         _ => panic!("expected legacy host"),
     };
 
-    let copy_name = app.duplicate_legacy_to_launcher(&ssh_host, &meta).unwrap();
+    let copy_name =
+        crate::hosts::duplicate_legacy_to_launcher(&app.store, &ssh_host, &meta).unwrap();
     let created = app
         .store
         .get_host_by_name(&copy_name)

--- a/src/app/tunnels.rs
+++ b/src/app/tunnels.rs
@@ -145,7 +145,8 @@ impl App {
                             &self.config.tunnel_reconnect,
                         );
                         if let Some(ev) = gave_up {
-                            self.log_tunnel_reconnect_events(
+                            crate::tunnel::log_tunnel_reconnect_events(
+                                &self.store,
                                 std::slice::from_ref(&ev),
                                 std::slice::from_ref(&tunnel),
                             );
@@ -537,7 +538,8 @@ impl App {
                         &self.config.tunnel_reconnect,
                     );
                     if let Some(ev) = gave_up {
-                        self.log_tunnel_reconnect_events(
+                        crate::tunnel::log_tunnel_reconnect_events(
+                            &self.store,
                             std::slice::from_ref(&ev),
                             std::slice::from_ref(&tunnel),
                         );
@@ -560,64 +562,6 @@ impl App {
         Ok(())
     }
 
-    pub(crate) fn log_tunnel_reconnect_events(
-        &self,
-        events: &[crate::tunnel::ReconnectEvent],
-        tunnels: &[crate::store::Tunnel],
-    ) {
-        for ev in events {
-            let tunnel = tunnels.iter().find(|t| t.id == ev.tunnel_id());
-            let (host_name, port, label) = tunnel
-                .map(|t| {
-                    let name = t
-                        .host_id
-                        .and_then(|hid| self.store.get_host(hid).ok().flatten())
-                        .map(|h| h.name)
-                        .unwrap_or_else(|| "unknown".into());
-                    (name, t.local_port, t.label.clone().unwrap_or_default())
-                })
-                .unwrap_or_else(|| ("unknown".into(), 0, String::new()));
-
-            match ev {
-                crate::tunnel::ReconnectEvent::Attempt { attempt, .. } => {
-                    let _ = self.store.log_auth_event(
-                        &host_name,
-                        None,
-                        "tunnel",
-                        "retry",
-                        &format!("tunnel reconnecting :{} {} attempt {attempt}", port, label),
-                        None,
-                    );
-                }
-                crate::tunnel::ReconnectEvent::Reconnected { .. } => {
-                    let _ = self.store.log_auth_event(
-                        &host_name,
-                        None,
-                        "tunnel",
-                        "launched",
-                        &format!("tunnel reconnected :{} {}", port, label),
-                        None,
-                    );
-                }
-                crate::tunnel::ReconnectEvent::GaveUp {
-                    attempts, error, ..
-                } => {
-                    let _ = self.store.log_auth_event(
-                        &host_name,
-                        None,
-                        "tunnel",
-                        "fail",
-                        &format!(
-                            "tunnel gave up :{} {} after {attempts} attempts — {error}",
-                            port, label
-                        ),
-                        None,
-                    );
-                }
-            }
-        }
-    }
-
     pub(crate) fn tick_tunnel_reconnect(&mut self) -> Result<()> {
         if self.should_quit {
             return Ok(());
@@ -631,7 +575,7 @@ impl App {
             |host_id| store.get_host(host_id).ok().flatten(),
             |host| resolve_pending_secret_for_managed(host, self.password_store.as_ref()).0,
         );
-        self.log_tunnel_reconnect_events(&events, &tunnels);
+        crate::tunnel::log_tunnel_reconnect_events(&self.store, &events, &tunnels);
         Ok(())
     }
 
@@ -646,7 +590,7 @@ impl App {
         let health_events = self
             .tunnel_manager
             .check_health(&self.tunnels, &self.config.tunnel_reconnect);
-        self.log_tunnel_reconnect_events(&health_events, &self.tunnels);
+        crate::tunnel::log_tunnel_reconnect_events(&self.store, &health_events, &self.tunnels);
         self.tick_tunnel_reconnect()
     }
 

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -34,6 +34,18 @@ impl SortMode {
             SortMode::Manual => "manual",
         }
     }
+
+    /// Parse CLI `--sort` values (not TUI display labels).
+    pub fn from_cli_str(s: &str) -> Option<Self> {
+        match s {
+            "label" => Some(Self::Label),
+            "last-connected" => Some(Self::LastConnected),
+            "favorite" => Some(Self::FavoriteFirst),
+            "group" => Some(Self::GroupThenLabel),
+            "manual" => Some(Self::Manual),
+            _ => None,
+        }
+    }
 }
 
 /// One section in the group tree (real group or virtual ungrouped bucket).

--- a/src/app/util.rs
+++ b/src/app/util.rs
@@ -180,6 +180,28 @@ pub fn mosh_argv_for_entry(entry: &HostEntry) -> Vec<String> {
     }
 }
 
+/// CLI connect argv: optional verbose logging, accept-new when secret present.
+pub fn prepare_cli_connect_argv(
+    mut argv: Vec<String>,
+    has_stored_secret: bool,
+    verbose: bool,
+) -> Vec<String> {
+    match argv.first().map(String::as_str) {
+        Some("ssh") => {
+            if verbose {
+                argv.insert(1, "-v".into());
+            }
+            if has_stored_secret {
+                argv.insert(1, "-o".into());
+                argv.insert(2, "StrictHostKeyChecking=accept-new".into());
+            }
+            argv
+        }
+        Some("mosh") if has_stored_secret => crate::ssh::inject_mosh_ssh_accept_new(argv),
+        _ => argv,
+    }
+}
+
 /// Apply connect-time tweaks to a bare session argv: verbose `ssh` logging and
 /// `StrictHostKeyChecking=accept-new` when a stored credential is present.
 pub fn prepare_session_connect_argv(mut argv: Vec<String>, has_stored_secret: bool) -> Vec<String> {
@@ -337,7 +359,7 @@ pub(crate) fn parse_tags(raw: &str) -> Vec<String> {
         .collect()
 }
 
-pub(crate) fn sort_host_indices(hosts: &[HostEntry], indices: &mut [usize], mode: SortMode) {
+pub fn sort_host_indices(hosts: &[HostEntry], indices: &mut [usize], mode: SortMode) {
     indices.sort_by(|&a, &b| compare_hosts(&hosts[a], &hosts[b], mode));
 }
 

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -1,10 +1,152 @@
-//! `sshub audit …` — placeholder. Phase 1 compile-only stub.
+//! `sshub audit` subcommands: auth-event audit log listing and stats.
 
 use anyhow::Result;
+use serde::Serialize;
 
 use super::CliContext;
+use crate::cli::output::{audit_event_json, format_audit_plain, now_ts};
+use crate::cli::parse::{
+    parse_days, parse_format, parse_limit, take_flag, take_opt, usage, OutputFormat,
+};
 
-pub fn run(_ctx: &mut CliContext, _args: &[String]) -> Result<i32> {
-    eprintln!("sshub: audit is not yet implemented");
-    Ok(2)
+pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    match args.first().map(String::as_str) {
+        Some("list") => cmd_list(ctx, &args[1..]),
+        Some("stats") => cmd_stats(ctx, &args[1..]),
+        Some(other) => {
+            eprintln!("sshub: unknown audit subcommand '{other}'");
+            eprintln!("sshub: try: audit list, audit stats");
+            Ok(2)
+        }
+        None => usage("audit needs a subcommand (list|stats)"),
+    }
+}
+
+fn cmd_list(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let fmt = parse_format(args).map_err(anyhow::Error::msg)?;
+    let limit = parse_limit(args, 50).map_err(anyhow::Error::msg)?;
+
+    let mut a = args.to_vec();
+    let status = take_opt(&mut a, "--status").unwrap_or_else(|| "all".into());
+    let via = take_opt(&mut a, "--via").unwrap_or_else(|| "all".into());
+    let host = take_opt(&mut a, "--host");
+    let days = take_opt(&mut a, "--days");
+
+    if !valid_status(&status) {
+        usage("audit list --status must be one of: all, ok, fail, retry");
+    }
+    if !valid_via(&via) {
+        usage("audit list --via must be one of: all, connect, tunnel, agent");
+    }
+
+    let since = match days {
+        Some(d) => {
+            let n: i64 = d
+                .parse()
+                .map_err(|_| anyhow::anyhow!("invalid --days '{d}'"))?;
+            Some(now_ts() - n * 86400)
+        }
+        None => None,
+    };
+
+    // Pass None for "all" so the store applies no filter (cleaner than the
+    // sentinel string, which the store also treats as "all").
+    let status_opt = (status != "all").then_some(status.as_str());
+    let via_opt = (via != "all").then_some(via.as_str());
+
+    let events =
+        ctx.store
+            .list_auth_events_cli(status_opt, since, via_opt, host.as_deref(), limit)?;
+
+    match fmt {
+        OutputFormat::Plain => {
+            for event in &events {
+                println!("{}", format_audit_plain(&audit_event_json(event)));
+            }
+        }
+        OutputFormat::Json => {
+            let rows: Vec<_> = events.iter().map(audit_event_json).collect();
+            println!("{}", serde_json::to_string_pretty(&rows)?);
+        }
+    }
+    Ok(0)
+}
+
+fn cmd_stats(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let fmt = parse_format(args).map_err(anyhow::Error::msg)?;
+    let days = parse_days(args, 30).map_err(anyhow::Error::msg)?;
+
+    let mut a = args.to_vec();
+    let via = take_opt(&mut a, "--via").unwrap_or_else(|| "all".into());
+    let include_retry = take_flag(&mut a, "--include-retry");
+
+    if !valid_via(&via) {
+        usage("audit stats --via must be one of: all, connect, tunnel, agent");
+    }
+
+    let via_opt = (via != "all").then_some(via.as_str());
+    let (ok, fail, retry) = ctx
+        .store
+        .auth_event_stats_filtered(days, via_opt, include_retry)?;
+
+    match fmt {
+        OutputFormat::Plain => {
+            println!("ok: {ok}");
+            println!("fail: {fail}");
+            if include_retry {
+                println!("retry: {retry}");
+            }
+            println!("window: last {days} days");
+        }
+        OutputFormat::Json => {
+            #[derive(Serialize)]
+            struct StatsJson {
+                ok: i64,
+                fail: i64,
+                retry: Option<i64>,
+                days: i64,
+            }
+            let out = StatsJson {
+                ok,
+                fail,
+                retry: include_retry.then_some(retry),
+                days,
+            };
+            println!("{}", serde_json::to_string_pretty(&out)?);
+        }
+    }
+    Ok(0)
+}
+
+fn valid_status(s: &str) -> bool {
+    matches!(s, "all" | "ok" | "fail" | "retry")
+}
+
+fn valid_via(s: &str) -> bool {
+    matches!(s, "all" | "connect" | "tunnel" | "agent")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_values_are_validated() {
+        for s in ["all", "ok", "fail", "retry"] {
+            assert!(valid_status(s));
+        }
+        for s in ["", "bogus", "launched", "success"] {
+            assert!(!valid_status(s));
+        }
+    }
+
+    #[test]
+    fn via_values_are_validated() {
+        for s in ["all", "connect", "tunnel", "agent"] {
+            assert!(valid_via(s));
+        }
+        for s in ["", "bogus", "local", "remote"] {
+            assert!(!valid_via(s));
+        }
+    }
 }

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -1,0 +1,10 @@
+//! `sshub audit …` — placeholder. Phase 1 compile-only stub.
+
+use anyhow::Result;
+
+use super::CliContext;
+
+pub fn run(_ctx: &mut CliContext, _args: &[String]) -> Result<i32> {
+    eprintln!("sshub: audit is not yet implemented");
+    Ok(2)
+}

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -381,7 +381,13 @@ _sshub() {{
     esac
 }}
 
-_sshub "$@"
+# Works both ways: as an fpath autoload file (zsh calls the function directly)
+# and when sourced from .zshrc (register it with compdef).
+if [ "$funcstack[1]" = "_sshub" ]; then
+    _sshub "$@"
+else
+    compdef _sshub sshub
+fi
 "#,
         top = TOP_LEVEL.join(" "),
         host_sub = HOST_SUB.join(" "),

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -237,10 +237,15 @@ _sshub_completions() {{
     fi
 
     case "${{COMP_WORDS[1]}}" in
-        host|connect)
+        host)
             if (( COMP_CWORD == 2 )); then
                 COMPREPLY=( $(compgen -W "$host_sub" -- "$cur") )
             elif (( COMP_CWORD >= 3 )) && [[ "${{COMP_WORDS[2]}}" == @(connect|show|resolve|delete|duplicate) ]]; then
+                COMPREPLY=( $(compgen -W "$hosts" -- "$cur") )
+            fi
+            ;;
+        connect)
+            if (( COMP_CWORD == 2 )); then
                 COMPREPLY=( $(compgen -W "$hosts" -- "$cur") )
             fi
             ;;
@@ -336,12 +341,15 @@ _sshub() {{
             ;;
         args)
             case $words[2] in
-                host|connect)
+                host)
                     if (( CURRENT == 3 )); then
                         _describe 'subcommand' host_cmds
                     elif (( CURRENT >= 4 )) && [[ $words[3] == (connect|show|resolve|delete|duplicate) ]]; then
                         _describe 'host' hosts
                     fi
+                    ;;
+                connect)
+                    (( CURRENT == 3 )) && _describe 'host' hosts
                     ;;
                 groups|group)
                     (( CURRENT == 3 )) && _describe 'subcommand' group_cmds

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -1,0 +1,441 @@
+//! Shell completion generators (bash/zsh/fish).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+use crate::secure_fs;
+
+use super::context::CliContext;
+use super::parse::{take_opt, usage};
+
+const CACHE_HEADER: &str = "# sshub-completion-cache v1";
+
+/// Top-level subcommands (static completion tree).
+const TOP_LEVEL: &[&str] = &[
+    "host",
+    "connect",
+    "list",
+    "groups",
+    "group",
+    "identity",
+    "tunnel",
+    "sftp",
+    "audit",
+    "tags",
+    "sync",
+    "import",
+    "export",
+    "completions",
+    "db",
+];
+
+const HOST_SUB: &[&str] = &[
+    "list",
+    "show",
+    "connect",
+    "resolve",
+    "search",
+    "add",
+    "edit",
+    "rename",
+    "delete",
+    "duplicate",
+];
+
+const GROUP_SUB: &[&str] = &["list", "show", "add", "edit", "delete"];
+
+const IDENTITY_SUB: &[&str] = &["list", "show", "add", "edit", "delete", "agent-remove"];
+
+const TUNNEL_SUB: &[&str] = &["list", "show", "create", "delete", "start", "stop"];
+
+const SFTP_SUB: &[&str] = &["ls", "get", "put", "rm", "mkdir", "rename", "chmod"];
+
+const AUDIT_SUB: &[&str] = &["list", "stats"];
+
+const DB_SUB: &[&str] = &["purge"];
+
+const COMPLETIONS_SUB: &[&str] = &["bash", "zsh", "fish"];
+
+pub fn run(_ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let shell = match rest.first() {
+        Some(s) => s.to_string(),
+        None => usage("completions requires a shell (bash|zsh|fish)"),
+    };
+
+    if !matches!(shell.as_str(), "bash" | "zsh" | "fish") {
+        eprintln!("sshub: unknown completions shell '{shell}'");
+        eprintln!("       try: sshub completions bash|zsh|fish");
+        return Ok(2);
+    }
+    rest.remove(0);
+
+    let cache_path = take_opt(&mut rest, "--cache");
+    let host_names = load_host_names(cache_path.as_deref())?;
+
+    if let Some(path) = cache_path {
+        write_cache(&path, &host_names)?;
+    }
+
+    let script = match shell.as_str() {
+        "bash" => render_bash(&host_names),
+        "zsh" => render_zsh(&host_names),
+        "fish" => render_fish(&host_names),
+        _ => unreachable!(),
+    };
+    print!("{script}");
+    Ok(0)
+}
+
+fn load_host_names(cache_path: Option<&str>) -> Result<Vec<String>> {
+    if let Some(path) = cache_path {
+        if Path::new(path).exists() {
+            if let Ok(names) = read_cache(path) {
+                return Ok(names);
+            }
+        }
+    }
+    fetch_host_names_via_subprocess()
+}
+
+fn fetch_host_names_via_subprocess() -> Result<Vec<String>> {
+    let exe = std::env::current_exe().context("resolve sshub executable path")?;
+    let output = Command::new(&exe)
+        .args(["host", "list", "--format", "json"])
+        .output()
+        .context("spawn sshub host list for completions")?;
+
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_host_list_json(&stdout)
+}
+
+fn parse_host_list_json(stdout: &str) -> Result<Vec<String>> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let value: serde_json::Value = serde_json::from_str(trimmed).unwrap_or(serde_json::Value::Null);
+    let mut names = Vec::new();
+    if let Some(arr) = value.as_array() {
+        for item in arr {
+            if let Some(n) = item.get("name").and_then(|v| v.as_str()) {
+                names.push(n.to_string());
+            } else if let Some(n) = item.as_str() {
+                names.push(n.to_string());
+            }
+        }
+    } else if let Some(arr) = value.as_array() {
+        for item in arr {
+            if let Some(s) = item.as_str() {
+                names.push(s.to_string());
+            }
+        }
+    }
+    Ok(names)
+}
+
+fn write_cache(path: &str, names: &[String]) -> Result<()> {
+    let p = PathBuf::from(path);
+    if let Some(parent) = p.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create cache directory {}", parent.display()))?;
+            secure_fs::restrict_dir(parent);
+        }
+    }
+    let mut body = String::from(CACHE_HEADER);
+    body.push('\n');
+    for n in names {
+        body.push_str(n);
+        body.push('\n');
+    }
+    fs::write(&p, &body).with_context(|| format!("write completion cache {}", p.display()))?;
+    secure_fs::restrict_file(&p);
+    Ok(())
+}
+
+fn read_cache(path: &str) -> Result<Vec<String>> {
+    let content = fs::read_to_string(path).with_context(|| format!("read cache {path}"))?;
+    Ok(content
+        .lines()
+        .filter(|l| !l.starts_with('#') && !l.trim().is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+fn words_csv(items: &[&str]) -> String {
+    items.join(" ")
+}
+
+fn names_csv(names: &[String]) -> String {
+    names.join(" ")
+}
+
+fn render_bash(host_names: &[String]) -> String {
+    format!(
+        r#"# sshub bash completion
+_sshub_completions() {{
+    local cur prev
+    cur="${{COMP_WORDS[COMP_CWORD]}}"
+    prev="${{COMP_WORDS[COMP_CWORD-1]}}"
+
+    local top="{top}"
+    local host_sub="{host_sub}"
+    local group_sub="{group_sub}"
+    local identity_sub="{identity_sub}"
+    local tunnel_sub="{tunnel_sub}"
+    local sftp_sub="{sftp_sub}"
+    local audit_sub="{audit_sub}"
+    local db_sub="{db_sub}"
+    local completions_sub="{completions_sub}"
+    local hosts="{hosts}"
+
+    if (( COMP_CWORD == 1 )); then
+        COMPREPLY=( $(compgen -W "$top" -- "$cur") )
+        return
+    fi
+
+    case "${{COMP_WORDS[1]}}" in
+        host|connect)
+            if (( COMP_CWORD == 2 )); then
+                COMPREPLY=( $(compgen -W "$host_sub" -- "$cur") )
+            elif (( COMP_CWORD >= 3 )) && [[ "${{COMP_WORDS[2]}}" == @(connect|show|resolve|delete|duplicate) ]]; then
+                COMPREPLY=( $(compgen -W "$hosts" -- "$cur") )
+            fi
+            ;;
+        list)
+            COMPREPLY=( $(compgen -W "--tag --group --sort --format plain json" -- "$cur") )
+            ;;
+        groups|group)
+            if (( COMP_CWORD == 2 )); then
+                COMPREPLY=( $(compgen -W "$group_sub" -- "$cur") )
+            fi
+            ;;
+        identity)
+            if (( COMP_CWORD == 2 )); then
+                COMPREPLY=( $(compgen -W "$identity_sub" -- "$cur") )
+            fi
+            ;;
+        tunnel)
+            if (( COMP_CWORD == 2 )); then
+                COMPREPLY=( $(compgen -W "$tunnel_sub" -- "$cur") )
+            fi
+            ;;
+        sftp)
+            if (( COMP_CWORD == 2 )); then
+                COMPREPLY=( $(compgen -W "$sftp_sub" -- "$cur") )
+            elif (( COMP_CWORD == 3 )); then
+                COMPREPLY=( $(compgen -W "$hosts" -- "$cur") )
+            fi
+            ;;
+        audit)
+            if (( COMP_CWORD == 2 )); then
+                COMPREPLY=( $(compgen -W "$audit_sub" -- "$cur") )
+            fi
+            ;;
+        db)
+            if (( COMP_CWORD == 2 )); then
+                COMPREPLY=( $(compgen -W "$db_sub" -- "$cur") )
+            fi
+            ;;
+        completions)
+            if (( COMP_CWORD == 2 )); then
+                COMPREPLY=( $(compgen -W "$completions_sub" -- "$cur") )
+            fi
+            ;;
+        tags|sync|import|export)
+            COMPREPLY=( $(compgen -W "--format plain json --stdout -o --cache" -- "$cur") )
+            ;;
+    esac
+}}
+complete -F _sshub_completions sshub
+"#,
+        top = words_csv(TOP_LEVEL),
+        host_sub = words_csv(HOST_SUB),
+        group_sub = words_csv(GROUP_SUB),
+        identity_sub = words_csv(IDENTITY_SUB),
+        tunnel_sub = words_csv(TUNNEL_SUB),
+        sftp_sub = words_csv(SFTP_SUB),
+        audit_sub = words_csv(AUDIT_SUB),
+        db_sub = words_csv(DB_SUB),
+        completions_sub = words_csv(COMPLETIONS_SUB),
+        hosts = names_csv(host_names),
+    )
+}
+
+fn render_zsh(host_names: &[String]) -> String {
+    format!(
+        r#"#compdef sshub
+# sshub zsh completion
+
+local -a top_cmds host_cmds group_cmds identity_cmds tunnel_cmds sftp_cmds audit_cmds db_cmds completion_cmds hosts
+
+top_cmds=({top})
+host_cmds=({host_sub})
+group_cmds=({group_sub})
+identity_cmds=({identity_sub})
+tunnel_cmds=({tunnel_sub})
+sftp_cmds=({sftp_sub})
+audit_cmds=({audit_sub})
+db_cmds=({db_sub})
+completion_cmds=({completions_sub})
+hosts=({hosts})
+
+_sshub() {{
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+
+    _arguments -C \
+        '1:command:->cmd' \
+        '*::arg:->args'
+
+    case $state in
+        cmd)
+            _describe 'command' top_cmds
+            ;;
+        args)
+            case $words[2] in
+                host|connect)
+                    if (( CURRENT == 3 )); then
+                        _describe 'subcommand' host_cmds
+                    elif (( CURRENT >= 4 )) && [[ $words[3] == (connect|show|resolve|delete|duplicate) ]]; then
+                        _describe 'host' hosts
+                    fi
+                    ;;
+                groups|group)
+                    (( CURRENT == 3 )) && _describe 'subcommand' group_cmds
+                    ;;
+                identity)
+                    (( CURRENT == 3 )) && _describe 'subcommand' identity_cmds
+                    ;;
+                tunnel)
+                    (( CURRENT == 3 )) && _describe 'subcommand' tunnel_cmds
+                    ;;
+                sftp)
+                    if (( CURRENT == 3 )); then
+                        _describe 'subcommand' sftp_cmds
+                    elif (( CURRENT == 4 )); then
+                        _describe 'host' hosts
+                    fi
+                    ;;
+                audit)
+                    (( CURRENT == 3 )) && _describe 'subcommand' audit_cmds
+                    ;;
+                db)
+                    (( CURRENT == 3 )) && _describe 'subcommand' db_cmds
+                    ;;
+                completions)
+                    (( CURRENT == 3 )) && _describe 'shell' completion_cmds
+                    ;;
+            esac
+            ;;
+    esac
+}}
+
+_sshub "$@"
+"#,
+        top = TOP_LEVEL.join(" "),
+        host_sub = HOST_SUB.join(" "),
+        group_sub = GROUP_SUB.join(" "),
+        identity_sub = IDENTITY_SUB.join(" "),
+        tunnel_sub = TUNNEL_SUB.join(" "),
+        sftp_sub = SFTP_SUB.join(" "),
+        audit_sub = AUDIT_SUB.join(" "),
+        db_sub = DB_SUB.join(" "),
+        completions_sub = COMPLETIONS_SUB.join(" "),
+        hosts = host_names.join(" "),
+    )
+}
+
+fn render_fish(host_names: &[String]) -> String {
+    let mut out = String::from("# sshub fish completion\n\n");
+    out.push_str("complete -c sshub -f\n\n");
+
+    for cmd in TOP_LEVEL {
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_use_subcommand' -a '{cmd}'\n"
+        ));
+    }
+
+    for sub in HOST_SUB {
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_seen_subcommand_from host connect' -a '{sub}'\n"
+        ));
+    }
+    for sub in GROUP_SUB {
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_seen_subcommand_from groups group' -a '{sub}'\n"
+        ));
+    }
+    for sub in IDENTITY_SUB {
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_seen_subcommand_from identity' -a '{sub}'\n"
+        ));
+    }
+    for sub in TUNNEL_SUB {
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_seen_subcommand_from tunnel' -a '{sub}'\n"
+        ));
+    }
+    for sub in SFTP_SUB {
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_seen_subcommand_from sftp' -a '{sub}'\n"
+        ));
+    }
+    for sub in AUDIT_SUB {
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_seen_subcommand_from audit' -a '{sub}'\n"
+        ));
+    }
+    for sub in DB_SUB {
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_seen_subcommand_from db' -a '{sub}'\n"
+        ));
+    }
+    for sub in COMPLETIONS_SUB {
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_seen_subcommand_from completions' -a '{sub}'\n"
+        ));
+    }
+
+    for name in host_names {
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_seen_subcommand_from host connect; and __fish_seen_subcommand_from connect show resolve delete duplicate' -a '{name}'\n"
+        ));
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_seen_subcommand_from sftp; and not __fish_seen_subcommand_from ls get put rm mkdir rename chmod' -a '{name}'\n"
+        ));
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hosts.cache");
+        let names = vec!["web".into(), "db".into()];
+        write_cache(path.to_str().unwrap(), &names).unwrap();
+        let read = read_cache(path.to_str().unwrap()).unwrap();
+        assert_eq!(read, names);
+    }
+
+    #[test]
+    fn bash_script_contains_top_level() {
+        let script = render_bash(&["prod".into()]);
+        assert!(script.contains("host"));
+        assert!(script.contains("group"));
+        assert!(script.contains("prod"));
+    }
+}

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -174,8 +174,42 @@ fn words_csv(items: &[&str]) -> String {
     items.join(" ")
 }
 
-fn names_csv(names: &[String]) -> String {
-    names.join(" ")
+/// Escape a host name for a bash double-quoted context (`local hosts="..."`),
+/// neutralizing string-breakout and command substitution. Host names are not
+/// restricted to a safe charset, and the generated script is sourced, so an
+/// unescaped name like `$(...)` would execute at completion-load time.
+fn bash_dq(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for c in name.chars() {
+        if matches!(c, '\\' | '"' | '`' | '$') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// POSIX single-quote a token for a zsh array literal (`hosts=(...)`).
+fn sq(name: &str) -> String {
+    format!("'{}'", name.replace('\'', "'\\''"))
+}
+
+/// Single-quote a token for fish (`-a '...'`); inside '...' fish only treats
+/// `\'` and `\\` as escapes.
+fn fish_sq(name: &str) -> String {
+    format!("'{}'", name.replace('\\', "\\\\").replace('\'', "\\'"))
+}
+
+fn bash_host_list(names: &[String]) -> String {
+    names
+        .iter()
+        .map(|n| bash_dq(n))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn zsh_host_list(names: &[String]) -> String {
+    names.iter().map(|n| sq(n)).collect::<Vec<_>>().join(" ")
 }
 
 fn render_bash(host_names: &[String]) -> String {
@@ -266,7 +300,7 @@ complete -F _sshub_completions sshub
         audit_sub = words_csv(AUDIT_SUB),
         db_sub = words_csv(DB_SUB),
         completions_sub = words_csv(COMPLETIONS_SUB),
-        hosts = names_csv(host_names),
+        hosts = bash_host_list(host_names),
     )
 }
 
@@ -350,7 +384,7 @@ _sshub "$@"
         audit_sub = AUDIT_SUB.join(" "),
         db_sub = DB_SUB.join(" "),
         completions_sub = COMPLETIONS_SUB.join(" "),
-        hosts = host_names.join(" "),
+        hosts = zsh_host_list(host_names),
     )
 }
 
@@ -406,11 +440,12 @@ fn render_fish(host_names: &[String]) -> String {
     }
 
     for name in host_names {
+        let q = fish_sq(name);
         out.push_str(&format!(
-            "complete -c sshub -n '__fish_seen_subcommand_from host connect; and __fish_seen_subcommand_from connect show resolve delete duplicate' -a '{name}'\n"
+            "complete -c sshub -n '__fish_seen_subcommand_from host connect; and __fish_seen_subcommand_from connect show resolve delete duplicate' -a {q}\n"
         ));
         out.push_str(&format!(
-            "complete -c sshub -n '__fish_seen_subcommand_from sftp; and not __fish_seen_subcommand_from ls get put rm mkdir rename chmod' -a '{name}'\n"
+            "complete -c sshub -n '__fish_seen_subcommand_from sftp; and not __fish_seen_subcommand_from ls get put rm mkdir rename chmod' -a {q}\n"
         ));
     }
 
@@ -437,5 +472,25 @@ mod tests {
         assert!(script.contains("host"));
         assert!(script.contains("group"));
         assert!(script.contains("prod"));
+    }
+
+    #[test]
+    fn host_names_are_shell_escaped() {
+        let names = vec!["x$(id)".to_string(), "q'z".to_string()];
+        let bash = render_bash(&names);
+        assert!(
+            bash.contains("x\\$(id)"),
+            "bash must escape $ in host names: {bash}"
+        );
+        let zsh = render_zsh(&names);
+        assert!(
+            zsh.contains("'q'\\''z'"),
+            "zsh must single-quote-escape host names: {zsh}"
+        );
+        let fish = render_fish(&names);
+        assert!(
+            fish.contains("'q\\'z'"),
+            "fish must escape quotes in host names: {fish}"
+        );
     }
 }

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -1,0 +1,156 @@
+//! CLI bootstrap context — opens store/metadata without starting the TUI.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+
+use crate::app::{resolve_pending_secret_for_managed, HostEntry};
+use crate::config::{self, AppConfig};
+use crate::credentials::{OsKeyring, PasswordStore};
+use crate::hosts::load_merged_hosts;
+use crate::metadata::MetadataDb;
+use crate::ssh::SshConfigResolver;
+use crate::store::{HostGroup, Identity, LauncherStore, ManagedHost, Tunnel};
+
+pub struct CliContext {
+    pub config: AppConfig,
+    pub store: Arc<LauncherStore>,
+    pub metadata: Arc<MetadataDb>,
+    pub resolver: SshConfigResolver,
+    pub password_store: Box<dyn PasswordStore>,
+    pub hosts: Vec<HostEntry>,
+}
+
+impl CliContext {
+    pub fn bootstrap() -> Result<Self> {
+        let config = config::load_config()?;
+        let data_dir = config::data_dir()?;
+        std::fs::create_dir_all(&data_dir)?;
+
+        let metadata = Arc::new(MetadataDb::open(data_dir.join("metadata.db"))?);
+        let store = Arc::new(LauncherStore::open(data_dir.join("launcher.db"))?);
+        let resolver = SshConfigResolver::default();
+        let password_store: Box<dyn PasswordStore> = Box::new(OsKeyring);
+
+        let mut ctx = Self {
+            config,
+            store,
+            metadata,
+            resolver,
+            password_store,
+            hosts: Vec::new(),
+        };
+        ctx.reload_hosts()?;
+        Ok(ctx)
+    }
+
+    pub fn reload_hosts(&mut self) -> Result<()> {
+        self.hosts = load_merged_hosts(&self.resolver, &self.store, self.metadata.as_ref())?;
+        Ok(())
+    }
+
+    pub fn host_by_name(&self, name: &str) -> Result<&HostEntry> {
+        self.hosts
+            .iter()
+            .find(|h| h.name() == name)
+            .with_context(|| format!("host '{name}' not found"))
+    }
+
+    pub fn managed_host_by_name(&self, name: &str) -> Result<ManagedHost> {
+        match self.host_by_name(name)? {
+            HostEntry::Managed(m) => Ok(m.clone()),
+            HostEntry::Legacy { .. } => {
+                anyhow::bail!("host '{name}' is not a managed launcher host")
+            }
+        }
+    }
+
+    pub fn group_by_name(&self, name: &str) -> Result<HostGroup> {
+        self.store
+            .list_groups()?
+            .into_iter()
+            .find(|g| g.name == name)
+            .with_context(|| format!("group '{name}' not found"))
+    }
+
+    pub fn identity_by_name(&self, name: &str) -> Result<Identity> {
+        self.store
+            .list_identities()?
+            .into_iter()
+            .find(|i| i.name == name)
+            .with_context(|| format!("identity '{name}' not found"))
+    }
+
+    /// Resolve a tunnel by numeric id, label, or local port. Ambiguity is an error.
+    pub fn resolve_tunnel(&self, token: &str) -> Result<Tunnel> {
+        if let Ok(id) = token.parse::<i64>() {
+            return self
+                .store
+                .get_tunnel(id)?
+                .with_context(|| format!("tunnel {id} not found"));
+        }
+        if let Ok(port) = token.parse::<u16>() {
+            let matches = self.store.find_tunnels_by_local_port(port)?;
+            return pick_tunnel(matches, "local-port");
+        }
+        let matches = self.store.find_tunnels_by_label(token)?;
+        pick_tunnel(matches, "label")
+    }
+
+    pub fn resolve_tunnel_host(&self, tunnel: &Tunnel) -> Result<ManagedHost> {
+        let host_id = tunnel
+            .host_id
+            .with_context(|| format!("tunnel {} has no host", tunnel.id))?;
+        self.store
+            .get_host(host_id)?
+            .with_context(|| format!("host {host_id} not found for tunnel {}", tunnel.id))
+    }
+
+    pub fn resolve_tunnel_secret(
+        &self,
+        host: &ManagedHost,
+    ) -> (Option<crate::session::PendingSecret>, String) {
+        resolve_pending_secret_for_managed(host, self.password_store.as_ref())
+    }
+}
+
+fn pick_tunnel(mut matches: Vec<Tunnel>, kind: &str) -> Result<Tunnel> {
+    match matches.len() {
+        0 => anyhow::bail!("no tunnel found for {kind}"),
+        1 => Ok(matches.remove(0)),
+        n => anyhow::bail!("ambiguous {kind}: {n} tunnels match"),
+    }
+}
+
+/// Resolve a group name to its database id (used by `group add/edit --parent`).
+pub fn resolve_parent_id(ctx: &CliContext, name: &str) -> Result<i64> {
+    ctx.group_by_name(name).map(|g| g.id)
+}
+
+/// Resolve an identity name to its database id (used by `group … --default-identity`).
+pub fn resolve_identity_id(ctx: &CliContext, name: &str) -> Result<i64> {
+    ctx.identity_by_name(name).map(|i| i.id)
+}
+
+/// Normalize a `--*-key`/`--certificate` path flag value: trim surrounding
+/// whitespace, expand a leading `~`, and return `None` for an empty value so
+/// callers can distinguish "not provided" from "set to blank".
+pub fn optional_path_flag(raw: &str) -> Result<Option<PathBuf>> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(crate::ssh::expand_tilde(trimmed)))
+}
+
+/// Read a secret from stdin (for `--password-stdin`), stripping the trailing
+/// newline so a piped `echo secret` does not store the newline.
+pub fn read_password_stdin() -> Result<String> {
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buf)
+        .context("read password from stdin")?;
+    Ok(buf.trim_end_matches(['\r', '\n']).to_string())
+}

--- a/src/cli/filter.rs
+++ b/src/cli/filter.rs
@@ -1,0 +1,124 @@
+//! Host list filtering and sorting for CLI.
+
+use crate::app::{sort_host_indices, HostEntry, SortMode};
+use crate::store::{HostGroup, LauncherStore};
+
+/// Tag AND filter (same semantics as TUI [`rebuild_filter`](crate::app::hostlist::App::rebuild_filter)).
+pub fn filter_by_tags(hosts: &[HostEntry], tags: &[String]) -> Vec<usize> {
+    if tags.is_empty() {
+        return (0..hosts.len()).collect();
+    }
+    hosts
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| {
+            let host_tags = entry.tags();
+            tags.iter().all(|f| host_tags.iter().any(|t| t == f))
+        })
+        .map(|(idx, _)| idx)
+        .collect()
+}
+
+/// Exact group membership by group name (not subtree).
+pub fn filter_by_group_name(
+    hosts: &[HostEntry],
+    groups: &[HostGroup],
+    group_name: &str,
+) -> Vec<usize> {
+    let Some(group) = groups.iter().find(|g| g.name == group_name) else {
+        return Vec::new();
+    };
+    hosts
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| entry.group_ids().contains(&group.id))
+        .map(|(idx, _)| idx)
+        .collect()
+}
+
+pub fn apply_filters(
+    hosts: &[HostEntry],
+    store: &LauncherStore,
+    tags: &[String],
+    group: Option<&str>,
+    sort: SortMode,
+) -> anyhow::Result<Vec<usize>> {
+    let mut indices = filter_by_tags(hosts, tags);
+    if let Some(gname) = group {
+        let groups = store.list_groups()?;
+        let group_indices = filter_by_group_name(hosts, &groups, gname);
+        indices.retain(|i| group_indices.contains(i));
+    }
+    sort_host_indices(hosts, &mut indices, sort);
+    Ok(indices)
+}
+
+pub fn all_group_names(
+    store: &LauncherStore,
+    include_reserved: bool,
+) -> anyhow::Result<Vec<String>> {
+    Ok(store
+        .list_groups()?
+        .into_iter()
+        .filter(|g| include_reserved || !g.reserved)
+        .map(|g| g.name)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::HostMetadata;
+    use crate::ssh::SshHost;
+    use crate::store::LauncherStore;
+
+    #[test]
+    fn tag_and_filter() {
+        let hosts = vec![
+            HostEntry::Legacy {
+                host: SshHost {
+                    name: "a".into(),
+                    ..Default::default()
+                },
+                meta: HostMetadata {
+                    host_name: "a".into(),
+                    tags: vec!["web".into(), "prod".into()],
+                    ..Default::default()
+                },
+            },
+            HostEntry::Legacy {
+                host: SshHost {
+                    name: "b".into(),
+                    ..Default::default()
+                },
+                meta: HostMetadata {
+                    host_name: "b".into(),
+                    tags: vec!["web".into()],
+                    ..Default::default()
+                },
+            },
+        ];
+        let idx = filter_by_tags(&hosts, &["web".into(), "prod".into()]);
+        assert_eq!(idx, vec![0]);
+    }
+
+    #[test]
+    fn group_name_filter() {
+        let store = LauncherStore::open_in_memory().unwrap();
+        let g = store
+            .create_group(&crate::store::NewHostGroup {
+                name: "prod".into(),
+                ..Default::default()
+            })
+            .unwrap();
+        let host = store
+            .create_host(&crate::store::NewHost::launcher("h1", "1.2.3.4"))
+            .unwrap();
+        store.set_host_groups(host.id, &[g.id]).unwrap();
+        let managed = store.get_host(host.id).unwrap().unwrap();
+        let hosts = vec![HostEntry::from_managed(managed)];
+        let groups = store.list_groups().unwrap();
+        let idx = filter_by_group_name(&hosts, &groups, "prod");
+        assert_eq!(idx, vec![0]);
+    }
+}

--- a/src/cli/filter.rs
+++ b/src/cli/filter.rs
@@ -70,7 +70,22 @@ mod tests {
     use super::*;
     use crate::metadata::HostMetadata;
     use crate::ssh::SshHost;
-    use crate::store::LauncherStore;
+    use crate::store::{HostUpdate, LauncherStore, NewHost, NewHostGroup};
+
+    /// Build a `Legacy` host entry with the given name and tags.
+    fn legacy(name: &str, tags: &[&str]) -> HostEntry {
+        HostEntry::Legacy {
+            host: SshHost {
+                name: name.into(),
+                ..Default::default()
+            },
+            meta: HostMetadata {
+                host_name: name.into(),
+                tags: tags.iter().map(|s| s.to_string()).collect(),
+                ..Default::default()
+            },
+        }
+    }
 
     #[test]
     fn tag_and_filter() {
@@ -120,5 +135,171 @@ mod tests {
         let groups = store.list_groups().unwrap();
         let idx = filter_by_group_name(&hosts, &groups, "prod");
         assert_eq!(idx, vec![0]);
+    }
+
+    #[test]
+    fn tag_filter_empty_returns_all() {
+        let hosts = vec![legacy("a", &["web"]), legacy("b", &[])];
+        // No requested tags: every host passes, order preserved.
+        assert_eq!(filter_by_tags(&hosts, &[]), vec![0, 1]);
+    }
+
+    #[test]
+    fn tag_filter_single_matches_every_host_with_that_tag() {
+        let hosts = vec![
+            legacy("a", &["web", "prod"]),
+            legacy("b", &["db"]),
+            legacy("c", &["web"]),
+        ];
+        // A single requested tag returns all hosts carrying it.
+        assert_eq!(filter_by_tags(&hosts, &["web".into()]), vec![0, 2]);
+    }
+
+    #[test]
+    fn tag_filter_requires_all_tags_not_any() {
+        let hosts = vec![
+            // Has one of the two requested tags: must be excluded (AND, not OR).
+            legacy("a", &["web"]),
+            // Has both requested tags plus an extra: included.
+            legacy("b", &["web", "prod", "eu"]),
+            // Has neither: excluded.
+            legacy("c", &["db"]),
+        ];
+        let idx = filter_by_tags(&hosts, &["web".into(), "prod".into()]);
+        assert_eq!(idx, vec![1]);
+    }
+
+    #[test]
+    fn group_filter_is_exact_membership_not_subtree() {
+        let store = LauncherStore::open_in_memory().unwrap();
+        let parent = store
+            .create_group(&NewHostGroup {
+                name: "prod".into(),
+                sort_order: 0,
+                ..Default::default()
+            })
+            .unwrap();
+        let child = store
+            .create_group(&NewHostGroup {
+                name: "eu".into(),
+                sort_order: 1,
+                parent_id: Some(parent.id),
+                ..Default::default()
+            })
+            .unwrap();
+        // Host lives only in the child group.
+        let host = store
+            .create_host(&NewHost {
+                name: "e1".into(),
+                address: "10.0.0.1".into(),
+                group_id: Some(child.id),
+                ..Default::default()
+            })
+            .unwrap();
+        store.set_host_groups(host.id, &[child.id]).unwrap();
+        let hosts = vec![HostEntry::from_managed(
+            store.get_host(host.id).unwrap().unwrap(),
+        )];
+        let groups = store.list_groups().unwrap();
+
+        // Filtering by the child group name returns the host.
+        assert_eq!(filter_by_group_name(&hosts, &groups, "eu"), vec![0]);
+        // Filtering by the parent group name does NOT (no subtree matching).
+        assert!(filter_by_group_name(&hosts, &groups, "prod").is_empty());
+    }
+
+    #[test]
+    fn group_filter_unknown_name_returns_empty() {
+        let store = LauncherStore::open_in_memory().unwrap();
+        let hosts: Vec<HostEntry> = Vec::new();
+        let groups = store.list_groups().unwrap();
+        assert!(filter_by_group_name(&hosts, &groups, "nope").is_empty());
+    }
+
+    #[test]
+    fn sort_label_is_case_insensitive_alphabetical() {
+        let hosts = vec![
+            legacy("banana", &[]),
+            legacy("Apple", &[]),
+            legacy("cherry", &[]),
+        ];
+        let mut idx: Vec<usize> = (0..hosts.len()).collect();
+        sort_host_indices(&hosts, &mut idx, SortMode::Label);
+        // Apple, banana, cherry (case-folded).
+        assert_eq!(idx, vec![1, 0, 2]);
+    }
+
+    #[test]
+    fn sort_manual_puts_legacy_hosts_at_tail() {
+        let store = LauncherStore::open_in_memory().unwrap();
+        let host = store
+            .create_host(&NewHost::launcher("managed", "1.2.3.4"))
+            .unwrap();
+        // Give the managed host a small, finite sort_order.
+        store
+            .update_host(
+                host.id,
+                &HostUpdate {
+                    sort_order: Some(5),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let managed = HostEntry::from_managed(store.get_host(host.id).unwrap().unwrap());
+        assert_eq!(managed.sort_order(), 5);
+
+        // Index 0 is legacy (sort_order == i32::MAX), index 1 is managed.
+        let hosts = vec![legacy("zzz-legacy", &[]), managed];
+        let mut idx: Vec<usize> = (0..hosts.len()).collect();
+        sort_host_indices(&hosts, &mut idx, SortMode::Manual);
+        // Managed (finite order) sorts ahead of the legacy host at i32::MAX.
+        assert_eq!(idx, vec![1, 0]);
+    }
+
+    #[test]
+    fn sort_group_uses_primary_group_order_not_label() {
+        let store = LauncherStore::open_in_memory().unwrap();
+        // "zeta" has a lower group sort_order than "alpha", so hosts in "zeta"
+        // must sort first even though "alpha" < "zeta" alphabetically.
+        let zeta = store
+            .create_group(&NewHostGroup {
+                name: "zeta".into(),
+                sort_order: 0,
+                ..Default::default()
+            })
+            .unwrap();
+        let alpha = store
+            .create_group(&NewHostGroup {
+                name: "alpha".into(),
+                sort_order: 1,
+                ..Default::default()
+            })
+            .unwrap();
+        let in_alpha = store
+            .create_host(&NewHost {
+                name: "a-host".into(),
+                address: "10.0.0.1".into(),
+                group_id: Some(alpha.id),
+                ..Default::default()
+            })
+            .unwrap();
+        let in_zeta = store
+            .create_host(&NewHost {
+                name: "z-host".into(),
+                address: "10.0.0.2".into(),
+                group_id: Some(zeta.id),
+                ..Default::default()
+            })
+            .unwrap();
+
+        // Index 0 is the alpha-group host, index 1 is the zeta-group host.
+        let hosts = vec![
+            HostEntry::from_managed(store.get_host(in_alpha.id).unwrap().unwrap()),
+            HostEntry::from_managed(store.get_host(in_zeta.id).unwrap().unwrap()),
+        ];
+        let mut idx: Vec<usize> = (0..hosts.len()).collect();
+        sort_host_indices(&hosts, &mut idx, SortMode::GroupThenLabel);
+        // zeta-group host (group sort_order 0) comes before alpha-group host.
+        assert_eq!(idx, vec![1, 0]);
     }
 }

--- a/src/cli/group.rs
+++ b/src/cli/group.rs
@@ -129,6 +129,11 @@ fn cmd_edit(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
     let group = ctx.group_by_name(&name)?;
 
     let set_name = take_opt(&mut rest, "--set-name");
+    if let Some(n) = &set_name {
+        if n.trim().is_empty() {
+            fail("group name cannot be empty");
+        }
+    }
     let set_sort = match take_opt(&mut rest, "--set-sort-order") {
         Some(s) => Some(
             s.parse::<i32>()

--- a/src/cli/group.rs
+++ b/src/cli/group.rs
@@ -1,0 +1,291 @@
+//! `sshub group …` — host group CRUD.
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::store::{HostGroup, HostGroupUpdate, LauncherStore, NewHostGroup};
+
+use super::context::{resolve_identity_id, resolve_parent_id, CliContext};
+use super::parse::{fail, parse_format, take_flag, take_opt, usage, OutputFormat, CONFIRM_YES};
+
+#[derive(Serialize)]
+struct GroupRecord<'a> {
+    id: i64,
+    name: &'a str,
+    sort_order: i32,
+    default_identity_id: Option<i64>,
+    parent_id: Option<i64>,
+    reserved: bool,
+}
+
+pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    match rest.first().map(String::as_str) {
+        Some("list") => {
+            rest.remove(0);
+            cmd_list(ctx, &rest)
+        }
+        Some("show") => {
+            rest.remove(0);
+            cmd_show(ctx, &rest)
+        }
+        Some("add") => {
+            rest.remove(0);
+            cmd_add(ctx, &rest)
+        }
+        Some("edit") => {
+            rest.remove(0);
+            cmd_edit(ctx, &rest)
+        }
+        Some("delete") => {
+            rest.remove(0);
+            cmd_delete(ctx, &rest)
+        }
+        Some(other) => {
+            eprintln!("sshub: unknown group subcommand '{other}'");
+            eprintln!("       try: sshub group list|show|add|edit|delete");
+            Ok(2)
+        }
+        None => {
+            usage("group needs a subcommand (list|show|add|edit|delete)");
+        }
+    }
+}
+
+fn cmd_list(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let fmt = parse_format(args).map_err(anyhow::Error::msg)?;
+    let include_all = args.iter().any(|a| a == "--all");
+    let groups: Vec<HostGroup> = ctx
+        .store
+        .list_groups()?
+        .into_iter()
+        .filter(|g| include_all || !g.reserved)
+        .collect();
+
+    match fmt {
+        OutputFormat::Plain => {
+            for g in &groups {
+                let marker = if g.reserved { " (reserved)" } else { "" };
+                println!("{:<6} {}{}", g.id, g.name, marker);
+            }
+        }
+        OutputFormat::Json => {
+            let records: Vec<GroupRecord<'_>> = groups.iter().map(group_record).collect();
+            println!("{}", serde_json::to_string(&records)?);
+        }
+    }
+    Ok(0)
+}
+
+fn cmd_show(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let fmt = parse_format(args).map_err(anyhow::Error::msg)?;
+    let name = group_name_arg(args);
+    let group = ctx.group_by_name(&name)?;
+
+    match fmt {
+        OutputFormat::Plain => print_group_plain(&group, ctx.store.as_ref())?,
+        OutputFormat::Json => {
+            let record = group_record(&group);
+            println!("{}", serde_json::to_string(&record)?);
+        }
+    }
+    Ok(0)
+}
+
+fn cmd_add(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let name = take_opt(&mut rest, "--name").unwrap_or_else(|| usage("group add requires --name"));
+    if name.trim().is_empty() {
+        fail("group name cannot be empty");
+    }
+
+    let parent_id = take_opt(&mut rest, "--parent")
+        .map(|p| resolve_parent_id(ctx, &p))
+        .transpose()?;
+    let default_identity_id = take_opt(&mut rest, "--default-identity")
+        .map(|n| resolve_identity_id(ctx, &n))
+        .transpose()?;
+    let sort_order = match take_opt(&mut rest, "--sort-order") {
+        Some(s) => s
+            .parse::<i32>()
+            .map_err(|_| anyhow::anyhow!("invalid sort order '{s}'"))?,
+        None => ctx.store.list_groups()?.len() as i32,
+    };
+
+    ctx.store.create_group(&NewHostGroup {
+        name: name.trim().to_string(),
+        sort_order,
+        default_identity_id,
+        parent_id,
+    })?;
+    ctx.reload_hosts()?;
+    println!("created group '{}'", name.trim());
+    Ok(0)
+}
+
+fn cmd_edit(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let name = take_opt(&mut rest, "--name").unwrap_or_else(|| usage("group edit requires --name"));
+    let group = ctx.group_by_name(&name)?;
+
+    let set_name = take_opt(&mut rest, "--set-name");
+    let set_sort = match take_opt(&mut rest, "--set-sort-order") {
+        Some(s) => Some(
+            s.parse::<i32>()
+                .map_err(|_| anyhow::anyhow!("invalid sort order '{s}'"))?,
+        ),
+        None => None,
+    };
+
+    let mut parent_id: Option<Option<i64>> = None;
+    if take_flag(&mut rest, "--clear-parent") {
+        parent_id = Some(None);
+    } else if let Some(p) = take_opt(&mut rest, "--set-parent") {
+        parent_id = Some(Some(resolve_parent_id(ctx, &p)?));
+    }
+
+    let mut default_identity_id: Option<Option<i64>> = None;
+    if take_flag(&mut rest, "--clear-default-identity") {
+        default_identity_id = Some(None);
+    } else if let Some(id_name) = take_opt(&mut rest, "--set-default-identity") {
+        default_identity_id = Some(Some(resolve_identity_id(ctx, &id_name)?));
+    }
+
+    if group.reserved && set_name.is_some() {
+        eprintln!("sshub: reserved group '{}' cannot be renamed", group.name);
+        return Ok(1);
+    }
+
+    let updated = ctx.store.update_group(
+        group.id,
+        &HostGroupUpdate {
+            name: set_name,
+            sort_order: set_sort,
+            default_identity_id,
+            parent_id,
+        },
+    )?;
+    if updated.is_none() {
+        fail(&format!("group '{name}' not found"));
+    }
+    ctx.reload_hosts()?;
+    println!("updated group '{name}'");
+    Ok(0)
+}
+
+fn cmd_delete(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let name =
+        take_opt(&mut rest, "--name").unwrap_or_else(|| usage("group delete requires --name"));
+    if !take_flag(&mut rest, CONFIRM_YES) {
+        fail(&format!(
+            "refusing to delete group '{name}' without {CONFIRM_YES}"
+        ));
+    }
+
+    let group = ctx.group_by_name(&name)?;
+    if group.reserved {
+        eprintln!("sshub: reserved group '{}' cannot be deleted", group.name);
+        return Ok(1);
+    }
+
+    if !ctx.store.delete_group(group.id)? {
+        fail(&format!("group '{name}' not found"));
+    }
+    ctx.reload_hosts()?;
+    println!("deleted group '{name}'");
+    Ok(0)
+}
+
+fn group_name_arg(args: &[String]) -> String {
+    let mut rest = args.to_vec();
+    if let Some(n) = take_opt(&mut rest, "--name") {
+        return n;
+    }
+    match super::parse::positional(args).first() {
+        Some(n) => (*n).to_string(),
+        None => usage("group show requires a group name"),
+    }
+}
+
+fn group_record(g: &HostGroup) -> GroupRecord<'_> {
+    GroupRecord {
+        id: g.id,
+        name: &g.name,
+        sort_order: g.sort_order,
+        default_identity_id: g.default_identity_id,
+        parent_id: g.parent_id,
+        reserved: g.reserved,
+    }
+}
+
+fn print_group_plain(group: &HostGroup, store: &LauncherStore) -> Result<()> {
+    println!("id:                 {}", group.id);
+    println!("name:               {}", group.name);
+    println!("sort_order:         {}", group.sort_order);
+    println!("reserved:           {}", group.reserved);
+    if let Some(pid) = group.parent_id {
+        let parent = store
+            .get_group(pid)?
+            .map(|g| g.name)
+            .unwrap_or_else(|| "?".into());
+        println!("parent:             {parent} ({pid})");
+    } else {
+        println!("parent:             (top level)");
+    }
+    if let Some(iid) = group.default_identity_id {
+        let ident = store
+            .get_identity(iid)?
+            .map(|i| i.name)
+            .unwrap_or_else(|| "?".into());
+        println!("default_identity:   {ident} ({iid})");
+    } else {
+        println!("default_identity:   (none)");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::store::LauncherStore;
+
+    #[test]
+    fn list_hides_favorites_by_default() {
+        let store = Arc::new(LauncherStore::open_in_memory().unwrap());
+        store
+            .create_group(&NewHostGroup {
+                name: "prod".into(),
+                ..Default::default()
+            })
+            .unwrap();
+        let fav_id = store.favorites_group_id().unwrap();
+        let ctx = test_ctx(store);
+        let code = cmd_list(&ctx, &[]).unwrap();
+        assert_eq!(code, 0);
+        let names: Vec<String> = ctx
+            .store
+            .list_groups()
+            .unwrap()
+            .into_iter()
+            .filter(|g| !g.reserved)
+            .map(|g| g.name)
+            .collect();
+        assert!(names.contains(&"prod".to_string()));
+        assert!(!names.iter().any(|n| n == "Favorites"));
+        let _ = fav_id;
+    }
+
+    fn test_ctx(store: Arc<LauncherStore>) -> CliContext {
+        CliContext {
+            config: crate::config::AppConfig::default(),
+            store,
+            metadata: Arc::new(crate::metadata::MetadataDb::default()),
+            resolver: crate::ssh::SshConfigResolver::default(),
+            password_store: Box::new(crate::credentials::OsKeyring),
+            hosts: Vec::new(),
+        }
+    }
+}

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,0 +1,169 @@
+//! Per-command help text. `sshub <cmd> --help` prints a USAGE block scoped to
+//! just that command instead of falling through to the global `sshub --help`.
+//!
+//! Wording mirrors `main.rs::print_help`, narrowed to one top-level command.
+
+/// Print a short USAGE block for `cmd`. Handles the same set of commands and
+/// aliases that `is_subcommand` accepts. Unrecognized commands get a one-line
+/// pointer back to the global help.
+pub fn print_command_help(cmd: &str) {
+    match cmd {
+        "host" => print_host(),
+        "connect" => print_connect(),
+        "list" => print_list(),
+        "groups" => print_groups(),
+        "group" => print_group(),
+        "identity" => print_identity(),
+        "tunnel" => print_tunnel(),
+        "sftp" => print_sftp(),
+        "audit" => print_audit(),
+        "tags" => print_tags(),
+        "sync" => print_sync(),
+        "import" => print_import(),
+        "export" => print_export(),
+        "completions" => print_completions(),
+        other => {
+            println!(
+                "sshub: no per-command help for '{other}'; run `sshub --help` for the command list"
+            );
+        }
+    }
+}
+
+fn print_host() {
+    println!(
+        r#"sshub host - manage launcher hosts (read/write)
+
+USAGE:
+    sshub host list [--tag TAG]... [--group GROUP] [--sort MODE] [--format plain|json]
+    sshub host show <name> [--format plain|json]
+    sshub host connect <name> [-v|--verbose]
+    sshub host resolve <name> [--format plain|json]
+    sshub host search <query> [--format plain|json]
+    sshub host add|edit|rename|delete|duplicate ..."#
+    );
+}
+
+fn print_connect() {
+    println!(
+        r#"sshub connect - open an SSH session to a host (alias for `host connect`)
+
+USAGE:
+    sshub connect <name> [-v|--verbose]"#
+    );
+}
+
+fn print_list() {
+    println!(
+        r#"sshub list - list launcher hosts (alias for `host list`)
+
+USAGE:
+    sshub list [--tag TAG]... [--group GROUP] [--sort MODE] [--format plain|json]"#
+    );
+}
+
+fn print_groups() {
+    println!(
+        r#"sshub groups - list host groups (alias for `group list`, forwards flags)
+
+USAGE:
+    sshub groups [--all] [--format plain|json]"#
+    );
+}
+
+fn print_group() {
+    println!(
+        r#"sshub group - manage host groups
+
+USAGE:
+    sshub group list [--all] [--format plain|json]
+    sshub group show <name> [--format plain|json]
+    sshub group add --name NAME [--parent GROUP] [--default-identity NAME] [--sort-order N]
+    sshub group edit --name NAME [--set-name ...] [--set-parent ...] [--clear-parent]
+                     [--set-default-identity ...] [--clear-default-identity] [--set-sort-order N]
+    sshub group delete --name NAME --yes"#
+    );
+}
+
+fn print_identity() {
+    println!(
+        r#"sshub identity - manage SSH identities
+
+USAGE:
+    sshub identity list|show|add|edit|delete|agent-remove ...
+    sshub identity agent-remove --name NAME"#
+    );
+}
+
+fn print_tunnel() {
+    println!(
+        r#"sshub tunnel - manage SSH tunnels
+
+USAGE:
+    sshub tunnel list|show|create|delete|start|stop ..."#
+    );
+}
+
+fn print_sftp() {
+    println!(
+        r#"sshub sftp - one-shot SFTP file operations
+
+USAGE:
+    sshub sftp ls|get|put|rm|mkdir|rename|chmod ..."#
+    );
+}
+
+fn print_audit() {
+    println!(
+        r#"sshub audit - inspect the connection audit log
+
+USAGE:
+    sshub audit list [--status STATUS] [--via VIA] [--host HOST] [--limit N] [--days N] [--format plain|json]
+    sshub audit stats [--days N] [--via VIA] [--include-retry] [--format plain|json]"#
+    );
+}
+
+fn print_tags() {
+    println!(
+        r#"sshub tags - list all tags in the inventory
+
+USAGE:
+    sshub tags [--format plain|json]"#
+    );
+}
+
+fn print_sync() {
+    println!(
+        r#"sshub sync - refresh ssh_config rows in the database
+
+USAGE:
+    sshub sync"#
+    );
+}
+
+fn print_import() {
+    println!(
+        r#"sshub import - import hosts from ~/.ssh/config
+
+USAGE:
+    sshub import"#
+    );
+}
+
+fn print_export() {
+    println!(
+        r#"sshub export - export launcher hosts to an ssh_config snippet
+
+USAGE:
+    sshub export [--stdout] [-o PATH]"#
+    );
+}
+
+fn print_completions() {
+    println!(
+        r#"sshub completions - generate shell completion scripts
+
+USAGE:
+    sshub completions bash|zsh|fish [--cache PATH]"#
+    );
+}

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -35,12 +35,20 @@ fn print_host() {
         r#"sshub host - manage launcher hosts (read/write)
 
 USAGE:
-    sshub host list [--tag TAG]... [--group GROUP] [--sort MODE] [--format plain|json]
-    sshub host show <name> [--format plain|json]
+    sshub host list    [--tag TAG]... [--group GROUP] [--sort MODE] [--format plain|json]
+    sshub host show    <name> [--format plain|json]
     sshub host connect <name> [-v|--verbose]
     sshub host resolve <name> [--format plain|json]
-    sshub host search <query> [--format plain|json]
-    sshub host add|edit|rename|delete|duplicate ..."#
+    sshub host search  <query> [--format plain|json]
+    sshub host add     --name NAME --address ADDR [--port N] [--username U] [--identity NAME]
+                       [--group NAME] [--tag TAG]... [--proxy-jump SPEC] [--transport ssh|mosh] ...
+    sshub host edit    --name NAME [--set-FIELD ... | --clear-FIELD ...]
+    sshub host rename  --name NAME --new-name NEW [--strict]
+    sshub host delete  --name NAME --yes
+    sshub host duplicate <name>
+
+--sort MODE: label|last-connected|favorite|group|manual. Run `man sshub` for the
+full add/edit flag list."#
     );
 }
 
@@ -90,7 +98,15 @@ fn print_identity() {
         r#"sshub identity - manage SSH identities
 
 USAGE:
-    sshub identity list|show|add|edit|delete|agent-remove ...
+    sshub identity list                  [--format plain|json]
+    sshub identity show   <name>         [--format plain|json]
+    sshub identity add    --name NAME [--username U] [--private-key PATH]
+                          [--certificate PATH] [--password-stdin]
+    sshub identity edit   --name NAME [--set-name ...] [--set-username ...] [--clear-username]
+                          [--set-private-key ...] [--clear-private-key]
+                          [--set-certificate ...] [--clear-certificate]
+                          [--password-stdin] [--clear-password]
+    sshub identity delete --name NAME --yes
     sshub identity agent-remove --name NAME"#
     );
 }
@@ -100,16 +116,34 @@ fn print_tunnel() {
         r#"sshub tunnel - manage SSH tunnels
 
 USAGE:
-    sshub tunnel list|show|create|delete|start|stop ..."#
+    sshub tunnel list                [--format plain|json]
+    sshub tunnel show   <id>         [--format plain|json]
+    sshub tunnel create --host NAME --type local|remote|dynamic --local-port P
+                        [--remote-host H] [--remote-port P] [--label L] [--keep-alive]
+    sshub tunnel start  <id>         [--foreground]
+    sshub tunnel stop   <id>
+    sshub tunnel delete <id> --yes
+
+<id> accepts a tunnel id, label, or local port. Detached tunnels record a PID
+file and are not visible to the TUI tunnel manager (and vice versa)."#
     );
 }
 
 fn print_sftp() {
     println!(
-        r#"sshub sftp - one-shot SFTP file operations
+        r#"sshub sftp - one-shot SFTP file operations (direct hosts only; ProxyJump unsupported)
 
 USAGE:
-    sshub sftp ls|get|put|rm|mkdir|rename|chmod ..."#
+    sshub sftp ls     <host> [remote-path] [--format plain|json]
+    sshub sftp get    <host> <remote-path> [local-path] [--recursive]
+    sshub sftp put    <host> <local-path> [remote-path] [--recursive]
+    sshub sftp rm     <host> <remote-path> [--recursive] --yes
+    sshub sftp mkdir  <host> <remote-path>
+    sshub sftp rename <host> <from> <to>
+    sshub sftp chmod  <host> <octal-mode> <remote-path>
+
+<host> is a saved host name. rm is destructive and requires --yes; --recursive
+descends into directories."#
     );
 }
 
@@ -118,8 +152,10 @@ fn print_audit() {
         r#"sshub audit - inspect the connection audit log
 
 USAGE:
-    sshub audit list [--status STATUS] [--via VIA] [--host HOST] [--limit N] [--days N] [--format plain|json]
-    sshub audit stats [--days N] [--via VIA] [--include-retry] [--format plain|json]"#
+    sshub audit list  [--status all|ok|fail|retry] [--via all|connect|tunnel|agent]
+                      [--host NAME] [--limit N] [--days N] [--format plain|json]
+    sshub audit stats [--days N] [--via all|connect|tunnel|agent] [--include-retry]
+                      [--format plain|json]"#
     );
 }
 

--- a/src/cli/host.rs
+++ b/src/cli/host.rs
@@ -275,10 +275,7 @@ fn cmd_add(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
     let spec = HostAddSpec::parse(args)?;
     let unique_name = ctx.store.unique_host_name(&spec.name, None)?;
     if unique_name != spec.name {
-        eprintln!(
-            "sshub: name '{}' taken — using '{}'",
-            spec.name, unique_name
-        );
+        eprintln!("sshub: name '{}' taken, using '{}'", spec.name, unique_name);
     }
 
     let identity_id = spec
@@ -446,7 +443,7 @@ fn cmd_edit(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
     if let Some(ref new_name) = patch.set_name {
         let unique = ctx.store.unique_host_name(new_name, Some(managed.id))?;
         if unique != *new_name {
-            eprintln!("sshub: name taken — using '{unique}'");
+            eprintln!("sshub: name taken, using '{unique}'");
             update.name = Some(unique);
         } else {
             update.name = Some(unique);

--- a/src/cli/host.rs
+++ b/src/cli/host.rs
@@ -206,14 +206,22 @@ fn cmd_connect(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
         }
     }
 
-    let username = entry.managed().and_then(|m| {
-        m.username
-            .as_deref()
-            .or_else(|| m.identity.as_ref().and_then(|i| i.username.as_deref()))
-    });
+    // For legacy ssh_config hosts entry.managed() is None, so fall back to the
+    // resolved SshHost (User / ProxyJump from ~/.ssh/config) rather than logging
+    // username=None and via=direct.
+    let ssh = entry.ssh_host();
+    let username = entry
+        .managed()
+        .and_then(|m| {
+            m.username
+                .as_deref()
+                .or_else(|| m.identity.as_ref().and_then(|i| i.username.as_deref()))
+        })
+        .or(ssh.user.as_deref());
     let via = entry
         .managed()
         .and_then(|m| m.proxy_jump.as_deref())
+        .or(ssh.proxy_jump.as_deref())
         .unwrap_or("direct");
 
     let program = argv.first().context("empty connect argv")?;
@@ -961,6 +969,7 @@ impl HostEditPatch {
             || self.set_identity.is_some()
             || self.clear_identity
             || self.set_label.is_some()
+            || self.touches_managed_fields()
     }
 
     fn metadata_only(&self) -> bool {
@@ -971,6 +980,18 @@ impl HostEditPatch {
             && self.password.is_none()
             && !self.clear_password
             && self.set_label.is_none()
+            && !self.touches_managed_fields()
+    }
+
+    /// Managed-row fields that `apply_metadata_edit` does not handle, so an edit
+    /// touching them must route through the full-edit path (and materialize a
+    /// legacy host first). Kept out of `changes_connection_fields` so they do
+    /// not trip the ssh_config connection-field read-only guard.
+    fn touches_managed_fields(&self) -> bool {
+        self.set_username.is_some()
+            || self.clear_username
+            || self.set_os_icon.is_some()
+            || self.clear_os_icon
     }
 
     fn changes_connection_fields(&self) -> bool {
@@ -996,4 +1017,44 @@ fn read_password_stdin() -> Result<String> {
 fn host_usage(msg: &str) -> ! {
     eprintln!("sshub: {msg}");
     std::process::exit(2);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn patch(args: &[&str]) -> HostEditPatch {
+        let v: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        HostEditPatch::parse(&v).unwrap()
+    }
+
+    #[test]
+    fn username_only_edit_routes_through_full_path() {
+        // Regression: --set-username alone must NOT be treated as metadata-only
+        // (apply_metadata_edit drops it); it must route to the full-edit path
+        // and materialize a legacy host first.
+        let p = patch(&["--name", "h", "--set-username", "bob"]);
+        assert!(!p.metadata_only());
+        assert!(p.needs_materialize());
+    }
+
+    #[test]
+    fn os_icon_only_edit_routes_through_full_path() {
+        let p = patch(&["--name", "h", "--set-os-icon", "linux"]);
+        assert!(!p.metadata_only());
+        assert!(p.needs_materialize());
+    }
+
+    #[test]
+    fn clear_username_only_edit_routes_through_full_path() {
+        let p = patch(&["--name", "h", "--clear-username"]);
+        assert!(!p.metadata_only());
+        assert!(p.needs_materialize());
+    }
+
+    #[test]
+    fn tags_only_edit_stays_metadata_only() {
+        let p = patch(&["--name", "h", "--set-tags", "a,b"]);
+        assert!(p.metadata_only());
+    }
 }

--- a/src/cli/host.rs
+++ b/src/cli/host.rs
@@ -155,11 +155,14 @@ fn cmd_connect(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
     );
 
     if let Some(cmd) = argv.first() {
+        // Best-effort pre-flight. If `which` itself cannot run (missing from
+        // PATH), fail open (unwrap_or(false)) rather than blocking a valid ssh:
+        // a genuinely missing program is still caught by the spawn error below.
         if Command::new("which")
             .arg(cmd)
             .output()
             .map(|o| !o.status.success())
-            .unwrap_or(true)
+            .unwrap_or(false)
         {
             eprintln!("sshub: command not found: '{cmd}'");
             return Ok(1);

--- a/src/cli/host.rs
+++ b/src/cli/host.rs
@@ -1,0 +1,1002 @@
+//! `sshub host` subcommand dispatch.
+
+use std::io::{self, Read};
+use std::process::{Command, Stdio};
+
+use anyhow::{bail, Context, Result};
+
+use crate::app::{
+    optional_field, parse_tags, prepare_cli_connect_argv, resolve_pending_secret,
+    session_argv_for_entry, SortMode,
+};
+use crate::cli::context::CliContext;
+use crate::cli::filter::apply_filters;
+use crate::cli::output::{
+    format_host_list_plain, format_host_plain, format_resolve_plain, host_record_json,
+    host_resolve_json, now_ts, parse_session_logging, parse_transport,
+};
+use crate::cli::parse::{self, OutputFormat};
+use crate::hosts::duplicate_legacy_to_launcher;
+use crate::metadata::{HostMetadata, MetadataStore};
+use crate::search::HostSearch;
+use crate::session::askpass::AskpassSecret;
+use crate::session_log::{allocate_log_path, effective_enabled, wrap_script_command};
+use crate::session_transport::SessionTransport;
+use crate::ssh::materialize_ssh_config_host;
+use crate::store::{DeleteHostOutcome, HostSource, HostUpdate, NewHost};
+
+pub fn run_host(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let Some(sub) = args.first().map(String::as_str) else {
+        host_usage("missing host subcommand");
+    };
+    let rest = &args[1..];
+    match sub {
+        "list" => cmd_list(ctx, rest),
+        "show" => cmd_show(ctx, rest),
+        "resolve" => cmd_resolve(ctx, rest),
+        "search" => cmd_search(ctx, rest),
+        "connect" => cmd_connect(ctx, rest),
+        "add" => cmd_add(ctx, rest),
+        "edit" => cmd_edit(ctx, rest),
+        "rename" => cmd_rename(ctx, rest),
+        "delete" => cmd_delete(ctx, rest),
+        "duplicate" => cmd_duplicate(ctx, rest),
+        other => {
+            eprintln!("sshub: unknown host subcommand '{other}'");
+            host_usage(
+                "try: list, show, connect, resolve, search, add, edit, rename, delete, duplicate",
+            );
+        }
+    }
+}
+
+fn cmd_list(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let mut args = args.to_vec();
+    let tags = parse::take_all(&mut args, "--tag");
+    let group = parse::take_opt(&mut args, "--group");
+    let sort = parse::parse_sort(args.as_slice())
+        .map_err(anyhow::Error::msg)?
+        .unwrap_or(SortMode::Label);
+    let fmt = parse::parse_format(args.as_slice()).map_err(anyhow::Error::msg)?;
+
+    let indices = apply_filters(&ctx.hosts, &ctx.store, &tags, group.as_deref(), sort)?;
+
+    match fmt {
+        OutputFormat::Json => {
+            let records: Vec<_> = indices
+                .iter()
+                .map(|&i| host_record_json(&ctx.hosts[i], &ctx.store))
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&records)?);
+        }
+        OutputFormat::Plain => {
+            let names: Vec<&str> = indices.iter().map(|&i| ctx.hosts[i].name()).collect();
+            if !names.is_empty() {
+                println!("{}", format_host_list_plain(&names));
+            }
+        }
+    }
+    Ok(0)
+}
+
+fn cmd_show(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let fmt = parse::parse_format(args).map_err(anyhow::Error::msg)?;
+    let pos = parse::positional(args);
+    let Some(name) = pos.first() else {
+        host_usage("show requires <name>");
+    };
+    let entry = ctx.host_by_name(name)?;
+    let record = host_record_json(entry, &ctx.store);
+    match fmt {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&record)?),
+        OutputFormat::Plain => println!("{}", format_host_plain(&record)),
+    }
+    Ok(0)
+}
+
+fn cmd_resolve(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let mut args = args.to_vec();
+    let verbose = parse::take_flag(&mut args, "--verbose") || parse::take_flag(&mut args, "-v");
+    let fmt = parse::parse_format(&args).map_err(anyhow::Error::msg)?;
+    let pos = parse::positional(&args);
+    let Some(name) = pos.first() else {
+        host_usage("resolve requires <name>");
+    };
+    let entry = ctx.host_by_name(name)?;
+    let resolve = host_resolve_json(entry, &ctx.store, ctx.password_store.as_ref(), verbose);
+    match fmt {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&resolve)?),
+        OutputFormat::Plain => println!("{}", format_resolve_plain(&resolve)),
+    }
+    Ok(0)
+}
+
+fn cmd_search(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let fmt = parse::parse_format(args).map_err(anyhow::Error::msg)?;
+    let pos = parse::positional(args);
+    let Some(query) = pos.first() else {
+        host_usage("search requires <query>");
+    };
+    let mut search = HostSearch::new();
+    let indices = search.update_query(&ctx.hosts, query);
+    match fmt {
+        OutputFormat::Json => {
+            let records: Vec<_> = indices
+                .iter()
+                .map(|&i| host_record_json(&ctx.hosts[i], &ctx.store))
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&records)?);
+        }
+        OutputFormat::Plain => {
+            let names: Vec<&str> = indices.iter().map(|&i| ctx.hosts[i].name()).collect();
+            if !names.is_empty() {
+                println!("{}", format_host_list_plain(&names));
+            }
+        }
+    }
+    Ok(0)
+}
+
+fn cmd_connect(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let mut args = args.to_vec();
+    let verbose = parse::take_flag(&mut args, "--verbose") || parse::take_flag(&mut args, "-v");
+    let pos = parse::positional(&args);
+    let Some(name) = pos.first() else {
+        host_usage("connect requires <name>");
+    };
+
+    let entry = ctx.host_by_name(name)?.clone();
+    let host_name = entry.name().to_string();
+    let (pending_secret, _) = resolve_pending_secret(&entry, ctx.password_store.as_ref());
+    let mut argv = prepare_cli_connect_argv(
+        session_argv_for_entry(&entry),
+        pending_secret.is_some(),
+        verbose,
+    );
+
+    if let Some(cmd) = argv.first() {
+        if Command::new("which")
+            .arg(cmd)
+            .output()
+            .map(|o| !o.status.success())
+            .unwrap_or(true)
+        {
+            eprintln!("sshub: command not found: '{cmd}'");
+            return Ok(1);
+        }
+    }
+
+    let is_mosh = matches!(entry.session_transport(), SessionTransport::Mosh);
+    let log_enabled = effective_enabled(
+        ctx.config.session_logging.enabled,
+        entry.session_logging_override(),
+    );
+
+    let mut log_path: Option<String> = None;
+    if log_enabled && !is_mosh {
+        if let Ok(data_dir) = crate::config::data_dir() {
+            match allocate_log_path(&data_dir, &host_name, entry.managed_id()) {
+                Ok(path) => {
+                    if let Some(wrapped) = wrap_script_command(&path, &argv) {
+                        argv = wrapped;
+                        log_path = Some(path.parent().unwrap_or(&path).display().to_string());
+                    } else {
+                        eprintln!(
+                            "sshub: warning: session logging requested but script(1) unavailable; continuing without transcript"
+                        );
+                    }
+                }
+                Err(e) => {
+                    eprintln!("sshub: warning: session logging unavailable: {e:#}");
+                }
+            }
+        }
+    } else if log_enabled && is_mosh {
+        eprintln!("sshub: warning: session logging skipped for mosh transport");
+    }
+
+    let mut askpass_guard = None;
+    let mut extra_env: Vec<(String, String)> = Vec::new();
+    if let Some(secret) = pending_secret.as_ref() {
+        if let Ok(exe) = std::env::current_exe() {
+            if let Ok(guard) = AskpassSecret::new(secret.value()) {
+                extra_env = guard.env(&exe);
+                askpass_guard = Some(guard);
+            }
+        }
+    }
+
+    let username = entry.managed().and_then(|m| {
+        m.username
+            .as_deref()
+            .or_else(|| m.identity.as_ref().and_then(|i| i.username.as_deref()))
+    });
+    let via = entry
+        .managed()
+        .and_then(|m| m.proxy_jump.as_deref())
+        .unwrap_or("direct");
+
+    let program = argv.first().context("empty connect argv")?;
+    let mut cmd = Command::new(program);
+    cmd.args(&argv[1..]);
+    cmd.stdin(Stdio::inherit());
+    cmd.stdout(Stdio::inherit());
+    cmd.stderr(Stdio::inherit());
+    for (k, v) in &extra_env {
+        cmd.env(k, v);
+    }
+
+    let mut child = match cmd.spawn() {
+        Ok(child) => {
+            let _ = ctx.store.log_auth_event(
+                &host_name,
+                username,
+                via,
+                "launched",
+                "cli connect",
+                log_path.as_deref(),
+            );
+            child
+        }
+        Err(e) => {
+            let msg = format!("spawn failed: {e:#}");
+            let _ = ctx
+                .store
+                .log_auth_event(&host_name, username, via, "fail", &msg, None);
+            eprintln!("sshub: {msg}");
+            return Ok(1);
+        }
+    };
+
+    let status = child.wait().context("wait connect child")?;
+    let timestamp = now_ts();
+
+    if let Some(id) = entry.managed_id() {
+        ctx.store.set_host_last_connected(id, timestamp)?;
+        if let Some(idx) = ctx.hosts.iter().position(|e| e.managed_id() == Some(id)) {
+            if let crate::app::HostEntry::Managed(m) = &mut ctx.hosts[idx] {
+                m.last_connected = Some(timestamp);
+            }
+        }
+    } else {
+        ctx.metadata.set_last_connected(entry.name(), timestamp)?;
+        if let Some(idx) = ctx.hosts.iter().position(|e| e.name() == entry.name()) {
+            if let Some((_, meta)) = ctx.hosts[idx].legacy_mut() {
+                meta.last_connected = Some(timestamp);
+            }
+        }
+    }
+
+    drop(askpass_guard);
+    Ok(status.code().unwrap_or(1))
+}
+
+fn cmd_add(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let spec = HostAddSpec::parse(args)?;
+    let unique_name = ctx.store.unique_host_name(&spec.name, None)?;
+    if unique_name != spec.name {
+        eprintln!(
+            "sshub: name '{}' taken — using '{}'",
+            spec.name, unique_name
+        );
+    }
+
+    let identity_id = spec
+        .identity
+        .as_deref()
+        .map(|n| ctx.identity_by_name(n))
+        .transpose()?
+        .map(|i| i.id);
+
+    let group_ids = resolve_group_ids(ctx, &spec.groups)?;
+
+    let created = ctx.store.create_host(&NewHost {
+        name: unique_name.clone(),
+        label: spec.label,
+        address: spec.address,
+        port: spec.port,
+        group_id: group_ids.first().copied(),
+        identity_id,
+        os_icon: spec.os_icon,
+        tags: spec.tags,
+        notes: spec.notes,
+        proxy_jump: spec.proxy_jump,
+        forward_agent: spec.forward_agent,
+        remote_command: spec.remote_command,
+        source: HostSource::Launcher,
+        has_password: spec.password.is_some(),
+        username: spec.username,
+        session_logging: spec.session_logging,
+        transport: spec.transport,
+    })?;
+
+    ctx.store.set_host_groups(created.id, &group_ids)?;
+
+    if let Some(pw) = spec.password {
+        if let Err(e) = ctx
+            .password_store
+            .set(&crate::credentials::host_key(created.id), &pw)
+        {
+            eprintln!("sshub: warning: storing password failed: {e:#}");
+        }
+    }
+
+    if spec.favorite {
+        let fav_id = ctx.store.favorites_group_id()?;
+        ctx.store.add_host_to_group(created.id, fav_id)?;
+    }
+
+    ctx.reload_hosts()?;
+    println!("{}", created.name);
+    Ok(0)
+}
+
+fn cmd_edit(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let patch = HostEditPatch::parse(args)?;
+    let name = patch.name.clone();
+
+    let needs_materialize = patch.needs_materialize();
+    let metadata_only = patch.metadata_only();
+
+    if needs_materialize && ctx.host_by_name(&name)?.managed().is_none() {
+        let materialized =
+            materialize_ssh_config_host(&ctx.resolver, &ctx.store, ctx.metadata.as_ref(), &name)?;
+        if !materialized {
+            bail!("host '{name}' could not be materialized");
+        }
+        ctx.reload_hosts()?;
+    }
+
+    let entry = ctx.host_by_name(&name)?.clone();
+
+    if metadata_only {
+        return apply_metadata_edit(ctx, &entry, &patch);
+    }
+
+    let managed = entry
+        .managed()
+        .ok_or_else(|| anyhow::anyhow!("host '{name}' has no managed row for connection edits"))?
+        .clone();
+
+    if managed.source == HostSource::SshConfig && patch.changes_connection_fields() {
+        bail!("connection fields are read-only for ssh_config hosts");
+    }
+
+    let mut update = HostUpdate::default();
+
+    if let Some(v) = patch.set_label {
+        update.label = Some(v);
+    }
+    if let Some(ref v) = patch.set_name {
+        update.name = Some(v.clone());
+    }
+    if let Some(v) = patch.set_address {
+        update.address = Some(v);
+    }
+    if let Some(v) = patch.set_port {
+        update.port = Some(v);
+    }
+    if let Some(v) = patch.set_username {
+        update.username = Some(v);
+    }
+    if patch.clear_username {
+        update.username = Some(None);
+    }
+    if let Some(v) = patch.set_tags {
+        update.tags = Some(v);
+    }
+    if let Some(v) = patch.set_notes {
+        update.notes = Some(v);
+    }
+    if patch.clear_notes {
+        update.notes = Some(None);
+    }
+    if let Some(v) = patch.set_environment {
+        update.environment = Some(v);
+    }
+    if patch.clear_environment {
+        update.environment = Some(None);
+    }
+    if let Some(v) = patch.set_proxy_jump {
+        update.proxy_jump = Some(v);
+    }
+    if patch.clear_proxy_jump {
+        update.proxy_jump = Some(None);
+    }
+    if let Some(v) = patch.set_remote_command {
+        update.remote_command = Some(v);
+    }
+    if patch.clear_remote_command {
+        update.remote_command = Some(None);
+    }
+    if let Some(v) = patch.set_forward_agent {
+        update.forward_agent = Some(v);
+    }
+    if let Some(v) = patch.set_os_icon {
+        update.os_icon = Some(v);
+    }
+    if patch.clear_os_icon {
+        update.os_icon = Some(None);
+    }
+    if let Some(v) = patch.set_session_logging {
+        update.session_logging = Some(v);
+    }
+    if let Some(v) = patch.set_transport {
+        update.transport = Some(v);
+    }
+    if let Some(v) = patch.favorite {
+        update.favorite = Some(v);
+    }
+    if let Some(v) = patch.set_identity {
+        let identity = ctx.identity_by_name(&v)?;
+        update.identity_id = Some(Some(identity.id));
+    }
+    if patch.clear_identity {
+        update.identity_id = Some(None);
+    }
+    if let Some(v) = patch.set_has_password {
+        update.has_password = Some(v);
+    }
+
+    let saved_name = patch
+        .set_name
+        .clone()
+        .unwrap_or_else(|| managed.name.clone());
+
+    if let Some(ref new_name) = patch.set_name {
+        let unique = ctx.store.unique_host_name(new_name, Some(managed.id))?;
+        if unique != *new_name {
+            eprintln!("sshub: name taken — using '{unique}'");
+            update.name = Some(unique);
+        } else {
+            update.name = Some(unique);
+        }
+    }
+
+    ctx.store.update_host(managed.id, &update)?;
+
+    if let Some(groups) = patch.set_groups {
+        let group_ids = resolve_group_ids(ctx, &groups)?;
+        ctx.store.set_host_groups(managed.id, &group_ids)?;
+    }
+
+    if let Some(pw) = patch.password {
+        if let Err(e) = ctx
+            .password_store
+            .set(&crate::credentials::host_key(managed.id), &pw)
+        {
+            eprintln!("sshub: warning: storing password failed: {e:#}");
+        }
+    } else if patch.clear_password {
+        let _ = ctx
+            .password_store
+            .delete(&crate::credentials::host_key(managed.id));
+    }
+
+    ctx.reload_hosts()?;
+    let out_name = update.name.as_deref().unwrap_or(saved_name.as_str());
+    println!("{out_name}");
+    Ok(0)
+}
+
+fn apply_metadata_edit(
+    ctx: &mut CliContext,
+    entry: &crate::app::HostEntry,
+    patch: &HostEditPatch,
+) -> Result<i32> {
+    let host_name = entry.name().to_string();
+
+    if let Some(managed) = entry.managed() {
+        let id = managed.id;
+        let mut update = HostUpdate::default();
+        if let Some(v) = patch.set_tags.clone() {
+            update.tags = Some(v);
+        }
+        if let Some(v) = patch.set_notes.clone() {
+            update.notes = Some(v);
+        }
+        if patch.clear_notes {
+            update.notes = Some(None);
+        }
+        if let Some(v) = patch.set_environment.clone() {
+            update.environment = Some(v);
+        }
+        if patch.clear_environment {
+            update.environment = Some(None);
+        }
+        if let Some(v) = patch.set_session_logging {
+            update.session_logging = Some(v);
+        }
+        if let Some(v) = patch.favorite {
+            update.favorite = Some(v);
+        }
+        if let Some(v) = patch.set_label.clone() {
+            update.label = Some(v);
+        }
+        if let Some(v) = patch.set_transport {
+            update.transport = Some(v);
+        }
+        ctx.store.update_host(id, &update)?;
+        if let Some(groups) = patch.set_groups.clone() {
+            let group_ids = resolve_group_ids(ctx, &groups)?;
+            ctx.store.set_host_groups(id, &group_ids)?;
+        }
+        if let Some(v) = patch.set_identity.clone() {
+            let identity = ctx.identity_by_name(&v)?;
+            ctx.store.update_host(
+                id,
+                &HostUpdate {
+                    identity_id: Some(Some(identity.id)),
+                    ..Default::default()
+                },
+            )?;
+        }
+        ctx.reload_hosts()?;
+        println!("{host_name}");
+        return Ok(0);
+    }
+
+    let favorite = patch.favorite.unwrap_or(entry.favorite());
+    let meta = HostMetadata {
+        host_name: host_name.clone(),
+        tags: patch
+            .set_tags
+            .clone()
+            .unwrap_or_else(|| entry.tags().to_vec()),
+        description: if patch.clear_notes {
+            None
+        } else {
+            patch
+                .set_notes
+                .clone()
+                .flatten()
+                .or_else(|| entry.description().map(str::to_string))
+        },
+        environment: if patch.clear_environment {
+            None
+        } else {
+            patch
+                .set_environment
+                .clone()
+                .flatten()
+                .or_else(|| entry.environment().map(str::to_string))
+        },
+        favorite,
+        last_connected: entry.last_connected(),
+        session_logging: patch
+            .set_session_logging
+            .unwrap_or(entry.session_logging_override()),
+        transport: patch.set_transport.unwrap_or(entry.session_transport()),
+    };
+    ctx.metadata.upsert(&meta)?;
+    ctx.reload_hosts()?;
+    println!("{host_name}");
+    Ok(0)
+}
+
+fn cmd_rename(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let mut args = args.to_vec();
+    let strict = parse::take_flag(&mut args, "--strict");
+    let name = parse::take_opt(&mut args, "--name")
+        .ok_or_else(|| anyhow::anyhow!("rename requires --name"))?;
+    let new_name = parse::take_opt(&mut args, "--new-name")
+        .ok_or_else(|| anyhow::anyhow!("rename requires --new-name"))?;
+
+    let managed = ctx.managed_host_by_name(&name)?.clone();
+    if managed.source != HostSource::Launcher {
+        bail!("only launcher hosts can be renamed");
+    }
+
+    let target = if strict {
+        if ctx.store.get_host_by_name(&new_name)?.is_some() {
+            bail!("host name '{new_name}' already exists");
+        }
+        new_name.clone()
+    } else {
+        ctx.store.unique_host_name(&new_name, Some(managed.id))?
+    };
+
+    ctx.store.update_host(
+        managed.id,
+        &HostUpdate {
+            name: Some(target.clone()),
+            ..Default::default()
+        },
+    )?;
+    ctx.reload_hosts()?;
+    println!("{target}");
+    Ok(0)
+}
+
+fn cmd_delete(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let mut args = args.to_vec();
+    if !parse::take_flag(&mut args, "--yes") {
+        eprintln!("sshub: delete requires --yes");
+        return Ok(1);
+    }
+    let name = parse::take_opt(&mut args, "--name")
+        .ok_or_else(|| anyhow::anyhow!("delete requires --name"))?;
+
+    let managed = ctx.managed_host_by_name(&name)?;
+    match ctx.store.delete_host(managed.id)? {
+        DeleteHostOutcome::Deleted => {
+            ctx.reload_hosts()?;
+            Ok(0)
+        }
+        DeleteHostOutcome::NotFound => {
+            eprintln!("sshub: host not found");
+            Ok(1)
+        }
+        DeleteHostOutcome::NotLauncher => {
+            eprintln!("sshub: only launcher-managed hosts can be deleted");
+            Ok(2)
+        }
+    }
+}
+
+fn cmd_duplicate(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let mut args = args.to_vec();
+    let fmt = parse::parse_format(&args).map_err(anyhow::Error::msg)?;
+    let name = parse::take_opt(&mut args, "--name")
+        .ok_or_else(|| anyhow::anyhow!("duplicate requires --name"))?;
+    let new_name = parse::take_opt(&mut args, "--new-name");
+
+    let entry = ctx.host_by_name(&name)?.clone();
+    let copy_name = match &entry {
+        crate::app::HostEntry::Managed(m) => {
+            if let Some(requested) = new_name {
+                let unique = ctx.store.unique_host_name(&requested, None)?;
+                let copy = ctx.store.duplicate_host(m.id)?.context("host not found")?;
+                if unique != copy.name {
+                    ctx.store.update_host(
+                        copy.id,
+                        &HostUpdate {
+                            name: Some(unique.clone()),
+                            ..Default::default()
+                        },
+                    )?;
+                    unique
+                } else {
+                    copy.name
+                }
+            } else {
+                ctx.store
+                    .duplicate_host(m.id)?
+                    .context("host not found")?
+                    .name
+            }
+        }
+        crate::app::HostEntry::Legacy { host, meta } => {
+            if let Some(requested) = new_name {
+                let mut h = host.clone();
+                h.name = requested.clone();
+                let mut m = meta.clone();
+                m.host_name = requested.clone();
+                duplicate_legacy_to_launcher(&ctx.store, &h, &m)?
+            } else {
+                duplicate_legacy_to_launcher(&ctx.store, host, meta)?
+            }
+        }
+    };
+
+    ctx.reload_hosts()?;
+    let record = host_record_json(ctx.host_by_name(&copy_name)?, &ctx.store);
+    match fmt {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&record)?),
+        OutputFormat::Plain => println!("{}", record.name),
+    }
+    Ok(0)
+}
+
+fn resolve_group_ids(ctx: &CliContext, names: &[String]) -> Result<Vec<i64>> {
+    names
+        .iter()
+        .map(|n| ctx.group_by_name(n).map(|g| g.id))
+        .collect()
+}
+
+struct HostAddSpec {
+    name: String,
+    address: String,
+    port: u16,
+    label: Option<String>,
+    groups: Vec<String>,
+    identity: Option<String>,
+    username: Option<String>,
+    tags: Vec<String>,
+    notes: Option<String>,
+    proxy_jump: Option<String>,
+    forward_agent: bool,
+    remote_command: Option<String>,
+    transport: SessionTransport,
+    session_logging: crate::session_log::SessionLoggingOverride,
+    os_icon: Option<String>,
+    favorite: bool,
+    password: Option<String>,
+}
+
+impl HostAddSpec {
+    fn parse(args: &[String]) -> Result<Self> {
+        let mut args = args.to_vec();
+        let name = parse::take_opt(&mut args, "--name")
+            .ok_or_else(|| anyhow::anyhow!("add requires --name"))?;
+        let address = parse::take_opt(&mut args, "--address")
+            .ok_or_else(|| anyhow::anyhow!("add requires --address"))?;
+        let port = parse::take_opt(&mut args, "--port")
+            .map(|p| p.parse())
+            .transpose()
+            .map_err(|_| anyhow::anyhow!("invalid --port"))?
+            .unwrap_or(22);
+        let label = parse::take_opt(&mut args, "--label").and_then(|s| optional_field(&s));
+        let groups = parse::take_all(&mut args, "--group");
+        let identity = parse::take_opt(&mut args, "--identity");
+        let username = parse::take_opt(&mut args, "--username").and_then(|s| optional_field(&s));
+        let tags = parse::take_opt(&mut args, "--tags")
+            .map(|t| parse_tags(&t))
+            .unwrap_or_default();
+        let notes = parse::take_opt(&mut args, "--notes").and_then(|s| optional_field(&s));
+        let proxy_jump =
+            parse::take_opt(&mut args, "--proxy-jump").and_then(|s| optional_field(&s));
+        let forward_agent = if parse::take_flag(&mut args, "--no-forward-agent") {
+            false
+        } else {
+            parse::take_flag(&mut args, "--forward-agent")
+        };
+        let remote_command =
+            parse::take_opt(&mut args, "--remote-command").and_then(|s| optional_field(&s));
+        let transport = parse::take_opt(&mut args, "--transport")
+            .and_then(|s| parse_transport(&s))
+            .unwrap_or(SessionTransport::Ssh);
+        let session_logging = parse::take_opt(&mut args, "--session-log")
+            .and_then(|s| parse_session_logging(&s))
+            .unwrap_or(crate::session_log::SessionLoggingOverride::Inherit);
+        let os_icon = parse::take_opt(&mut args, "--os-icon").and_then(|s| optional_field(&s));
+        let favorite = parse::take_flag(&mut args, "--favorite");
+        let password = if parse::take_flag(&mut args, "--password-stdin") {
+            Some(read_password_stdin()?)
+        } else {
+            None
+        };
+        Ok(Self {
+            name,
+            address,
+            port,
+            label,
+            groups,
+            identity,
+            username,
+            tags,
+            notes,
+            proxy_jump,
+            forward_agent,
+            remote_command,
+            transport,
+            session_logging,
+            os_icon,
+            favorite,
+            password,
+        })
+    }
+}
+
+struct HostEditPatch {
+    name: String,
+    set_label: Option<Option<String>>,
+    set_name: Option<String>,
+    set_address: Option<String>,
+    set_port: Option<u16>,
+    set_username: Option<Option<String>>,
+    clear_username: bool,
+    set_tags: Option<Vec<String>>,
+    set_notes: Option<Option<String>>,
+    clear_notes: bool,
+    set_environment: Option<Option<String>>,
+    clear_environment: bool,
+    set_proxy_jump: Option<Option<String>>,
+    clear_proxy_jump: bool,
+    set_remote_command: Option<Option<String>>,
+    clear_remote_command: bool,
+    set_forward_agent: Option<bool>,
+    set_os_icon: Option<Option<String>>,
+    clear_os_icon: bool,
+    set_session_logging: Option<crate::session_log::SessionLoggingOverride>,
+    set_transport: Option<SessionTransport>,
+    favorite: Option<bool>,
+    set_identity: Option<String>,
+    clear_identity: bool,
+    set_groups: Option<Vec<String>>,
+    set_has_password: Option<bool>,
+    password: Option<String>,
+    clear_password: bool,
+}
+
+impl HostEditPatch {
+    fn parse(args: &[String]) -> Result<Self> {
+        let mut args = args.to_vec();
+        let name = parse::take_opt(&mut args, "--name")
+            .ok_or_else(|| anyhow::anyhow!("edit requires --name"))?;
+
+        let mut patch = Self {
+            name,
+            set_label: None,
+            set_name: None,
+            set_address: None,
+            set_port: None,
+            set_username: None,
+            clear_username: false,
+            set_tags: None,
+            set_notes: None,
+            clear_notes: false,
+            set_environment: None,
+            clear_environment: false,
+            set_proxy_jump: None,
+            clear_proxy_jump: false,
+            set_remote_command: None,
+            clear_remote_command: false,
+            set_forward_agent: None,
+            set_os_icon: None,
+            clear_os_icon: false,
+            set_session_logging: None,
+            set_transport: None,
+            favorite: None,
+            set_identity: None,
+            clear_identity: false,
+            set_groups: None,
+            set_has_password: None,
+            password: None,
+            clear_password: false,
+        };
+
+        if let Some(v) = parse::take_opt(&mut args, "--set-label") {
+            patch.set_label = Some(optional_field(&v));
+        }
+        if let Some(v) = parse::take_opt(&mut args, "--set-name") {
+            patch.set_name = Some(v);
+        }
+        if let Some(v) = parse::take_opt(&mut args, "--set-address") {
+            patch.set_address = Some(v);
+        }
+        if let Some(v) = parse::take_opt(&mut args, "--set-port") {
+            patch.set_port = Some(v.parse().context("invalid --set-port")?);
+        }
+        if let Some(v) = parse::take_opt(&mut args, "--set-username") {
+            patch.set_username = Some(optional_field(&v));
+        }
+        patch.clear_username = parse::take_flag(&mut args, "--clear-username");
+        if let Some(v) = parse::take_opt(&mut args, "--set-tags") {
+            patch.set_tags = Some(parse_tags(&v));
+        }
+        if let Some(v) = parse::take_opt(&mut args, "--set-notes") {
+            patch.set_notes = Some(optional_field(&v));
+        }
+        patch.clear_notes = parse::take_flag(&mut args, "--clear-notes");
+        if let Some(v) = parse::take_opt(&mut args, "--set-environment") {
+            patch.set_environment = Some(optional_field(&v));
+        }
+        patch.clear_environment = parse::take_flag(&mut args, "--clear-environment");
+        if let Some(v) = parse::take_opt(&mut args, "--set-proxy-jump") {
+            patch.set_proxy_jump = Some(optional_field(&v));
+        }
+        patch.clear_proxy_jump = parse::take_flag(&mut args, "--clear-proxy-jump");
+        if let Some(v) = parse::take_opt(&mut args, "--set-remote-command") {
+            patch.set_remote_command = Some(optional_field(&v));
+        }
+        patch.clear_remote_command = parse::take_flag(&mut args, "--clear-remote-command");
+        if parse::take_flag(&mut args, "--set-forward-agent") {
+            patch.set_forward_agent = Some(true);
+        }
+        if parse::take_flag(&mut args, "--no-forward-agent") {
+            patch.set_forward_agent = Some(false);
+        }
+        if let Some(v) = parse::take_opt(&mut args, "--set-os-icon") {
+            patch.set_os_icon = Some(optional_field(&v));
+        }
+        patch.clear_os_icon = parse::take_flag(&mut args, "--clear-os-icon");
+        if let Some(v) = parse::take_opt(&mut args, "--set-session-log") {
+            patch.set_session_logging = Some(
+                parse_session_logging(&v)
+                    .ok_or_else(|| anyhow::anyhow!("invalid --set-session-log"))?,
+            );
+        }
+        if let Some(v) = parse::take_opt(&mut args, "--set-transport") {
+            patch.set_transport = Some(
+                parse_transport(&v).ok_or_else(|| anyhow::anyhow!("invalid --set-transport"))?,
+            );
+        }
+        if parse::take_flag(&mut args, "--favorite") {
+            patch.favorite = Some(true);
+        }
+        if parse::take_flag(&mut args, "--no-favorite") {
+            patch.favorite = Some(false);
+        }
+        if let Some(v) = parse::take_opt(&mut args, "--set-identity") {
+            patch.set_identity = Some(v);
+        }
+        patch.clear_identity = parse::take_flag(&mut args, "--clear-identity");
+        let groups = parse::take_all(&mut args, "--set-group");
+        if !groups.is_empty() {
+            patch.set_groups = Some(groups);
+        }
+        if parse::take_flag(&mut args, "--set-password-stdin") {
+            patch.password = Some(read_password_stdin()?);
+            patch.set_has_password = Some(true);
+        }
+        patch.clear_password = parse::take_flag(&mut args, "--clear-password");
+
+        if !patch.has_any_patch() {
+            bail!("edit requires at least one --set-* flag");
+        }
+        Ok(patch)
+    }
+
+    fn has_any_patch(&self) -> bool {
+        self.set_label.is_some()
+            || self.set_name.is_some()
+            || self.set_address.is_some()
+            || self.set_port.is_some()
+            || self.set_username.is_some()
+            || self.clear_username
+            || self.set_tags.is_some()
+            || self.set_notes.is_some()
+            || self.clear_notes
+            || self.set_environment.is_some()
+            || self.clear_environment
+            || self.set_proxy_jump.is_some()
+            || self.clear_proxy_jump
+            || self.set_remote_command.is_some()
+            || self.clear_remote_command
+            || self.set_forward_agent.is_some()
+            || self.set_os_icon.is_some()
+            || self.clear_os_icon
+            || self.set_session_logging.is_some()
+            || self.set_transport.is_some()
+            || self.favorite.is_some()
+            || self.set_identity.is_some()
+            || self.clear_identity
+            || self.set_groups.is_some()
+            || self.password.is_some()
+            || self.clear_password
+    }
+
+    fn needs_materialize(&self) -> bool {
+        self.changes_connection_fields()
+            || self.set_groups.is_some()
+            || self.set_identity.is_some()
+            || self.clear_identity
+            || self.set_label.is_some()
+    }
+
+    fn metadata_only(&self) -> bool {
+        !self.changes_connection_fields()
+            && self.set_groups.is_none()
+            && self.set_identity.is_none()
+            && !self.clear_identity
+            && self.password.is_none()
+            && !self.clear_password
+            && self.set_label.is_none()
+    }
+
+    fn changes_connection_fields(&self) -> bool {
+        self.set_name.is_some()
+            || self.set_address.is_some()
+            || self.set_port.is_some()
+            || self.set_proxy_jump.is_some()
+            || self.clear_proxy_jump
+            || self.set_forward_agent.is_some()
+            || self.set_remote_command.is_some()
+            || self.clear_remote_command
+    }
+}
+
+fn read_password_stdin() -> Result<String> {
+    let mut buf = String::new();
+    io::stdin()
+        .read_to_string(&mut buf)
+        .context("read password from stdin")?;
+    Ok(buf.trim_end_matches(['\r', '\n']).to_string())
+}
+
+fn host_usage(msg: &str) -> ! {
+    eprintln!("sshub: {msg}");
+    std::process::exit(2);
+}

--- a/src/cli/identity.rs
+++ b/src/cli/identity.rs
@@ -1,0 +1,336 @@
+//! `sshub identity …` — SSH identity CRUD and agent key removal.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::credentials::identity_key;
+use crate::store::{DeleteIdentityOutcome, Identity, IdentityUpdate, NewIdentity};
+
+use super::context::{optional_path_flag, read_password_stdin, CliContext};
+use super::parse::{
+    fail, fail_code, parse_format, take_flag, take_opt, usage, OutputFormat, CONFIRM_YES,
+};
+
+#[derive(Serialize)]
+struct IdentityRecord<'a> {
+    id: i64,
+    name: &'a str,
+    username: Option<&'a str>,
+    private_key: Option<String>,
+    certificate: Option<String>,
+    has_password: bool,
+}
+
+pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    match rest.first().map(String::as_str) {
+        Some("list") => {
+            rest.remove(0);
+            cmd_list(ctx, &rest)
+        }
+        Some("show") => {
+            rest.remove(0);
+            cmd_show(ctx, &rest)
+        }
+        Some("add") => {
+            rest.remove(0);
+            cmd_add(ctx, &rest)
+        }
+        Some("edit") => {
+            rest.remove(0);
+            cmd_edit(ctx, &rest)
+        }
+        Some("delete") => {
+            rest.remove(0);
+            cmd_delete(ctx, &rest)
+        }
+        Some("agent-remove") => {
+            rest.remove(0);
+            cmd_agent_remove(ctx, &rest)
+        }
+        Some(other) => {
+            eprintln!("sshub: unknown identity subcommand '{other}'");
+            eprintln!("       try: sshub identity list|show|add|edit|delete|agent-remove");
+            Ok(2)
+        }
+        None => {
+            usage("identity needs a subcommand (list|show|add|edit|delete|agent-remove)");
+        }
+    }
+}
+
+fn cmd_list(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let fmt = parse_format(args).map_err(anyhow::Error::msg)?;
+    let identities = ctx.store.list_identities()?;
+
+    match fmt {
+        OutputFormat::Plain => {
+            for i in &identities {
+                println!("{:<6} {}", i.id, i.name);
+            }
+        }
+        OutputFormat::Json => {
+            let records: Vec<IdentityRecord<'_>> = identities.iter().map(identity_record).collect();
+            println!("{}", serde_json::to_string(&records)?);
+        }
+    }
+    Ok(0)
+}
+
+fn cmd_show(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let fmt = parse_format(args).map_err(anyhow::Error::msg)?;
+    let name = identity_name_arg(args);
+    let identity = ctx.identity_by_name(&name)?;
+
+    match fmt {
+        OutputFormat::Plain => print_identity_plain(&identity)?,
+        OutputFormat::Json => {
+            let record = identity_record(&identity);
+            println!("{}", serde_json::to_string(&record)?);
+        }
+    }
+    Ok(0)
+}
+
+fn cmd_add(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let name =
+        take_opt(&mut rest, "--name").unwrap_or_else(|| usage("identity add requires --name"));
+    if name.trim().is_empty() {
+        fail("identity name cannot be empty");
+    }
+
+    let username = take_opt(&mut rest, "--username");
+    let private_key = match take_opt(&mut rest, "--private-key") {
+        Some(p) => optional_path_flag(&p)?,
+        None => None,
+    };
+    let certificate = match take_opt(&mut rest, "--certificate") {
+        Some(p) => optional_path_flag(&p)?,
+        None => None,
+    };
+    let password_stdin = take_flag(&mut rest, "--password-stdin");
+    let sort_order = ctx.store.list_identities()?.len() as i32;
+
+    let created = ctx.store.create_identity(&NewIdentity {
+        name: name.trim().to_string(),
+        username,
+        private_key,
+        certificate,
+        sort_order,
+        has_password: password_stdin,
+    })?;
+
+    if password_stdin {
+        let pw = read_password_stdin()?;
+        if !pw.is_empty() {
+            ctx.password_store.set(&identity_key(created.id), &pw)?;
+        }
+    }
+
+    println!("created identity '{}'", created.name);
+    Ok(0)
+}
+
+fn cmd_edit(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let name =
+        take_opt(&mut rest, "--name").unwrap_or_else(|| usage("identity edit requires --name"));
+    let identity = ctx.identity_by_name(&name)?;
+
+    let set_name = take_opt(&mut rest, "--set-name");
+    let set_username = if take_flag(&mut rest, "--clear-username") {
+        Some(None)
+    } else {
+        take_opt(&mut rest, "--set-username").map(Some)
+    };
+    let set_private_key: Option<Option<PathBuf>> = if take_flag(&mut rest, "--clear-private-key") {
+        Some(None)
+    } else {
+        match take_opt(&mut rest, "--set-private-key") {
+            Some(p) => Some(optional_path_flag(&p)?),
+            None => None,
+        }
+    };
+    let set_certificate: Option<Option<PathBuf>> = if take_flag(&mut rest, "--clear-certificate") {
+        Some(None)
+    } else {
+        match take_opt(&mut rest, "--set-certificate") {
+            Some(p) => Some(optional_path_flag(&p)?),
+            None => None,
+        }
+    };
+    let password_stdin = take_flag(&mut rest, "--password-stdin");
+    let clear_password = take_flag(&mut rest, "--clear-password");
+
+    let mut has_password = identity.has_password;
+    if clear_password {
+        ctx.password_store.delete(&identity_key(identity.id))?;
+        has_password = false;
+    }
+    if password_stdin {
+        let pw = read_password_stdin()?;
+        if pw.is_empty() {
+            ctx.password_store.delete(&identity_key(identity.id))?;
+            has_password = false;
+        } else {
+            ctx.password_store.set(&identity_key(identity.id), &pw)?;
+            has_password = true;
+        }
+    }
+
+    let updated = ctx.store.update_identity(
+        identity.id,
+        &IdentityUpdate {
+            name: set_name,
+            username: set_username,
+            private_key: set_private_key,
+            certificate: set_certificate,
+            has_password: if password_stdin || clear_password {
+                Some(has_password)
+            } else {
+                None
+            },
+            ..Default::default()
+        },
+    )?;
+    if updated.is_none() {
+        fail(&format!("identity '{name}' not found"));
+    }
+    println!("updated identity '{name}'");
+    Ok(0)
+}
+
+fn cmd_delete(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let name =
+        take_opt(&mut rest, "--name").unwrap_or_else(|| usage("identity delete requires --name"));
+    if !take_flag(&mut rest, CONFIRM_YES) {
+        fail(&format!(
+            "refusing to delete identity '{name}' without {CONFIRM_YES}"
+        ));
+    }
+
+    let identity = ctx.identity_by_name(&name)?;
+    match ctx.store.delete_identity(identity.id)? {
+        DeleteIdentityOutcome::Deleted => {
+            let _ = ctx.password_store.delete(&identity_key(identity.id));
+            println!("deleted identity '{name}'");
+            Ok(0)
+        }
+        DeleteIdentityOutcome::NotFound => fail(&format!("identity '{name}' not found")),
+        DeleteIdentityOutcome::InUse { host_count } => fail_code(
+            &format!("identity '{name}' is used by {host_count} host(s)"),
+            2,
+        ),
+    }
+}
+
+fn cmd_agent_remove(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let name = take_opt(&mut rest, "--name")
+        .unwrap_or_else(|| usage("identity agent-remove requires --name"));
+
+    let identity = match ctx.store.get_identity_by_name(&name)? {
+        Some(i) => i,
+        None => fail(&format!("identity '{name}' not found")),
+    };
+
+    let Some(ref key_path) = identity.private_key else {
+        fail(&format!("identity '{name}' has no private key path"));
+    };
+
+    let expanded = crate::ssh::expand_tilde(&key_path.to_string_lossy());
+    let key_display = expanded.to_string_lossy();
+
+    match crate::ssh::agent::remove_key(&key_display) {
+        Ok(()) => {
+            let _ = ctx.store.log_auth_event(
+                &name,
+                None,
+                "agent",
+                "ok",
+                &format!("key removed from agent: {key_display}"),
+                None,
+            );
+            println!("removed '{}' from agent", name);
+            Ok(0)
+        }
+        Err(e) => {
+            let _ = ctx.store.log_auth_event(
+                &name,
+                None,
+                "agent",
+                "fail",
+                &format!("remove from agent failed: {e:#}"),
+                None,
+            );
+            fail(&format!("ssh-add -d failed: {e:#}"));
+        }
+    }
+}
+
+fn identity_name_arg(args: &[String]) -> String {
+    let mut rest = args.to_vec();
+    if let Some(n) = take_opt(&mut rest, "--name") {
+        return n;
+    }
+    match super::parse::positional(args).first() {
+        Some(n) => (*n).to_string(),
+        None => usage("identity show requires an identity name"),
+    }
+}
+
+fn identity_record(i: &Identity) -> IdentityRecord<'_> {
+    IdentityRecord {
+        id: i.id,
+        name: &i.name,
+        username: i.username.as_deref(),
+        private_key: i
+            .private_key
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned()),
+        certificate: i
+            .certificate
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned()),
+        has_password: i.has_password,
+    }
+}
+
+fn print_identity_plain(identity: &Identity) -> Result<()> {
+    println!("id:           {}", identity.id);
+    println!("name:         {}", identity.name);
+    if let Some(u) = &identity.username {
+        println!("username:     {u}");
+    }
+    if let Some(k) = &identity.private_key {
+        println!("private_key:  {}", k.display());
+    }
+    if let Some(c) = &identity.certificate {
+        println!("certificate:  {}", c.display());
+    }
+    println!("has_password: {}", identity.has_password);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_record_serializes() {
+        let i = Identity {
+            id: 1,
+            name: "work".into(),
+            username: Some("alice".into()),
+            private_key: Some(PathBuf::from("/home/alice/.ssh/id_ed25519")),
+            certificate: None,
+            has_password: true,
+        };
+        let json = serde_json::to_string(&identity_record(&i)).unwrap();
+        assert!(json.contains("\"name\":\"work\""));
+    }
+}

--- a/src/cli/identity.rs
+++ b/src/cli/identity.rs
@@ -112,6 +112,14 @@ fn cmd_add(ctx: &CliContext, args: &[String]) -> Result<i32> {
         None => None,
     };
     let password_stdin = take_flag(&mut rest, "--password-stdin");
+    // Read the secret before creating the row so has_password reflects reality:
+    // an empty piped password must not leave has_password=true with no secret.
+    let password = if password_stdin {
+        let pw = read_password_stdin()?;
+        (!pw.is_empty()).then_some(pw)
+    } else {
+        None
+    };
     let sort_order = ctx.store.list_identities()?.len() as i32;
 
     let created = ctx.store.create_identity(&NewIdentity {
@@ -120,14 +128,11 @@ fn cmd_add(ctx: &CliContext, args: &[String]) -> Result<i32> {
         private_key,
         certificate,
         sort_order,
-        has_password: password_stdin,
+        has_password: password.is_some(),
     })?;
 
-    if password_stdin {
-        let pw = read_password_stdin()?;
-        if !pw.is_empty() {
-            ctx.password_store.set(&identity_key(created.id), &pw)?;
-        }
+    if let Some(pw) = password {
+        ctx.password_store.set(&identity_key(created.id), &pw)?;
     }
 
     println!("created identity '{}'", created.name);
@@ -141,6 +146,11 @@ fn cmd_edit(ctx: &CliContext, args: &[String]) -> Result<i32> {
     let identity = ctx.identity_by_name(&name)?;
 
     let set_name = take_opt(&mut rest, "--set-name");
+    if let Some(n) = &set_name {
+        if n.trim().is_empty() {
+            fail("identity name cannot be empty");
+        }
+    }
     let set_username = if take_flag(&mut rest, "--clear-username") {
         Some(None)
     } else {

--- a/src/cli/inventory.rs
+++ b/src/cli/inventory.rs
@@ -1,0 +1,107 @@
+//! Inventory and config commands: tags, sync, import, export.
+
+use anyhow::{Context, Result};
+
+use crate::secure_fs;
+use crate::ssh::{
+    export_launcher_hosts_to, import_ssh_config, render_launcher_hosts, sync_ssh_config_hosts,
+    ImportReport,
+};
+use std::collections::BTreeSet;
+
+use super::context::CliContext;
+use super::parse::{fail, parse_format, take_flag, take_opt, OutputFormat};
+
+pub fn run_tags(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let fmt = parse_format(args).map_err(anyhow::Error::msg)?;
+    let mut tags: BTreeSet<String> = BTreeSet::new();
+    for entry in &ctx.hosts {
+        for t in entry.tags() {
+            tags.insert(t.clone());
+        }
+    }
+
+    match fmt {
+        OutputFormat::Plain => {
+            for t in &tags {
+                println!("{t}");
+            }
+        }
+        OutputFormat::Json => {
+            let list: Vec<&str> = tags.iter().map(String::as_str).collect();
+            println!("{}", serde_json::to_string(&list)?);
+        }
+    }
+    Ok(0)
+}
+
+pub fn run_sync(ctx: &mut CliContext, _args: &[String]) -> Result<i32> {
+    let updated = sync_ssh_config_hosts(&ctx.resolver, &ctx.store)?;
+    println!("updated {updated} ssh_config host(s)");
+    ctx.reload_hosts()?;
+    Ok(0)
+}
+
+pub fn run_import(ctx: &mut CliContext, _args: &[String]) -> Result<i32> {
+    let report = import_ssh_config(&ctx.resolver, &ctx.store, ctx.metadata.as_ref())?;
+    print_import_report(&report);
+    ctx.reload_hosts()?;
+    Ok(0)
+}
+
+pub fn run_export(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let stdout = take_flag(&mut rest, "--stdout");
+    let out_path = take_opt(&mut rest, "-o").or_else(|| take_opt(&mut rest, "--output"));
+
+    if stdout && out_path.is_some() {
+        fail("export: use either --stdout or -o PATH, not both");
+    }
+
+    if stdout {
+        let content = render_launcher_hosts(&ctx.store)?;
+        print!("{content}");
+        return Ok(0);
+    }
+
+    let path = match out_path {
+        Some(p) => std::path::PathBuf::from(p),
+        None => crate::ssh::exported_conf_path()?,
+    };
+
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create export directory {}", parent.display()))?;
+            secure_fs::restrict_dir(parent);
+        }
+    }
+
+    let written = export_launcher_hosts_to(&ctx.store, &path)?;
+    println!("exported launcher hosts to {}", written.display());
+    Ok(0)
+}
+
+fn print_import_report(report: &ImportReport) {
+    println!(
+        "imported: {} inserted, {} updated, {} skipped (launcher), {} failed",
+        report.inserted, report.updated, report.skipped_launcher, report.failed
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn import_report_format() {
+        let report = ImportReport {
+            inserted: 2,
+            updated: 1,
+            skipped_launcher: 5,
+            failed: 0,
+        };
+        // smoke: formatting doesn't panic
+        print_import_report(&report);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod completions;
 pub mod context;
 pub mod filter;
 pub mod group;
+pub mod help;
 pub mod host;
 pub mod identity;
 pub mod inventory;
@@ -40,6 +41,10 @@ pub fn is_subcommand(cmd: &str) -> bool {
 /// Dispatch a subcommand. `rest` is argv AFTER the subcommand token. main.rs
 /// owns bootstrap and passes `ctx` in; this fn must NOT call CliContext::bootstrap.
 pub fn run_subcommand(ctx: &mut CliContext, cmd: &str, rest: &[String]) -> Result<i32> {
+    if rest.iter().any(|a| a == "--help" || a == "-h") {
+        help::print_command_help(cmd);
+        return Ok(0);
+    }
     match cmd {
         "host" => host::run_host(ctx, rest),
         // aliases:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,69 @@
+pub mod audit;
+pub mod completions;
+pub mod context;
+pub mod filter;
+pub mod group;
+pub mod host;
+pub mod identity;
+pub mod inventory;
+pub mod output;
+pub mod parse;
+pub mod sftp;
+pub mod tunnel;
+
+pub use context::CliContext;
+
+use anyhow::Result;
+
+/// True if `cmd` is a recognized CLI subcommand or alias. Called by main.rs
+/// BEFORE bootstrap (cheap string check). Must NOT bootstrap a CliContext.
+pub fn is_subcommand(cmd: &str) -> bool {
+    matches!(
+        cmd,
+        "host"
+            | "connect"
+            | "list"
+            | "tunnel"
+            | "group"
+            | "groups"
+            | "identity"
+            | "tags"
+            | "sync"
+            | "import"
+            | "export"
+            | "completions"
+            | "sftp"
+            | "audit"
+    )
+}
+
+/// Dispatch a subcommand. `rest` is argv AFTER the subcommand token. main.rs
+/// owns bootstrap and passes `ctx` in; this fn must NOT call CliContext::bootstrap.
+pub fn run_subcommand(ctx: &mut CliContext, cmd: &str, rest: &[String]) -> Result<i32> {
+    match cmd {
+        "host" => host::run_host(ctx, rest),
+        // aliases:
+        "connect" => host::run_host(ctx, &prepend("connect", rest)),
+        "list" => host::run_host(ctx, &prepend("list", rest)),
+        "groups" => group::run(ctx, &prepend("list", rest)),
+
+        "tunnel" => tunnel::run(ctx, rest),
+        "group" => group::run(ctx, rest),
+        "identity" => identity::run(ctx, rest),
+        "tags" => inventory::run_tags(ctx, rest),
+        "sync" => inventory::run_sync(ctx, rest),
+        "import" => inventory::run_import(ctx, rest),
+        "export" => inventory::run_export(ctx, rest),
+        "completions" => completions::run(ctx, rest),
+        "sftp" => sftp::run(ctx, rest),
+        "audit" => audit::run(ctx, rest),
+        other => anyhow::bail!("unknown subcommand: {other}"),
+    }
+}
+
+fn prepend(head: &str, rest: &[String]) -> Vec<String> {
+    let mut v = Vec::with_capacity(rest.len() + 1);
+    v.push(head.to_string());
+    v.extend_from_slice(rest);
+    v
+}

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,0 +1,363 @@
+//! JSON DTOs and plain-text formatters for CLI output.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+
+use crate::app::{
+    prepare_cli_connect_argv, resolve_pending_secret, session_argv_for_entry, HostEntry,
+};
+use crate::credentials::PasswordStore;
+use crate::session_log::SessionLoggingOverride;
+use crate::session_transport::SessionTransport;
+use crate::store::{AuthEvent, HostSource, LauncherStore, Tunnel, TunnelType};
+
+#[derive(Debug, Serialize)]
+pub struct HostRecordJson {
+    pub name: String,
+    pub label: Option<String>,
+    pub address: Option<String>,
+    pub user: Option<String>,
+    pub port: Option<u16>,
+    pub group: Option<String>,
+    pub groups: Vec<String>,
+    pub identity: Option<String>,
+    pub proxy_jump: Option<String>,
+    pub source: String,
+    pub tags: Vec<String>,
+    pub environment: Option<String>,
+    pub description: Option<String>,
+    pub favorite: bool,
+    pub last_connected: Option<i64>,
+    pub session_logging: String,
+    pub transport: String,
+    pub forward_agent: Option<bool>,
+    pub remote_command: Option<String>,
+    pub os_icon: Option<String>,
+    pub has_password: bool,
+    pub managed_id: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HostResolveJson {
+    #[serde(flatten)]
+    pub host: HostRecordJson,
+    pub argv: Vec<String>,
+    pub has_stored_secret: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuditEventJson {
+    pub id: i64,
+    pub host_name: String,
+    pub username: Option<String>,
+    pub via: Option<String>,
+    pub status: String,
+    pub note: Option<String>,
+    pub log_path: Option<String>,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TunnelJson {
+    pub id: i64,
+    pub host_id: Option<i64>,
+    pub host_name: Option<String>,
+    pub tunnel_type: String,
+    pub local_port: u16,
+    pub remote_host: String,
+    pub remote_port: u16,
+    pub label: Option<String>,
+    pub auto_connect: bool,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+pub fn host_record_json(entry: &HostEntry, store: &LauncherStore) -> HostRecordJson {
+    let ssh = entry.ssh_host();
+    let groups = group_names(entry, store);
+    let (group, identity, source, has_password, managed_id, os_icon, forward_agent) =
+        match entry.managed() {
+            Some(m) => (
+                m.group.as_ref().map(|g| g.name.clone()),
+                m.identity
+                    .as_ref()
+                    .map(|i| i.name.clone())
+                    .or_else(|| ssh.identity_file.clone()),
+                m.source.as_str().to_string(),
+                m.has_password,
+                Some(m.id),
+                m.os_icon.clone(),
+                Some(m.forward_agent),
+            ),
+            None => (
+                None,
+                ssh.identity_file.clone(),
+                HostSource::SshConfig.as_str().to_string(),
+                false,
+                None,
+                None,
+                ssh.forward_agent,
+            ),
+        };
+
+    HostRecordJson {
+        name: entry.name().to_string(),
+        label: entry
+            .managed()
+            .and_then(|m| m.label.clone())
+            .filter(|l| !l.is_empty())
+            .or_else(|| {
+                if entry.display_name() != entry.name() {
+                    Some(entry.display_name().to_string())
+                } else {
+                    None
+                }
+            }),
+        address: ssh.hostname.clone(),
+        user: ssh.user.clone(),
+        port: ssh.port,
+        group,
+        groups,
+        identity,
+        proxy_jump: ssh.proxy_jump.clone(),
+        source,
+        tags: entry.tags().to_vec(),
+        environment: entry.environment().map(str::to_string),
+        description: entry.description().map(str::to_string),
+        favorite: entry.favorite(),
+        last_connected: entry.last_connected(),
+        session_logging: entry.session_logging_override().label().to_string(),
+        transport: entry.session_transport().label().to_string(),
+        forward_agent,
+        remote_command: ssh.remote_command.clone(),
+        os_icon,
+        has_password,
+        managed_id,
+    }
+}
+
+pub fn host_resolve_json(
+    entry: &HostEntry,
+    store: &LauncherStore,
+    password_store: &dyn PasswordStore,
+    verbose: bool,
+) -> HostResolveJson {
+    let (pending_secret, _) = resolve_pending_secret(entry, password_store);
+    let argv = prepare_cli_connect_argv(
+        session_argv_for_entry(entry),
+        pending_secret.is_some(),
+        verbose,
+    );
+    HostResolveJson {
+        host: host_record_json(entry, store),
+        argv,
+        has_stored_secret: pending_secret.is_some(),
+    }
+}
+
+pub fn audit_event_json(event: &AuthEvent) -> AuditEventJson {
+    AuditEventJson {
+        id: event.id,
+        host_name: event.host_name.clone(),
+        username: event.username.clone(),
+        via: event.via.clone(),
+        status: event.status.clone(),
+        note: event.note.clone(),
+        log_path: event.log_path.clone(),
+        created_at: event.created_at,
+    }
+}
+
+pub fn tunnel_json(tunnel: &Tunnel, store: &LauncherStore) -> TunnelJson {
+    let host_name = tunnel
+        .host_id
+        .and_then(|id| store.get_host(id).ok().flatten())
+        .map(|h| h.name);
+    TunnelJson {
+        id: tunnel.id,
+        host_id: tunnel.host_id,
+        host_name,
+        tunnel_type: tunnel_type_cli(tunnel.tunnel_type),
+        local_port: tunnel.local_port,
+        remote_host: tunnel.remote_host.clone(),
+        remote_port: tunnel.remote_port,
+        label: tunnel.label.clone(),
+        auto_connect: tunnel.auto_connect,
+        created_at: tunnel.created_at,
+        updated_at: tunnel.updated_at,
+    }
+}
+
+fn tunnel_type_cli(t: TunnelType) -> String {
+    match t {
+        TunnelType::Local => "local".into(),
+        TunnelType::Remote => "remote".into(),
+        TunnelType::Dynamic => "dynamic".into(),
+    }
+}
+
+fn group_names(entry: &HostEntry, store: &LauncherStore) -> Vec<String> {
+    if let Some(m) = entry.managed() {
+        return m.groups.iter().map(|g| g.name.clone()).collect();
+    }
+    store
+        .list_groups()
+        .ok()
+        .map(|groups| {
+            groups
+                .into_iter()
+                .filter(|g| entry.group_ids().contains(&g.id))
+                .map(|g| g.name)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub fn format_host_plain(record: &HostRecordJson) -> String {
+    let mut lines = vec![
+        format!("Host: {}", record.name),
+        format!(
+            "Label: {}",
+            record.label.as_deref().unwrap_or(record.name.as_str())
+        ),
+        format!("Address: {}", opt_dash(&record.address)),
+        format!("User: {}", opt_dash(&record.user)),
+        format!(
+            "Port: {}",
+            record
+                .port
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "—".into())
+        ),
+        format!("Group: {}", opt_dash(&record.group)),
+        format!(
+            "Groups: {}",
+            if record.groups.is_empty() {
+                "—".into()
+            } else {
+                record.groups.join(", ")
+            }
+        ),
+        format!("Identity: {}", opt_dash(&record.identity)),
+        format!("ProxyJump: {}", opt_dash(&record.proxy_jump)),
+        format!("Source: {}", record.source),
+        String::new(),
+        format!(
+            "Tags: {}",
+            if record.tags.is_empty() {
+                "—".into()
+            } else {
+                record.tags.join(", ")
+            }
+        ),
+        format!("Environment: {}", opt_dash(&record.environment)),
+        format!("Description: {}", opt_dash(&record.description)),
+        format!("Favorite: {}", if record.favorite { "yes" } else { "no" }),
+        format!(
+            "Last connected: {}",
+            record
+                .last_connected
+                .map(|ts| ts.to_string())
+                .unwrap_or_else(|| "—".into())
+        ),
+        format!("Session log: {}", record.session_logging),
+        format!("Transport: {}", record.transport),
+    ];
+    if let Some(fa) = record.forward_agent {
+        lines.push(format!("ForwardAgent: {}", fa));
+    }
+    if let Some(rc) = &record.remote_command {
+        if !rc.is_empty() {
+            lines.push(format!("RemoteCommand: {rc}"));
+        }
+    }
+    if let Some(icon) = &record.os_icon {
+        if !icon.is_empty() {
+            lines.push(format!("OS icon: {icon}"));
+        }
+    }
+    lines.join("\n")
+}
+
+pub fn format_host_list_plain(names: &[&str]) -> String {
+    names.join("\n")
+}
+
+pub fn format_resolve_plain(resolve: &HostResolveJson) -> String {
+    let mut out = format_host_plain(&resolve.host);
+    out.push_str("\n\nCommand:\n");
+    out.push_str(&format!("  {}", resolve.argv.join(" ")));
+    out.push_str("\n\nHas stored secret: ");
+    out.push_str(if resolve.has_stored_secret {
+        "yes"
+    } else {
+        "no"
+    });
+    out
+}
+
+pub fn format_audit_plain(event: &AuditEventJson) -> String {
+    format!(
+        "{} {} {} via={} status={}{}",
+        event.created_at,
+        event.host_name,
+        event.username.as_deref().unwrap_or("-"),
+        event.via.as_deref().unwrap_or("-"),
+        event.status,
+        event
+            .note
+            .as_ref()
+            .map(|n| format!(" ({n})"))
+            .unwrap_or_default()
+    )
+}
+
+pub fn format_tunnel_plain(tunnel: &TunnelJson) -> String {
+    format!(
+        "#{} {} {} localhost:{} -> {}:{}{}",
+        tunnel.id,
+        tunnel.tunnel_type,
+        tunnel.host_name.as_deref().unwrap_or("-"),
+        tunnel.local_port,
+        tunnel.remote_host,
+        tunnel.remote_port,
+        tunnel
+            .label
+            .as_ref()
+            .map(|l| format!(" [{l}]"))
+            .unwrap_or_default()
+    )
+}
+
+fn opt_dash(value: &Option<String>) -> String {
+    value
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or("—")
+        .to_string()
+}
+
+pub fn now_ts() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+pub fn parse_session_logging(s: &str) -> Option<SessionLoggingOverride> {
+    match s {
+        "inherit" => Some(SessionLoggingOverride::Inherit),
+        "on" => Some(SessionLoggingOverride::On),
+        "off" => Some(SessionLoggingOverride::Off),
+        _ => None,
+    }
+}
+
+pub fn parse_transport(s: &str) -> Option<SessionTransport> {
+    match s {
+        "ssh" => Some(SessionTransport::Ssh),
+        "mosh" => Some(SessionTransport::Mosh),
+        _ => None,
+    }
+}

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -1,0 +1,118 @@
+//! Shared CLI argument parsing helpers (hand-rolled, no clap).
+
+use crate::app::SortMode;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputFormat {
+    #[default]
+    Plain,
+    Json,
+}
+
+pub fn parse_format(args: &[String]) -> Result<OutputFormat, String> {
+    let mut fmt = OutputFormat::Plain;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--format" => {
+                let v = args.get(i + 1).ok_or("--format requires a value")?;
+                fmt = match v.as_str() {
+                    "plain" => OutputFormat::Plain,
+                    "json" => OutputFormat::Json,
+                    other => return Err(format!("unknown format '{other}'")),
+                };
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    Ok(fmt)
+}
+
+pub fn take_flag(args: &mut Vec<String>, flag: &str) -> bool {
+    if let Some(pos) = args.iter().position(|a| a == flag) {
+        args.remove(pos);
+        true
+    } else {
+        false
+    }
+}
+
+pub fn take_opt(args: &mut Vec<String>, flag: &str) -> Option<String> {
+    if let Some(pos) = args.iter().position(|a| a == flag) {
+        args.remove(pos);
+        args.get(pos).cloned().inspect(|_| {
+            args.remove(pos);
+        })
+    } else {
+        None
+    }
+}
+
+pub fn take_all(args: &mut Vec<String>, flag: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    while let Some(pos) = args.iter().position(|a| a == flag) {
+        args.remove(pos);
+        if args.get(pos).is_some() {
+            out.push(args.remove(pos));
+        }
+    }
+    out
+}
+
+pub fn parse_sort(args: &[String]) -> Result<Option<SortMode>, String> {
+    for (i, a) in args.iter().enumerate() {
+        if a == "--sort" {
+            let v = args.get(i + 1).ok_or("--sort requires a value")?;
+            return SortMode::from_cli_str(v)
+                .ok_or_else(|| format!("unknown sort mode '{v}'"))
+                .map(Some);
+        }
+    }
+    Ok(None)
+}
+
+pub fn parse_limit(args: &[String], default: usize) -> Result<usize, String> {
+    for (i, a) in args.iter().enumerate() {
+        if a == "--limit" {
+            let v = args.get(i + 1).ok_or("--limit requires a value")?;
+            return v.parse().map_err(|_| format!("invalid limit '{v}'"));
+        }
+    }
+    Ok(default)
+}
+
+pub fn parse_days(args: &[String], default: i64) -> Result<i64, String> {
+    for (i, a) in args.iter().enumerate() {
+        if a == "--days" {
+            let v = args.get(i + 1).ok_or("--days requires a value")?;
+            return v.parse().map_err(|_| format!("invalid days '{v}'"));
+        }
+    }
+    Ok(default)
+}
+
+pub fn positional(args: &[String]) -> Vec<&str> {
+    args.iter()
+        .filter(|a| !a.starts_with('-'))
+        .map(String::as_str)
+        .collect()
+}
+
+/// Confirmation flag for destructive subcommands (delete, etc.).
+pub const CONFIRM_YES: &str = "--yes";
+
+pub fn usage(msg: &str) -> ! {
+    eprintln!("sshub: {msg}");
+    std::process::exit(2);
+}
+
+pub fn fail(msg: &str) -> ! {
+    eprintln!("sshub: {msg}");
+    std::process::exit(1);
+}
+
+pub fn fail_code(msg: &str, code: i32) -> ! {
+    eprintln!("sshub: {msg}");
+    std::process::exit(code);
+}

--- a/src/cli/sftp.rs
+++ b/src/cli/sftp.rs
@@ -1,0 +1,10 @@
+//! `sshub sftp …` — placeholder. Phase 1 compile-only stub.
+
+use anyhow::Result;
+
+use super::CliContext;
+
+pub fn run(_ctx: &mut CliContext, _args: &[String]) -> Result<i32> {
+    eprintln!("sshub: sftp is not yet implemented");
+    Ok(2)
+}

--- a/src/cli/sftp.rs
+++ b/src/cli/sftp.rs
@@ -1,10 +1,388 @@
-//! `sshub sftp …` — placeholder. Phase 1 compile-only stub.
+//! `sshub sftp …`: one-shot SFTP operations over a direct host.
+//!
+//! Each subcommand drives the existing background SFTP worker
+//! ([`crate::sftp::worker`]) synchronously: connect, send a single command,
+//! then block on the event channel until the worker reports the terminal event
+//! (`QueueDone` for transfers, `OpDone` for remote ops, `DirListing` for `ls`).
+//! There is no TUI and no queue building here; the worker's own recursion
+//! handles directory trees when a transfer is flagged `is_dir`.
+
+use std::path::PathBuf;
+use std::sync::mpsc::{Receiver, Sender};
 
 use anyhow::Result;
+use serde::Serialize;
 
+use super::parse;
 use super::CliContext;
+use crate::sftp::model::{Direction, QueuedTransfer, Side};
+use crate::sftp::{SftpCommand, SftpEvent};
 
-pub fn run(_ctx: &mut CliContext, _args: &[String]) -> Result<i32> {
-    eprintln!("sshub: sftp is not yet implemented");
-    Ok(2)
+pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    match args.first().map(String::as_str) {
+        Some("ls") => cmd_ls(ctx, &args[1..]),
+        Some("get") => cmd_get(ctx, &args[1..]),
+        Some("put") => cmd_put(ctx, &args[1..]),
+        Some("rm") => cmd_rm(ctx, &args[1..]),
+        Some("mkdir") => cmd_mkdir(ctx, &args[1..]),
+        Some("rename") => cmd_rename(ctx, &args[1..]),
+        Some("chmod") => cmd_chmod(ctx, &args[1..]),
+        Some(other) => {
+            eprintln!(
+                "sshub: unknown sftp subcommand '{other}' (try: ls, get, put, rm, mkdir, rename, chmod)"
+            );
+            Ok(2)
+        }
+        None => parse::usage("sftp needs a subcommand (ls|get|put|rm|mkdir|rename|chmod)"),
+    }
+}
+
+/// Resolve `host`, spawn the SFTP worker, and block until the connection
+/// result arrives. On success returns the live channels; on any failure prints
+/// a diagnostic to stderr and returns the process exit code to use.
+///
+/// ProxyJump hosts are rejected up front: the libssh2 transport cannot chain a
+/// jump, so a connection attempt would only hang and then fail.
+fn connect_worker(
+    ctx: &CliContext,
+    host: &str,
+) -> Result<(Sender<SftpCommand>, Receiver<SftpEvent>), i32> {
+    let entry = match ctx.host_by_name(host) {
+        Ok(e) => e.clone(),
+        Err(e) => {
+            eprintln!("sshub: {e}");
+            return Err(1);
+        }
+    };
+    let ssh_host = entry.ssh_host();
+    if ssh_host.proxy_jump.is_some() {
+        eprintln!("sshub: SFTP via ProxyJump is not supported; pick a direct host");
+        return Err(1);
+    }
+
+    let (secret, _diag) = crate::app::resolve_pending_secret(&entry, ctx.password_store.as_ref());
+    let agent = crate::ssh::agent::detect_agent();
+    let (tx, rx) = crate::sftp::spawn_sftp_worker(ssh_host, secret, agent);
+
+    match rx.recv() {
+        Ok(SftpEvent::Connected) => Ok((tx, rx)),
+        Ok(SftpEvent::ConnectFailed(e)) => {
+            eprintln!("sshub: connect failed: {e}");
+            Err(1)
+        }
+        other => {
+            eprintln!("sshub: unexpected sftp event: {other:?}");
+            Err(1)
+        }
+    }
+}
+
+/// One JSON row for `ls --format json`.
+#[derive(Serialize)]
+struct LsEntryJson {
+    name: String,
+    is_dir: bool,
+    size: u64,
+}
+
+/// `sshub sftp ls <host> [remote-path] [--format plain|json]`
+fn cmd_ls(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let fmt = match parse::parse_format(&rest) {
+        Ok(f) => f,
+        Err(e) => parse::usage(&e),
+    };
+    let _ = parse::take_opt(&mut rest, "--format");
+    let pos = parse::positional(&rest);
+    let host = match pos.first() {
+        Some(h) => *h,
+        None => parse::usage("sftp ls needs a <host>"),
+    };
+    let path = PathBuf::from(pos.get(1).copied().unwrap_or("."));
+
+    let (tx, rx) = match connect_worker(ctx, host) {
+        Ok(v) => v,
+        Err(code) => return Ok(code),
+    };
+    if tx
+        .send(SftpCommand::ListDir(Side::Remote, path.clone()))
+        .is_err()
+    {
+        eprintln!("sshub: sftp worker went away");
+        return Ok(1);
+    }
+
+    loop {
+        match rx.recv() {
+            Ok(SftpEvent::DirListing(_, _, entries)) => {
+                match fmt {
+                    parse::OutputFormat::Plain => {
+                        for e in &entries {
+                            println!("{}", e.name);
+                        }
+                    }
+                    parse::OutputFormat::Json => {
+                        let rows: Vec<LsEntryJson> = entries
+                            .iter()
+                            .map(|e| LsEntryJson {
+                                name: e.name.clone(),
+                                is_dir: e.is_dir,
+                                size: e.size,
+                            })
+                            .collect();
+                        println!("{}", serde_json::to_string_pretty(&rows)?);
+                    }
+                }
+                return Ok(0);
+            }
+            Ok(SftpEvent::Error(e)) => {
+                eprintln!("sshub: {e}");
+                return Ok(1);
+            }
+            Ok(_) => continue,
+            Err(_) => {
+                eprintln!("sshub: sftp worker went away");
+                return Ok(1);
+            }
+        }
+    }
+}
+
+/// `sshub sftp get <host> <remote-path> [local-path] [--recursive]`
+fn cmd_get(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let recursive = parse::take_flag(&mut rest, "--recursive");
+    let pos = parse::positional(&rest);
+    let host = match pos.first() {
+        Some(h) => *h,
+        None => parse::usage("sftp get needs a <host> and <remote-path>"),
+    };
+    let remote = match pos.get(1) {
+        Some(r) => PathBuf::from(*r),
+        None => parse::usage("sftp get needs a <remote-path>"),
+    };
+    let base = remote
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| ".".to_string());
+    let local = pos
+        .get(2)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(".").join(&base));
+
+    let (tx, rx) = match connect_worker(ctx, host) {
+        Ok(v) => v,
+        Err(code) => return Ok(code),
+    };
+    let item = QueuedTransfer {
+        direction: Direction::Download,
+        src: remote,
+        dst: local,
+        name: base,
+        is_dir: recursive,
+    };
+    run_queue(&tx, &rx, item)
+}
+
+/// `sshub sftp put <host> <local-path> [remote-path] [--recursive]`
+fn cmd_put(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let recursive = parse::take_flag(&mut rest, "--recursive");
+    let pos = parse::positional(&rest);
+    let host = match pos.first() {
+        Some(h) => *h,
+        None => parse::usage("sftp put needs a <host> and <local-path>"),
+    };
+    let local = match pos.get(1) {
+        Some(l) => PathBuf::from(*l),
+        None => parse::usage("sftp put needs a <local-path>"),
+    };
+    let base = local
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| ".".to_string());
+    let remote = pos
+        .get(2)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(&base));
+    // A local directory is always transferred recursively; --recursive is also
+    // honoured so a caller can force it explicitly.
+    let is_dir = std::fs::metadata(&local)
+        .map(|m| m.is_dir())
+        .unwrap_or(false)
+        || recursive;
+
+    let (tx, rx) = match connect_worker(ctx, host) {
+        Ok(v) => v,
+        Err(code) => return Ok(code),
+    };
+    let item = QueuedTransfer {
+        direction: Direction::Upload,
+        src: local,
+        dst: remote,
+        name: base,
+        is_dir,
+    };
+    run_queue(&tx, &rx, item)
+}
+
+/// Send a single-item queue and block until `QueueDone`, aggregating any
+/// per-transfer `Error` events. Returns exit 1 if any error was reported.
+fn run_queue(
+    tx: &Sender<SftpCommand>,
+    rx: &Receiver<SftpEvent>,
+    item: QueuedTransfer,
+) -> Result<i32> {
+    if tx.send(SftpCommand::RunQueue(vec![item])).is_err() {
+        eprintln!("sshub: sftp worker went away");
+        return Ok(1);
+    }
+    let mut had_err = false;
+    loop {
+        match rx.recv() {
+            Ok(SftpEvent::QueueDone) => break,
+            Ok(SftpEvent::Error(e)) => {
+                eprintln!("sshub: {e}");
+                had_err = true;
+            }
+            Ok(_) => continue,
+            Err(_) => {
+                eprintln!("sshub: sftp worker went away");
+                return Ok(1);
+            }
+        }
+    }
+    Ok(if had_err { 1 } else { 0 })
+}
+
+/// `sshub sftp rm <host> <remote-path> [--recursive] [--yes]`
+///
+/// DESTRUCTIVE. With `--recursive` the whole subtree is deleted and there is no
+/// undo, so the operation is refused unless `--yes` confirms it.
+fn cmd_rm(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let mut rest = args.to_vec();
+    let recursive = parse::take_flag(&mut rest, "--recursive");
+    let yes = parse::take_flag(&mut rest, parse::CONFIRM_YES);
+    let pos = parse::positional(&rest);
+    let host = match pos.first() {
+        Some(h) => *h,
+        None => parse::usage("sftp rm needs a <host> and <remote-path>"),
+    };
+    let remote = match pos.get(1) {
+        Some(r) => PathBuf::from(*r),
+        None => parse::usage("sftp rm needs a <remote-path>"),
+    };
+    // Deleting a tree is irreversible: demand explicit confirmation.
+    if !yes {
+        parse::fail_code("sftp rm is destructive; pass --yes to confirm", 1);
+    }
+
+    let (tx, rx) = match connect_worker(ctx, host) {
+        Ok(v) => v,
+        Err(code) => return Ok(code),
+    };
+    if tx.send(SftpCommand::Remove(remote, recursive)).is_err() {
+        eprintln!("sshub: sftp worker went away");
+        return Ok(1);
+    }
+    run_op(&rx)
+}
+
+/// `sshub sftp mkdir <host> <remote-path>`
+fn cmd_mkdir(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let pos = parse::positional(args);
+    let host = match pos.first() {
+        Some(h) => *h,
+        None => parse::usage("sftp mkdir needs a <host> and <remote-path>"),
+    };
+    let remote = match pos.get(1) {
+        Some(r) => PathBuf::from(*r),
+        None => parse::usage("sftp mkdir needs a <remote-path>"),
+    };
+
+    let (tx, rx) = match connect_worker(ctx, host) {
+        Ok(v) => v,
+        Err(code) => return Ok(code),
+    };
+    if tx.send(SftpCommand::Mkdir(remote)).is_err() {
+        eprintln!("sshub: sftp worker went away");
+        return Ok(1);
+    }
+    run_op(&rx)
+}
+
+/// `sshub sftp rename <host> <from> <to>`
+fn cmd_rename(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let pos = parse::positional(args);
+    let host = match pos.first() {
+        Some(h) => *h,
+        None => parse::usage("sftp rename needs a <host>, <from> and <to>"),
+    };
+    let from = match pos.get(1) {
+        Some(f) => PathBuf::from(*f),
+        None => parse::usage("sftp rename needs a <from> path"),
+    };
+    let to = match pos.get(2) {
+        Some(t) => PathBuf::from(*t),
+        None => parse::usage("sftp rename needs a <to> path"),
+    };
+
+    let (tx, rx) = match connect_worker(ctx, host) {
+        Ok(v) => v,
+        Err(code) => return Ok(code),
+    };
+    if tx.send(SftpCommand::Rename(from, to)).is_err() {
+        eprintln!("sshub: sftp worker went away");
+        return Ok(1);
+    }
+    run_op(&rx)
+}
+
+/// `sshub sftp chmod <host> <mode> <remote-path>` (`mode` is an octal string).
+fn cmd_chmod(ctx: &CliContext, args: &[String]) -> Result<i32> {
+    let pos = parse::positional(args);
+    let host = match pos.first() {
+        Some(h) => *h,
+        None => parse::usage("sftp chmod needs a <host>, <mode> and <remote-path>"),
+    };
+    let mode_str = match pos.get(1) {
+        Some(m) => *m,
+        None => parse::usage("sftp chmod needs an octal <mode>"),
+    };
+    let remote = match pos.get(2) {
+        Some(r) => PathBuf::from(*r),
+        None => parse::usage("sftp chmod needs a <remote-path>"),
+    };
+    let mode = match u32::from_str_radix(mode_str, 8) {
+        Ok(m) => m,
+        Err(_) => parse::usage(&format!("invalid octal mode '{mode_str}'")),
+    };
+
+    let (tx, rx) = match connect_worker(ctx, host) {
+        Ok(v) => v,
+        Err(code) => return Ok(code),
+    };
+    if tx.send(SftpCommand::Chmod(remote, mode)).is_err() {
+        eprintln!("sshub: sftp worker went away");
+        return Ok(1);
+    }
+    run_op(&rx)
+}
+
+/// Block until a remote op reports `OpDone` (success) or `Error` (failure).
+fn run_op(rx: &Receiver<SftpEvent>) -> Result<i32> {
+    loop {
+        match rx.recv() {
+            Ok(SftpEvent::OpDone) => return Ok(0),
+            Ok(SftpEvent::Error(e)) => {
+                eprintln!("sshub: {e}");
+                return Ok(1);
+            }
+            Ok(_) => continue,
+            Err(_) => {
+                eprintln!("sshub: sftp worker went away");
+                return Ok(1);
+            }
+        }
+    }
 }

--- a/src/cli/tunnel.rs
+++ b/src/cli/tunnel.rs
@@ -1,0 +1,343 @@
+//! Tunnel CLI subcommands.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::app::resolve_pending_secret_for_managed;
+use crate::cli::context::CliContext;
+use crate::cli::parse::{fail, fail_code, parse_format, take_flag, take_opt, OutputFormat};
+use crate::store::{NewTunnel, Tunnel, TunnelType};
+use crate::tunnel::{
+    ensure_tunnel_pid_dir, log_tunnel_reconnect_events, spawn_detached_tunnel,
+    stop_detached_tunnel, tunnel_data_dir, tunnel_runtime_state, TunnelManager,
+};
+
+pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    match args.first().map(String::as_str) {
+        Some("list") => cmd_list(ctx, &args[1..])?,
+        Some("show") => cmd_show(ctx, &args[1..])?,
+        Some("create") => cmd_create(ctx, &args[1..])?,
+        Some("delete") => cmd_delete(ctx, &args[1..])?,
+        Some("start") => cmd_start(ctx, &args[1..])?,
+        Some("stop") => cmd_stop(ctx, &args[1..])?,
+        Some(other) => {
+            fail(&format!(
+                "unknown tunnel subcommand '{other}' (try: list, show, create, delete, start, stop)"
+            ));
+        }
+        None => fail("tunnel requires a subcommand (list, show, create, delete, start, stop)"),
+    }
+    Ok(0)
+}
+
+fn cmd_list(ctx: &CliContext, args: &[String]) -> Result<()> {
+    let fmt = parse_format(args).map_err(anyhow::Error::msg)?;
+    let tunnels = ctx.store.list_tunnels()?;
+    let pid_dir = ensure_tunnel_pid_dir(&tunnel_data_dir()?)?;
+
+    let rows: Vec<TunnelListRow> = tunnels
+        .iter()
+        .map(|t| {
+            let host_name = t
+                .host_id
+                .and_then(|hid| ctx.store.get_host(hid).ok().flatten())
+                .map(|h| h.name)
+                .unwrap_or_else(|| "?".into());
+            let state = tunnel_runtime_state(t.id, t.local_port, &pid_dir);
+            TunnelListRow {
+                id: t.id,
+                label: t.label.clone(),
+                host: host_name,
+                tunnel_type: t.tunnel_type.label().to_string(),
+                local_port: t.local_port,
+                remote_host: t.remote_host.clone(),
+                remote_port: t.remote_port,
+                keep_alive: t.auto_connect,
+                state: state.as_str().to_string(),
+            }
+        })
+        .collect();
+
+    match fmt {
+        OutputFormat::Plain => {
+            for row in &rows {
+                let label = row.label.as_deref().unwrap_or("");
+                println!(
+                    "{}\t{}\t:{}\t{}\t{}",
+                    row.id, row.state, row.local_port, row.host, label
+                );
+            }
+        }
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&rows)?);
+        }
+    }
+    Ok(())
+}
+
+fn cmd_show(ctx: &CliContext, args: &[String]) -> Result<()> {
+    let fmt = parse_format(args).map_err(anyhow::Error::msg)?;
+    let token = positional_one(args, "show")?;
+    let tunnel = ctx.resolve_tunnel(token)?;
+    let pid_dir = ensure_tunnel_pid_dir(&tunnel_data_dir()?)?;
+    let state = tunnel_runtime_state(tunnel.id, tunnel.local_port, &pid_dir);
+    let host_name = tunnel
+        .host_id
+        .and_then(|hid| ctx.store.get_host(hid).ok().flatten())
+        .map(|h| h.name)
+        .unwrap_or_else(|| "?".into());
+
+    let row = TunnelShowRow {
+        id: tunnel.id,
+        label: tunnel.label.clone(),
+        host: host_name,
+        tunnel_type: tunnel.tunnel_type.label().to_string(),
+        local_port: tunnel.local_port,
+        remote_host: tunnel.remote_host.clone(),
+        remote_port: tunnel.remote_port,
+        keep_alive: tunnel.auto_connect,
+        state: state.as_str().to_string(),
+        created_at: tunnel.created_at,
+        updated_at: tunnel.updated_at,
+    };
+
+    match fmt {
+        OutputFormat::Plain => {
+            println!("id: {}", row.id);
+            if let Some(ref l) = row.label {
+                println!("label: {l}");
+            }
+            println!("host: {}", row.host);
+            println!("type: {}", row.tunnel_type);
+            println!("local_port: {}", row.local_port);
+            if tunnel.tunnel_type != TunnelType::Dynamic {
+                println!("remote: {}:{}", row.remote_host, row.remote_port);
+            }
+            println!("keep_alive: {}", row.keep_alive);
+            println!("state: {}", row.state);
+        }
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&row)?);
+        }
+    }
+    Ok(())
+}
+
+fn cmd_create(ctx: &mut CliContext, args: &[String]) -> Result<()> {
+    let mut a = args.to_vec();
+    let host_name =
+        take_opt(&mut a, "--host").ok_or_else(|| anyhow::anyhow!("--host is required"))?;
+    let tunnel_type =
+        parse_tunnel_type(&take_opt(&mut a, "--type").unwrap_or_else(|| "local".into()))?;
+    let local_port: u16 = take_opt(&mut a, "--local-port")
+        .ok_or_else(|| anyhow::anyhow!("--local-port is required"))?
+        .parse()
+        .context("invalid --local-port")?;
+    let remote_host = take_opt(&mut a, "--remote-host").unwrap_or_else(|| "localhost".into());
+    let remote_port: u16 = take_opt(&mut a, "--remote-port")
+        .unwrap_or_else(|| "0".into())
+        .parse()
+        .unwrap_or(0);
+    let label = take_opt(&mut a, "--label");
+    let keep_alive = take_flag(&mut a, "--keep-alive");
+
+    let managed = ctx.managed_host_by_name(&host_name)?;
+    let new = NewTunnel {
+        host_id: Some(managed.id),
+        tunnel_type,
+        local_port,
+        remote_host,
+        remote_port: if tunnel_type == TunnelType::Dynamic {
+            0
+        } else {
+            remote_port
+        },
+        label,
+        auto_connect: keep_alive,
+    };
+    let id = ctx.store.create_tunnel(&new)?;
+    println!("created tunnel {id} :{local_port}");
+    Ok(())
+}
+
+fn cmd_delete(ctx: &mut CliContext, args: &[String]) -> Result<()> {
+    let mut a = args.to_vec();
+    if !take_flag(&mut a, "--yes") {
+        fail_code("tunnel delete requires --yes", 1);
+    }
+    let token = positional_one(&a, "delete")?;
+    let tunnel = ctx.resolve_tunnel(token)?;
+    let data_dir = tunnel_data_dir()?;
+    let _ = stop_detached_tunnel(&data_dir, tunnel.id);
+    ctx.store.delete_tunnel(tunnel.id)?;
+    println!("deleted tunnel {}", tunnel.id);
+    Ok(())
+}
+
+fn cmd_start(ctx: &CliContext, args: &[String]) -> Result<()> {
+    let mut a = args.to_vec();
+    let foreground = take_flag(&mut a, "--foreground");
+    let token = positional_one(&a, "start")?;
+    let tunnel = ctx.resolve_tunnel(token)?;
+    let host = ctx.resolve_tunnel_host(&tunnel)?;
+    let (secret, _) = ctx.resolve_tunnel_secret(&host);
+    let label = tunnel.label.as_deref().unwrap_or("");
+    let host_name = host.name.as_str();
+
+    if foreground {
+        return run_foreground(ctx, &tunnel, &host, secret);
+    }
+
+    let data_dir = tunnel_data_dir()?;
+    let pid = spawn_detached_tunnel(&tunnel, &host, secret.as_ref(), &data_dir)?;
+    let _ = ctx.store.log_auth_event(
+        host_name,
+        None,
+        "tunnel",
+        "launched",
+        &format!("tunnel started (cli) :{} {label}", tunnel.local_port),
+        None,
+    );
+    println!(
+        "started tunnel {} pid {pid} :{}",
+        tunnel.id, tunnel.local_port
+    );
+    Ok(())
+}
+
+fn run_foreground(
+    ctx: &CliContext,
+    tunnel: &Tunnel,
+    host: &crate::store::ManagedHost,
+    secret: Option<crate::session::PendingSecret>,
+) -> Result<()> {
+    let cfg = ctx.config.tunnel_reconnect.clone();
+    let store = Arc::clone(&ctx.store);
+    let password_store = ctx.password_store.as_ref();
+    let host_name = host.name.clone();
+    let label = tunnel.label.clone().unwrap_or_default();
+    let local_port = tunnel.local_port;
+
+    let mut mgr = TunnelManager::new();
+    mgr.start(tunnel, Some(host), secret.as_ref())
+        .context("tunnel start failed")?;
+    let _ = store.log_auth_event(
+        &host_name,
+        None,
+        "tunnel",
+        "launched",
+        &format!("tunnel started (cli foreground) :{local_port} {label}"),
+        None,
+    );
+
+    loop {
+        let tunnels = vec![tunnel.clone()];
+        let health = mgr.check_health(&tunnels, &cfg);
+        log_tunnel_reconnect_events(&store, &health, &tunnels);
+
+        if mgr.is_gave_up(tunnel.id) {
+            fail_code(
+                &format!(
+                    "tunnel gave up: {}",
+                    mgr.error_detail(tunnel.id).unwrap_or("unknown error")
+                ),
+                1,
+            );
+        }
+
+        let reconnect = mgr.tick_reconnect(
+            &tunnels,
+            &cfg,
+            |host_id| store.get_host(host_id).ok().flatten(),
+            |h| resolve_pending_secret_for_managed(h, password_store).0,
+        );
+        log_tunnel_reconnect_events(&store, &reconnect, &tunnels);
+
+        if !mgr.has_child(tunnel.id)
+            && !mgr.is_reconnecting(tunnel.id)
+            && mgr.status(tunnel.id) == "stopped"
+        {
+            break;
+        }
+
+        std::thread::sleep(Duration::from_secs(1));
+    }
+    Ok(())
+}
+
+fn cmd_stop(ctx: &CliContext, args: &[String]) -> Result<()> {
+    let token = positional_one(args, "stop")?;
+    let tunnel = ctx.resolve_tunnel(token)?;
+    let data_dir = tunnel_data_dir()?;
+    let stopped = stop_detached_tunnel(&data_dir, tunnel.id)?;
+    let host_name = tunnel
+        .host_id
+        .and_then(|hid| ctx.store.get_host(hid).ok().flatten())
+        .map(|h| h.name)
+        .unwrap_or_else(|| "unknown".into());
+    if stopped {
+        let _ = ctx.store.log_auth_event(
+            &host_name,
+            None,
+            "tunnel",
+            "ok",
+            &format!("tunnel stopped (cli) :{}", tunnel.local_port),
+            None,
+        );
+        println!("stopped tunnel {}", tunnel.id);
+    } else {
+        println!("tunnel {} was not running", tunnel.id);
+    }
+    Ok(())
+}
+
+fn parse_tunnel_type(s: &str) -> Result<TunnelType> {
+    match s {
+        "local" | "L" => Ok(TunnelType::Local),
+        "remote" | "R" => Ok(TunnelType::Remote),
+        "dynamic" | "D" => Ok(TunnelType::Dynamic),
+        other => anyhow::bail!("unknown tunnel type '{other}'"),
+    }
+}
+
+fn positional_one<'a>(args: &'a [String], sub: &str) -> Result<&'a str> {
+    let pos: Vec<_> = args
+        .iter()
+        .filter(|a| !a.starts_with('-'))
+        .map(String::as_str)
+        .collect();
+    pos.first()
+        .copied()
+        .with_context(|| format!("tunnel {sub} requires an id, label, or local-port"))
+}
+
+#[derive(Serialize)]
+struct TunnelListRow {
+    id: i64,
+    label: Option<String>,
+    host: String,
+    tunnel_type: String,
+    local_port: u16,
+    remote_host: String,
+    remote_port: u16,
+    keep_alive: bool,
+    state: String,
+}
+
+#[derive(Serialize)]
+struct TunnelShowRow {
+    id: i64,
+    label: Option<String>,
+    host: String,
+    tunnel_type: String,
+    local_port: u16,
+    remote_host: String,
+    remote_port: u16,
+    keep_alive: bool,
+    state: String,
+    created_at: i64,
+    updated_at: i64,
+}

--- a/src/cli/tunnel.rs
+++ b/src/cli/tunnel.rs
@@ -256,11 +256,23 @@ fn run_foreground(
         );
         log_tunnel_reconnect_events(&store, &reconnect, &tunnels);
 
-        if !mgr.has_child(tunnel.id)
-            && !mgr.is_reconnecting(tunnel.id)
-            && mgr.status(tunnel.id) == "stopped"
-        {
-            break;
+        // Terminal states once the child is gone and no reconnect is pending.
+        // A keep-alive tunnel that exhausts its retries is caught by is_gave_up
+        // above; a non-keep-alive tunnel whose child dies lands in "error" with
+        // no reconnect, so we must exit here (nonzero) or the loop would spin
+        // forever waiting for a "stopped" that never comes.
+        if !mgr.has_child(tunnel.id) && !mgr.is_reconnecting(tunnel.id) {
+            match mgr.status(tunnel.id) {
+                "stopped" => break,
+                "error" => fail_code(
+                    &format!(
+                        "tunnel exited: {}",
+                        mgr.error_detail(tunnel.id).unwrap_or("unknown error")
+                    ),
+                    1,
+                ),
+                _ => {}
+            }
         }
 
         std::thread::sleep(Duration::from_secs(1));

--- a/src/hosts/crud.rs
+++ b/src/hosts/crud.rs
@@ -1,0 +1,80 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use crate::metadata::HostMetadata;
+use crate::ssh::SshHost;
+use crate::store::{LauncherStore, NewHost, NewIdentity};
+
+/// Duplicate a legacy ssh_config alias into a launcher-managed host.
+///
+/// May auto-create a matching identity when user/key fields are present.
+pub fn duplicate_legacy_to_launcher(
+    store: &LauncherStore,
+    host: &SshHost,
+    meta: &HostMetadata,
+) -> Result<String> {
+    let mut name = format!("{}-copy", host.name);
+    let mut suffix = 2u32;
+    while store.get_host_by_name(&name)?.is_some() {
+        name = format!("{}-copy-{}", host.name, suffix);
+        suffix += 1;
+    }
+
+    let address = host.hostname.clone().unwrap_or_else(|| host.name.clone());
+    let port = host.port.unwrap_or(22);
+
+    let mut new_host = NewHost::launcher(name.clone(), address);
+    new_host.port = port;
+    new_host.tags = meta.tags.clone();
+    new_host.notes = meta.description.clone();
+    new_host.proxy_jump = host.proxy_jump.clone();
+    new_host.forward_agent = host.forward_agent.unwrap_or(false);
+    new_host.remote_command = host.remote_command.clone();
+    new_host.session_logging = meta.session_logging;
+    new_host.transport = meta.transport;
+    new_host.identity_id = match_identity_for_ssh_host(store, host)?;
+    store.create_host(&new_host)?;
+    Ok(name)
+}
+
+/// Find or create an identity matching ssh `-G` user/key fields.
+pub fn match_identity_for_ssh_host(store: &LauncherStore, host: &SshHost) -> Result<Option<i64>> {
+    let user = host.user.as_deref();
+    let key = host.identity_file.as_deref();
+    if user.is_none() && key.is_none() {
+        return Ok(None);
+    }
+
+    for identity in store.list_identities()? {
+        let id_user = identity.username.as_deref();
+        let id_key = identity
+            .private_key
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned());
+        let matches = match (user, key) {
+            (Some(u), Some(k)) => id_user == Some(u) && id_key.as_deref() == Some(k),
+            (Some(u), None) => id_user == Some(u),
+            (None, Some(k)) => id_key.as_deref() == Some(k),
+            (None, None) => false,
+        };
+        if matches {
+            return Ok(Some(identity.id));
+        }
+    }
+
+    let mut identity_name = format!("{}-identity", host.name);
+    let mut suffix = 2u32;
+    while store.get_identity_by_name(&identity_name)?.is_some() {
+        identity_name = format!("{}-identity-{}", host.name, suffix);
+        suffix += 1;
+    }
+
+    let created = store.create_identity(&NewIdentity {
+        name: identity_name,
+        username: host.user.clone(),
+        private_key: key.map(PathBuf::from),
+        ..Default::default()
+    })?;
+    Ok(Some(created.id))
+}

--- a/src/hosts/loader.rs
+++ b/src/hosts/loader.rs
@@ -1,0 +1,54 @@
+use std::collections::HashSet;
+
+use anyhow::Result;
+
+use crate::app::HostEntry;
+use crate::metadata::MetadataStore;
+use crate::ssh::{sync_ssh_config_hosts, HostResolver};
+use crate::store::{HostSource, LauncherStore};
+
+/// Load the merged host list (launcher + ssh_config DB rows + legacy aliases).
+///
+/// Mirrors the host-loading portion of [`crate::app::App::reload_hosts`]:
+/// sync ssh_config rows, merge DB hosts, then append unresolved legacy aliases
+/// with metadata defaults applied.
+pub fn load_merged_hosts(
+    resolver: &dyn HostResolver,
+    store: &LauncherStore,
+    metadata: &dyn MetadataStore,
+) -> Result<Vec<HostEntry>> {
+    sync_ssh_config_hosts(resolver, store)?;
+
+    let launcher_hosts = store.list_hosts_filtered(Some(HostSource::Launcher))?;
+    let ssh_config_hosts = store.list_hosts_filtered(Some(HostSource::SshConfig))?;
+    let db_names: HashSet<String> = launcher_hosts
+        .iter()
+        .chain(ssh_config_hosts.iter())
+        .map(|h| h.name.clone())
+        .collect();
+
+    let mut hosts: Vec<HostEntry> = launcher_hosts
+        .into_iter()
+        .chain(ssh_config_hosts)
+        .map(HostEntry::from_managed)
+        .collect();
+
+    let config_names = resolver.list_hosts()?;
+    metadata.ensure_defaults(&config_names)?;
+
+    for name in config_names {
+        if db_names.contains(&name) {
+            continue;
+        }
+        let host = match resolver.resolve_host(&name) {
+            Ok(host) => host,
+            Err(_) => continue,
+        };
+        let meta = metadata
+            .get(&name)?
+            .unwrap_or_else(|| crate::metadata::HostMetadata::new(&name));
+        hosts.push(HostEntry::Legacy { host, meta });
+    }
+
+    Ok(hosts)
+}

--- a/src/hosts/mod.rs
+++ b/src/hosts/mod.rs
@@ -1,0 +1,5 @@
+pub mod crud;
+pub mod loader;
+
+pub use crud::{duplicate_legacy_to_launcher, match_identity_for_ssh_host};
+pub use loader::load_merged_hosts;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod app;
+pub mod cli;
 pub mod config;
 pub mod credentials;
+pub mod hosts;
 pub mod import;
 pub mod keybinds;
 pub mod launcher;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,10 +27,24 @@ fn main() -> Result<()> {
         return run_db(&args[1..]);
     }
 
+    if let Some(cmd) = args.first() {
+        if sshub::cli::is_subcommand(cmd) {
+            let code = run_cli(&args)?;
+            std::process::exit(code);
+        }
+    }
+
     if args.iter().any(|a| a == "--dry-run") {
         return Ok(());
     }
     sshub::run()
+}
+
+fn run_cli(args: &[String]) -> Result<i32> {
+    let cmd = args[0].as_str();
+    let rest = &args[1..];
+    let mut ctx = sshub::cli::CliContext::bootstrap()?;
+    sshub::cli::run_subcommand(&mut ctx, cmd, rest)
 }
 
 /// Handle `sshub db <subcommand>`.
@@ -82,19 +96,61 @@ fn print_help() {
         r#"sshub — SSHub TUI SSH host launcher
 
 USAGE:
-    sshub [OPTIONS]
-    sshub db purge [{CONFIRM_FLAG}]
+    sshub [OPTIONS]                         Launch TUI (default)
+    sshub <command> [args]                  Headless CLI subcommands
 
 OPTIONS:
     -h, --help              Print help
     -V, --version           Print version
         --dry-run           Exit immediately (smoke / CI)
-        {CONFIRM_FLAG}   Confirm a destructive command (e.g. db purge)
 
-COMMANDS:
-    db purge                Delete the launcher database (managed hosts, groups,
-                            identities, tunnels, audit log). Irreversible -
-                            requires {CONFIRM_FLAG}. Leaves ~/.ssh/config alone.
+HOST (read/write):
+    sshub host list [--tag TAG]... [--group GROUP] [--sort MODE] [--format plain|json]
+    sshub host show <name> [--format plain|json]
+    sshub host connect <name> [-v|--verbose]
+    sshub host resolve <name> [--format plain|json]
+    sshub host search <query> [--format plain|json]
+    sshub host add|edit|rename|delete|duplicate …
+
+ALIASES:
+    sshub connect <name>                    Same as `host connect`
+    sshub list …                            Same as `host list`
+
+GROUPS:
+    sshub group list [--all] [--format plain|json]
+    sshub group show <name> [--format plain|json]
+    sshub group add --name NAME [--parent GROUP] [--default-identity NAME] [--sort-order N]
+    sshub group edit --name NAME [--set-name …] [--set-parent …] [--clear-parent]
+                     [--set-default-identity …] [--clear-default-identity] [--set-sort-order N]
+    sshub group delete --name NAME --yes
+    sshub groups …                          Alias for `group list` (forwards flags)
+
+IDENTITIES:
+    sshub identity list|show|add|edit|delete|agent-remove …
+    sshub identity agent-remove --name NAME
+
+TUNNELS:
+    sshub tunnel list|show|create|delete|start|stop …
+
+SFTP (one-shot):
+    sshub sftp ls|get|put|rm|mkdir|rename|chmod …
+
+AUDIT:
+    sshub audit list|stats …
+
+INVENTORY / CONFIG:
+    sshub tags [--format plain|json]
+    sshub sync                              Refresh ssh_config rows in DB
+    sshub import                            Import ~/.ssh/config hosts
+    sshub export [--stdout] [-o PATH]       Export launcher hosts to ssh_config snippet
+    sshub db purge [{CONFIRM_FLAG}]
+
+COMPLETIONS:
+    sshub completions bash|zsh|fish [--cache PATH]
+
+DESTRUCTIVE CONFIRMATION:
+    Most delete commands require --yes
+    db purge requires {CONFIRM_FLAG} (irreversible database wipe)
 
 ENVIRONMENT:
     SSHUB_CONFIG_DIR          Override config directory (fallback: SSH_LAUNCHER_CONFIG_DIR)

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,21 @@ fn main() -> Result<()> {
 
     let args: Vec<String> = std::env::args().skip(1).collect();
 
+    // Subcommands must be handled before the global flags and the TUI launch
+    // path, so that `sshub <cmd> --help` reaches the subcommand's own help
+    // (via cli::run_subcommand) instead of the global `--help` below.
+    if args.first().map(String::as_str) == Some("db") {
+        return run_db(&args[1..]);
+    }
+
+    if let Some(cmd) = args.first() {
+        if sshub::cli::is_subcommand(cmd) {
+            let code = run_cli(&args)?;
+            std::process::exit(code);
+        }
+    }
+
+    // Global flags apply only when no subcommand was given.
     if args.iter().any(|a| a == "--help" || a == "-h") {
         print_help();
         return Ok(());
@@ -22,16 +37,7 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Subcommands must be handled before the TUI launch path.
-    if args.first().map(String::as_str) == Some("db") {
-        return run_db(&args[1..]);
-    }
-
     if let Some(cmd) = args.first() {
-        if sshub::cli::is_subcommand(cmd) {
-            let code = run_cli(&args)?;
-            std::process::exit(code);
-        }
         // A non-flag first arg that is neither `db` nor a known subcommand is a
         // usage error. The TUI takes no positional args, so falling through to
         // it would launch a full-screen app for a typo (and fail without a TTY).
@@ -101,7 +107,7 @@ fn run_db_purge(confirmed: bool) -> Result<()> {
 
 fn print_help() {
     println!(
-        r#"sshub — SSHub TUI SSH host launcher
+        r#"sshub - SSHub TUI SSH host launcher
 
 USAGE:
     sshub [OPTIONS]                         Launch TUI (default)

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,14 @@ fn main() -> Result<()> {
             let code = run_cli(&args)?;
             std::process::exit(code);
         }
+        // A non-flag first arg that is neither `db` nor a known subcommand is a
+        // usage error. The TUI takes no positional args, so falling through to
+        // it would launch a full-screen app for a typo (and fail without a TTY).
+        if !cmd.starts_with('-') {
+            eprintln!("sshub: unknown command '{cmd}'");
+            eprintln!("       run `sshub --help` for the command list");
+            std::process::exit(2);
+        }
     }
 
     if args.iter().any(|a| a == "--dry-run") {

--- a/src/session_log.rs
+++ b/src/session_log.rs
@@ -238,8 +238,98 @@ impl Drop for SessionLogWriter {
     }
 }
 
-/// Delete oldest `.log` files beyond `retention_files` in `host_dir`.
-pub fn prune_retention(host_dir: &Path, retention_files: usize) -> Result<()> {
+/// Allocate a fresh log file path for external session capture (e.g. `script(1)`).
+pub fn allocate_log_path(
+    base_dir: impl AsRef<Path>,
+    host_name: &str,
+    host_id: Option<i64>,
+) -> Result<PathBuf> {
+    let base_dir = base_dir.as_ref().to_path_buf();
+    let logs_root = base_dir.join("logs");
+    fs::create_dir_all(&logs_root)
+        .with_context(|| format!("create session logs dir {}", logs_root.display()))?;
+    secure_fs::restrict_dir(&logs_root);
+
+    let host_dir = logs_root.join(host_log_dir_name(host_name, host_id));
+    fs::create_dir_all(&host_dir)
+        .with_context(|| format!("create host log dir {}", host_dir.display()))?;
+    secure_fs::restrict_dir(&host_dir);
+
+    let (path, _file) = create_unique_log_file(&host_dir, 0)?;
+    Ok(path)
+}
+
+/// Wrap `inner_argv` in a platform `script(1)` invocation for session logging.
+///
+/// Returns `None` when `script` is unavailable or the OS has no supported wrapper.
+pub fn wrap_script_command(log_path: &Path, inner_argv: &[String]) -> Option<Vec<String>> {
+    if inner_argv.is_empty() {
+        return None;
+    }
+    script_binary()?;
+
+    let log = log_path.to_string_lossy().into_owned();
+
+    #[cfg(target_os = "linux")]
+    {
+        let inner = shell_join(inner_argv);
+        Some(vec![
+            "script".into(),
+            "-q".into(),
+            "-a".into(),
+            log,
+            "-c".into(),
+            inner,
+        ])
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let mut argv = vec!["script".into(), "-q".into(), log];
+        argv.extend(inner_argv.iter().cloned());
+        return Some(argv);
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = log;
+        None
+    }
+}
+
+fn script_binary() -> Option<&'static str> {
+    if std::process::Command::new("which")
+        .arg("script")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    {
+        Some("script")
+    } else {
+        None
+    }
+}
+
+fn shell_join(argv: &[String]) -> String {
+    argv.iter()
+        .map(|a| shell_quote(a))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote(s: &str) -> String {
+    if s.is_empty() {
+        return "''".into();
+    }
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '/')
+    {
+        return s.to_string();
+    }
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+fn prune_retention(host_dir: &Path, retention_files: usize) -> Result<()> {
     if retention_files == 0 {
         return Ok(());
     }

--- a/src/ssh/export.rs
+++ b/src/ssh/export.rs
@@ -26,7 +26,8 @@ pub fn export_launcher_hosts(store: &LauncherStore) -> Result<PathBuf> {
     export_launcher_hosts_to(store, &path)
 }
 
-fn render_launcher_hosts(store: &LauncherStore) -> Result<String> {
+/// Render launcher-native hosts as ssh_config text (no file write).
+pub fn render_launcher_hosts(store: &LauncherStore) -> Result<String> {
     let hosts = store.list_hosts_filtered(Some(HostSource::Launcher))?;
     let mut out = String::from(EXPORT_HEADER);
     for host in hosts {

--- a/src/ssh/host.rs
+++ b/src/ssh/host.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SshHost {
     pub name: String,
     pub hostname: Option<String>,

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -8,6 +8,7 @@ mod resolver;
 
 pub use export::{
     atomic_write_with_backup, export_launcher_hosts, export_launcher_hosts_to, exported_conf_path,
+    render_launcher_hosts,
 };
 pub use host::{
     build_mosh_alias_argv, build_mosh_argv, build_ssh_alias_argv, build_ssh_argv,

--- a/src/store/hosts.rs
+++ b/src/store/hosts.rs
@@ -748,25 +748,134 @@ impl LauncherStore {
 
     /// Count events by status for the last N days.
     pub fn auth_event_stats(&self, days: i64) -> Result<(i64, i64)> {
+        let (ok, fail, _) = self.auth_event_stats_filtered(days, None, false)?;
+        Ok((ok, fail))
+    }
+
+    /// CLI stats with optional via filter and retry bucket.
+    pub fn auth_event_stats_filtered(
+        &self,
+        days: i64,
+        via: Option<&str>,
+        include_retry: bool,
+    ) -> Result<(i64, i64, i64)> {
         let cutoff = now_ts() - days * 86400;
         self.with_conn(|conn| {
-            // A successful connect is logged as 'launched' (session started);
-            // 'ok' is kept for backward compatibility. Everything else is a
-            // failure.
+            let via_clause = via_filter_sql(via);
             let ok: i64 = conn.query_row(
-                "SELECT COUNT(*) FROM auth_events
-                 WHERE status IN ('ok', 'launched') AND created_at >= ?1",
+                &format!(
+                    "SELECT COUNT(*) FROM auth_events
+                     WHERE status IN ('ok', 'launched') AND created_at >= ?1{via_clause}"
+                ),
                 params![cutoff],
                 |row| row.get(0),
             )?;
             let fail: i64 = conn.query_row(
-                "SELECT COUNT(*) FROM auth_events
-                 WHERE status NOT IN ('ok', 'launched') AND created_at >= ?1",
+                &format!(
+                    "SELECT COUNT(*) FROM auth_events
+                     WHERE status NOT IN ('ok', 'launched', 'retry') AND created_at >= ?1{via_clause}"
+                ),
                 params![cutoff],
                 |row| row.get(0),
             )?;
-            Ok((ok, fail))
+            let retry = if include_retry {
+                conn.query_row(
+                    &format!(
+                        "SELECT COUNT(*) FROM auth_events
+                         WHERE status = 'retry' AND created_at >= ?1{via_clause}"
+                    ),
+                    params![cutoff],
+                    |row| row.get(0),
+                )?
+            } else {
+                0
+            };
+            Ok((ok, fail, retry))
         })
+    }
+
+    /// Extended audit list for CLI (`--via`, `--host`, status buckets).
+    pub fn list_auth_events_cli(
+        &self,
+        status: Option<&str>,
+        since: Option<i64>,
+        via: Option<&str>,
+        host_name: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<AuthEvent>> {
+        self.with_conn(|conn| {
+            let mut sql = String::from(
+                "SELECT id, host_name, username, via, status, note, log_path, created_at FROM auth_events",
+            );
+            let mut conds: Vec<String> = Vec::new();
+            if let Some(s) = status.filter(|s| *s != "all") {
+                conds.push(status_sql(s));
+            }
+            if since.is_some() {
+                conds.push("created_at >= ?".into());
+            }
+            if let Some(v) = via.filter(|v| *v != "all") {
+                match v {
+                    "connect" => conds.push("via NOT IN ('tunnel', 'agent')".into()),
+                    "tunnel" => conds.push("via = 'tunnel'".into()),
+                    "agent" => conds.push("via = 'agent'".into()),
+                    other => conds.push(format!("via = '{other}'")),
+                }
+            }
+            if host_name.is_some() {
+                conds.push("host_name = ?".into());
+            }
+            if !conds.is_empty() {
+                sql.push_str(" WHERE ");
+                sql.push_str(&conds.join(" AND "));
+            }
+            sql.push_str(" ORDER BY created_at DESC, id DESC LIMIT ?");
+
+            let mut bind: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+            if let Some(ts) = since {
+                bind.push(Box::new(ts));
+            }
+            if let Some(h) = host_name {
+                bind.push(Box::new(h.to_string()));
+            }
+            bind.push(Box::new(limit as i64));
+
+            let mut stmt = conn.prepare(&sql)?;
+            let refs: Vec<&dyn rusqlite::types::ToSql> = bind.iter().map(|b| b.as_ref()).collect();
+            let rows = stmt.query_map(refs.as_slice(), |row| {
+                Ok(AuthEvent {
+                    id: row.get(0)?,
+                    host_name: row.get(1)?,
+                    username: row.get(2)?,
+                    via: row.get(3)?,
+                    status: row.get(4)?,
+                    note: row.get(5)?,
+                    log_path: row.get(6)?,
+                    created_at: row.get(7)?,
+                })
+            })?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(Into::into)
+        })
+    }
+}
+
+fn status_sql(status: &str) -> String {
+    match status {
+        "ok" => "status IN ('ok', 'launched')".into(),
+        "fail" => "status NOT IN ('ok', 'launched', 'retry')".into(),
+        "retry" => "status = 'retry'".into(),
+        other => format!("status = '{other}'"),
+    }
+}
+
+fn via_filter_sql(via: Option<&str>) -> String {
+    match via {
+        None | Some("all") => String::new(),
+        Some("connect") => " AND via NOT IN ('tunnel', 'agent')".into(),
+        Some("tunnel") => " AND via = 'tunnel'".into(),
+        Some("agent") => " AND via = 'agent'".into(),
+        Some(v) => format!(" AND via = '{v}'"),
     }
 }
 

--- a/src/store/tunnels.rs
+++ b/src/store/tunnels.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 
 use super::migrate::now_ts;
 use super::types::{NewTunnel, Tunnel, TunnelType};
@@ -59,6 +59,57 @@ impl LauncherStore {
             Ok(affected > 0)
         })
     }
+
+    pub fn get_tunnel(&self, id: i64) -> Result<Option<Tunnel>> {
+        self.with_conn(|conn| {
+            conn.prepare(
+                "SELECT id, host_id, tunnel_type, local_port, remote_host, remote_port, label, auto_connect, created_at, updated_at
+                 FROM tunnels WHERE id = ?1",
+            )?
+            .query_row(params![id], row_to_tunnel)
+            .optional()
+            .map_err(Into::into)
+        })
+    }
+
+    pub fn find_tunnels_by_label(&self, label: &str) -> Result<Vec<Tunnel>> {
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, host_id, tunnel_type, local_port, remote_host, remote_port, label, auto_connect, created_at, updated_at
+                 FROM tunnels WHERE label = ?1",
+            )?;
+            let rows = stmt.query_map(params![label], row_to_tunnel)?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(Into::into)
+        })
+    }
+
+    pub fn find_tunnels_by_local_port(&self, port: u16) -> Result<Vec<Tunnel>> {
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, host_id, tunnel_type, local_port, remote_host, remote_port, label, auto_connect, created_at, updated_at
+                 FROM tunnels WHERE local_port = ?1",
+            )?;
+            let rows = stmt.query_map(params![port as i64], row_to_tunnel)?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(Into::into)
+        })
+    }
+}
+
+fn row_to_tunnel(row: &rusqlite::Row<'_>) -> rusqlite::Result<Tunnel> {
+    Ok(Tunnel {
+        id: row.get(0)?,
+        host_id: row.get(1)?,
+        tunnel_type: TunnelType::parse_db(row.get::<_, String>(2)?.as_str()),
+        local_port: u16::try_from(row.get::<_, i64>(3)?).unwrap_or(0),
+        remote_host: row.get(4)?,
+        remote_port: u16::try_from(row.get::<_, i64>(5)?).unwrap_or(0),
+        label: row.get(6)?,
+        auto_connect: row.get::<_, i64>(7)? != 0,
+        created_at: row.get(8)?,
+        updated_at: row.get(9)?,
+    })
 }
 
 #[cfg(test)]

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -168,6 +168,16 @@ fn help_lines() -> Vec<Line<'static>> {
         entry("s", "Open SSH session for this host (SFTP stays live)"),
         entry("Esc", "Disconnect · back to picker"),
         entry("", ""),
+        entry("[cli]", ""),
+        entry(
+            "",
+            "Headless CLI available: run  sshub --help  (or  sshub <cmd> --help)",
+        ),
+        entry(
+            "",
+            "for connect, tunnel, sftp, import/export from scripts (no TUI).",
+        ),
+        entry("", ""),
         entry("? / Shift+H", "Toggle this help screen"),
         entry("F2 / Ctrl+S", "Save form (rebindable)"),
         entry("Ctrl+K", "Edit keybindings (all actions)"),

--- a/src/tunnel/audit.rs
+++ b/src/tunnel/audit.rs
@@ -1,0 +1,59 @@
+use crate::store::{LauncherStore, Tunnel};
+
+use super::ReconnectEvent;
+
+/// Log tunnel reconnect lifecycle events to the auth audit table.
+pub fn log_tunnel_reconnect_events(
+    store: &LauncherStore,
+    events: &[ReconnectEvent],
+    tunnels: &[Tunnel],
+) {
+    for ev in events {
+        let tunnel = tunnels.iter().find(|t| t.id == ev.tunnel_id());
+        let (host_name, port, label) = tunnel
+            .map(|t| {
+                let name = t
+                    .host_id
+                    .and_then(|hid| store.get_host(hid).ok().flatten())
+                    .map(|h| h.name)
+                    .unwrap_or_else(|| "unknown".into());
+                (name, t.local_port, t.label.clone().unwrap_or_default())
+            })
+            .unwrap_or_else(|| ("unknown".into(), 0, String::new()));
+
+        match ev {
+            ReconnectEvent::Attempt { attempt, .. } => {
+                let _ = store.log_auth_event(
+                    &host_name,
+                    None,
+                    "tunnel",
+                    "retry",
+                    &format!("tunnel reconnecting :{port} {label} attempt {attempt}"),
+                    None,
+                );
+            }
+            ReconnectEvent::Reconnected { .. } => {
+                let _ = store.log_auth_event(
+                    &host_name,
+                    None,
+                    "tunnel",
+                    "launched",
+                    &format!("tunnel reconnected :{port} {label}"),
+                    None,
+                );
+            }
+            ReconnectEvent::GaveUp {
+                attempts, error, ..
+            } => {
+                let _ = store.log_auth_event(
+                    &host_name,
+                    None,
+                    "tunnel",
+                    "fail",
+                    &format!("tunnel gave up :{port} {label} after {attempts} attempts — {error}"),
+                    None,
+                );
+            }
+        }
+    }
+}

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -6,8 +6,19 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 
 use crate::config::{tunnel_backoff_delay, tunnel_failure_attempt, TunnelReconnectConfig};
-use crate::session::{askpass, PendingSecret};
-use crate::store::{ManagedHost, Tunnel, TunnelType};
+use crate::session::PendingSecret;
+use crate::store::{ManagedHost, Tunnel};
+
+pub mod audit;
+pub mod spawn;
+
+pub use audit::log_tunnel_reconnect_events;
+pub use spawn::{
+    build_tunnel_argv, ensure_tunnel_pid_dir, is_local_port_bound, is_pid_alive, kill_pid,
+    read_tunnel_pid, remove_tunnel_pid, spawn_detached_tunnel, splice_tunnel_ssh_options,
+    stage_tunnel_askpass, stop_detached_tunnel, tunnel_data_dir, tunnel_pid_path,
+    tunnel_runtime_state, write_tunnel_pid, TunnelRuntimeState,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReconnectEvent {
@@ -73,7 +84,7 @@ struct TunnelProcess {
     /// True until the child survives [`TunnelReconnectConfig::stable_secs`].
     proving: bool,
     stderr_tail: Arc<Mutex<String>>,
-    _askpass: Option<askpass::AskpassSecret>,
+    _askpass: Option<crate::session::askpass::AskpassSecret>,
 }
 
 pub struct TunnelManager {
@@ -110,62 +121,8 @@ impl TunnelManager {
             self.stop_process(tunnel.id)?;
         }
 
-        let mut args: Vec<String> = vec!["ssh".into(), "-N".into()];
-        splice_tunnel_ssh_options(&mut args, secret.is_some());
-
-        let flag = match tunnel.tunnel_type {
-            TunnelType::Local => "-L",
-            TunnelType::Remote => "-R",
-            TunnelType::Dynamic => "-D",
-        };
-
-        let spec = if tunnel.tunnel_type == TunnelType::Dynamic {
-            format!("{}", tunnel.local_port)
-        } else {
-            format!(
-                "{}:{}:{}",
-                tunnel.local_port, tunnel.remote_host, tunnel.remote_port
-            )
-        };
-
-        args.push(flag.into());
-        args.push(spec);
-
-        if let Some(host) = host {
-            if host.port != 22 {
-                args.push("-p".into());
-                args.push(host.port.to_string());
-            }
-            if let Some(ref jump) = host.proxy_jump {
-                if !jump.is_empty() {
-                    args.push("-J".into());
-                    args.push(jump.clone());
-                }
-            }
-            if host.forward_agent {
-                args.push("-A".into());
-            }
-            if let Some(ref identity) = host.identity {
-                if let Some(ref key) = identity.private_key {
-                    args.push("-i".into());
-                    args.push(key.to_string_lossy().into_owned());
-                }
-            }
-            let target = if let Some(ref username) = host.username {
-                format!("{}@{}", username, host.address)
-            } else if let Some(ref identity) = host.identity {
-                if let Some(ref u) = identity.username {
-                    format!("{}@{}", u, host.address)
-                } else {
-                    host.address.clone()
-                }
-            } else {
-                host.address.clone()
-            };
-            args.push(target);
-        } else {
-            anyhow::bail!("No host associated with tunnel");
-        }
+        let host = host.ok_or_else(|| anyhow::anyhow!("No host associated with tunnel"))?;
+        let args = build_tunnel_argv(tunnel, host, secret.is_some())?;
 
         let mut cmd = Command::new(&args[0]);
         cmd.args(&args[1..])
@@ -558,54 +515,6 @@ impl TunnelManager {
     }
 }
 
-/// Insert non-interactive ssh options after the `ssh` argv0. Background tunnels
-/// must never open `/dev/tty` for a password prompt — that writes over the TUI
-/// and steals mouse/keyboard input from crossterm.
-fn splice_tunnel_ssh_options(args: &mut Vec<String>, has_stored_secret: bool) {
-    if args.first().map(String::as_str) != Some("ssh") {
-        return;
-    }
-    let batchmode = if has_stored_secret {
-        "BatchMode=no"
-    } else {
-        "BatchMode=yes"
-    };
-    let mut opts = vec![
-        "-o".to_string(),
-        batchmode.to_string(),
-        "-o".to_string(),
-        "ConnectTimeout=30".to_string(),
-        "-o".to_string(),
-        "ServerAliveInterval=10".to_string(),
-        "-o".to_string(),
-        "ServerAliveCountMax=3".to_string(),
-        "-o".to_string(),
-        "TCPKeepAlive=yes".to_string(),
-    ];
-    if has_stored_secret {
-        opts.push("-o".to_string());
-        opts.push("StrictHostKeyChecking=accept-new".to_string());
-    }
-    for (i, opt) in opts.into_iter().enumerate() {
-        args.insert(1 + i, opt);
-    }
-}
-
-fn stage_tunnel_askpass(
-    cmd: &mut Command,
-    secret: Option<&PendingSecret>,
-) -> Result<Option<askpass::AskpassSecret>> {
-    let Some(secret) = secret else {
-        return Ok(None);
-    };
-    let exe = std::env::current_exe()?;
-    let guard = askpass::AskpassSecret::new(secret.value())?;
-    for (k, v) in guard.env(&exe) {
-        cmd.env(k, v);
-    }
-    Ok(Some(guard))
-}
-
 impl Drop for TunnelManager {
     fn drop(&mut self) {
         for (_, mut proc) in self.processes.drain() {
@@ -619,37 +528,6 @@ impl Drop for TunnelManager {
 mod tests {
     use super::*;
     use std::time::Duration;
-
-    #[test]
-    fn splice_tunnel_ssh_options_forces_batchmode_without_secret() {
-        let mut args = vec!["ssh".into(), "-N".into(), "host".into()];
-        splice_tunnel_ssh_options(&mut args, false);
-        assert!(args.windows(2).any(|w| w == ["-o", "BatchMode=yes"]));
-        assert!(!args.iter().any(|a| a.contains("accept-new")));
-    }
-
-    #[test]
-    fn splice_tunnel_ssh_options_allows_askpass_with_secret() {
-        let mut args = vec!["ssh".into(), "-N".into(), "host".into()];
-        splice_tunnel_ssh_options(&mut args, true);
-        assert!(args.windows(2).any(|w| w == ["-o", "BatchMode=no"]));
-        assert!(args
-            .windows(2)
-            .any(|w| w == ["-o", "StrictHostKeyChecking=accept-new"]));
-    }
-
-    #[test]
-    fn splice_tunnel_ssh_options_includes_keepalive() {
-        let mut args = vec!["ssh".into(), "-N".into(), "host".into()];
-        splice_tunnel_ssh_options(&mut args, false);
-        assert!(args
-            .windows(2)
-            .any(|w| w == ["-o", "ServerAliveInterval=10"]));
-        assert!(args
-            .windows(2)
-            .any(|w| w == ["-o", "ServerAliveCountMax=3"]));
-        assert!(args.windows(2).any(|w| w == ["-o", "TCPKeepAlive=yes"]));
-    }
 
     #[test]
     fn mark_user_stopped_clears_reconnect_state() {
@@ -685,7 +563,6 @@ mod tests {
             max_attempts: 2,
             ..Default::default()
         };
-        // After one recorded failure (attempt 1), the next start failure exhausts budget.
         mgr.schedule_reconnect(1, "err1", &cfg, 1);
         let ev = mgr.on_auto_start_failed(1, "err2", &cfg);
         assert!(matches!(

--- a/src/tunnel/spawn.rs
+++ b/src/tunnel/spawn.rs
@@ -1,0 +1,321 @@
+use std::fs;
+use std::io::Write;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result};
+
+use crate::config;
+use crate::secure_fs;
+use crate::session::{askpass, PendingSecret};
+use crate::store::{ManagedHost, Tunnel, TunnelType};
+
+/// Runtime liveness for CLI `tunnel list` / `show`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TunnelRuntimeState {
+    Running,
+    Stopped,
+    External,
+    Unknown,
+}
+
+impl TunnelRuntimeState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Stopped => "stopped",
+            Self::External => "external",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Build the full `ssh -N …` argv for a tunnel (without spawning).
+pub fn build_tunnel_argv(
+    tunnel: &Tunnel,
+    host: &ManagedHost,
+    has_stored_secret: bool,
+) -> Result<Vec<String>> {
+    let mut args: Vec<String> = vec!["ssh".into(), "-N".into()];
+    splice_tunnel_ssh_options(&mut args, has_stored_secret);
+
+    let flag = match tunnel.tunnel_type {
+        TunnelType::Local => "-L",
+        TunnelType::Remote => "-R",
+        TunnelType::Dynamic => "-D",
+    };
+
+    let spec = if tunnel.tunnel_type == TunnelType::Dynamic {
+        format!("{}", tunnel.local_port)
+    } else {
+        format!(
+            "{}:{}:{}",
+            tunnel.local_port, tunnel.remote_host, tunnel.remote_port
+        )
+    };
+
+    args.push(flag.into());
+    args.push(spec);
+
+    if host.port != 22 {
+        args.push("-p".into());
+        args.push(host.port.to_string());
+    }
+    if let Some(ref jump) = host.proxy_jump {
+        if !jump.is_empty() {
+            args.push("-J".into());
+            args.push(jump.clone());
+        }
+    }
+    if host.forward_agent {
+        args.push("-A".into());
+    }
+    if let Some(ref identity) = host.identity {
+        if let Some(ref key) = identity.private_key {
+            args.push("-i".into());
+            args.push(key.to_string_lossy().into_owned());
+        }
+    }
+    let target = if let Some(ref username) = host.username {
+        format!("{}@{}", username, host.address)
+    } else if let Some(ref identity) = host.identity {
+        if let Some(ref u) = identity.username {
+            format!("{}@{}", u, host.address)
+        } else {
+            host.address.clone()
+        }
+    } else {
+        host.address.clone()
+    };
+    args.push(target);
+    Ok(args)
+}
+
+/// Insert non-interactive ssh options after the `ssh` argv0. Background tunnels
+/// must never open `/dev/tty` for a password prompt — that writes over the TUI
+/// and steals mouse/keyboard input from crossterm.
+pub fn splice_tunnel_ssh_options(args: &mut Vec<String>, has_stored_secret: bool) {
+    if args.first().map(String::as_str) != Some("ssh") {
+        return;
+    }
+    let batchmode = if has_stored_secret {
+        "BatchMode=no"
+    } else {
+        "BatchMode=yes"
+    };
+    let mut opts = vec![
+        "-o".to_string(),
+        batchmode.to_string(),
+        "-o".to_string(),
+        "ConnectTimeout=30".to_string(),
+        "-o".to_string(),
+        "ServerAliveInterval=10".to_string(),
+        "-o".to_string(),
+        "ServerAliveCountMax=3".to_string(),
+        "-o".to_string(),
+        "TCPKeepAlive=yes".to_string(),
+    ];
+    if has_stored_secret {
+        opts.push("-o".to_string());
+        opts.push("StrictHostKeyChecking=accept-new".to_string());
+    }
+    for (i, opt) in opts.into_iter().enumerate() {
+        args.insert(1 + i, opt);
+    }
+}
+
+pub fn stage_tunnel_askpass(
+    cmd: &mut Command,
+    secret: Option<&PendingSecret>,
+) -> Result<Option<askpass::AskpassSecret>> {
+    let Some(secret) = secret else {
+        return Ok(None);
+    };
+    let exe = std::env::current_exe()?;
+    let guard = askpass::AskpassSecret::new(secret.value())?;
+    for (k, v) in guard.env(&exe) {
+        cmd.env(k, v);
+    }
+    Ok(Some(guard))
+}
+
+/// Ensure `data_dir/tunnels/` exists with owner-only permissions.
+pub fn ensure_tunnel_pid_dir(data_dir: &Path) -> Result<PathBuf> {
+    let dir = data_dir.join("tunnels");
+    fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+    secure_fs::restrict_dir(&dir);
+    Ok(dir)
+}
+
+pub fn tunnel_pid_path(pid_dir: &Path, tunnel_id: i64) -> PathBuf {
+    pid_dir.join(format!("{tunnel_id}.pid"))
+}
+
+pub fn read_tunnel_pid(path: &Path) -> Result<Option<u32>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let pid: u32 = raw
+        .trim()
+        .parse()
+        .with_context(|| format!("invalid pid in {}", path.display()))?;
+    Ok(Some(pid))
+}
+
+pub fn write_tunnel_pid(path: &Path, pid: u32) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+        secure_fs::restrict_dir(parent);
+    }
+    let mut f = fs::File::create(path).with_context(|| format!("create {}", path.display()))?;
+    write!(f, "{pid}")?;
+    secure_fs::restrict_file(path);
+    Ok(())
+}
+
+pub fn remove_tunnel_pid(path: &Path) -> Result<()> {
+    if path.exists() {
+        fs::remove_file(path).with_context(|| format!("remove {}", path.display()))?;
+    }
+    Ok(())
+}
+
+pub fn is_pid_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        unsafe { libc::kill(pid as i32, 0) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+pub fn kill_pid(pid: u32) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let rc = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+        if rc != 0 {
+            anyhow::bail!("failed to signal pid {pid}");
+        }
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        anyhow::bail!("tunnel stop is unsupported on this platform");
+    }
+}
+
+/// True when `127.0.0.1:port` is already bound (another listener).
+pub fn is_local_port_bound(port: u16) -> bool {
+    TcpListener::bind(("127.0.0.1", port)).is_err()
+}
+
+pub fn tunnel_runtime_state(tunnel_id: i64, local_port: u16, pid_dir: &Path) -> TunnelRuntimeState {
+    let pid_path = tunnel_pid_path(pid_dir, tunnel_id);
+    match read_tunnel_pid(&pid_path) {
+        Ok(Some(pid)) if is_pid_alive(pid) => return TunnelRuntimeState::Running,
+        Ok(Some(_)) => {
+            let _ = remove_tunnel_pid(&pid_path);
+        }
+        Ok(None) => {}
+        Err(_) => return TunnelRuntimeState::Unknown,
+    }
+    match TcpListener::bind(("127.0.0.1", local_port)) {
+        Err(_) => TunnelRuntimeState::External,
+        Ok(_) => TunnelRuntimeState::Stopped,
+    }
+}
+
+/// Spawn a detached tunnel child and record its PID under `data_dir/tunnels/`.
+pub fn spawn_detached_tunnel(
+    tunnel: &Tunnel,
+    host: &ManagedHost,
+    secret: Option<&PendingSecret>,
+    data_dir: &Path,
+) -> Result<u32> {
+    let pid_dir = ensure_tunnel_pid_dir(data_dir)?;
+    let pid_path = tunnel_pid_path(&pid_dir, tunnel.id);
+
+    if let Some(old_pid) = read_tunnel_pid(&pid_path)? {
+        if is_pid_alive(old_pid) {
+            anyhow::bail!("tunnel {} already running (pid {old_pid})", tunnel.id);
+        }
+        remove_tunnel_pid(&pid_path)?;
+    }
+
+    if is_local_port_bound(tunnel.local_port) {
+        anyhow::bail!("local port {} already in use", tunnel.local_port);
+    }
+
+    let args = build_tunnel_argv(tunnel, host, secret.is_some())?;
+    let mut cmd = Command::new(&args[0]);
+    cmd.args(&args[1..])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let _askpass = stage_tunnel_askpass(&mut cmd, secret)?;
+    let child = cmd.spawn().context("spawn tunnel ssh")?;
+    let pid = child.id();
+    write_tunnel_pid(&pid_path, pid)?;
+    Ok(pid)
+}
+
+/// Stop a CLI-detached tunnel via its PID file. Returns true when a live PID was signalled.
+pub fn stop_detached_tunnel(data_dir: &Path, tunnel_id: i64) -> Result<bool> {
+    let pid_dir = ensure_tunnel_pid_dir(data_dir)?;
+    let pid_path = tunnel_pid_path(&pid_dir, tunnel_id);
+    let Some(pid) = read_tunnel_pid(&pid_path)? else {
+        return Ok(false);
+    };
+    let was_live = is_pid_alive(pid);
+    if was_live {
+        kill_pid(pid)?;
+    }
+    remove_tunnel_pid(&pid_path)?;
+    Ok(was_live)
+}
+
+/// Resolved data directory for tunnel PID files.
+pub fn tunnel_data_dir() -> Result<PathBuf> {
+    config::data_dir()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splice_tunnel_ssh_options_forces_batchmode_without_secret() {
+        let mut args = vec!["ssh".into(), "-N".into(), "host".into()];
+        splice_tunnel_ssh_options(&mut args, false);
+        assert!(args.windows(2).any(|w| w == ["-o", "BatchMode=yes"]));
+        assert!(!args.iter().any(|a| a.contains("accept-new")));
+    }
+
+    #[test]
+    fn splice_tunnel_ssh_options_allows_askpass_with_secret() {
+        let mut args = vec!["ssh".into(), "-N".into(), "host".into()];
+        splice_tunnel_ssh_options(&mut args, true);
+        assert!(args.windows(2).any(|w| w == ["-o", "BatchMode=no"]));
+        assert!(args
+            .windows(2)
+            .any(|w| w == ["-o", "StrictHostKeyChecking=accept-new"]));
+    }
+
+    #[test]
+    fn pid_file_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = ensure_tunnel_pid_dir(tmp.path()).unwrap();
+        let path = tunnel_pid_path(&dir, 42);
+        write_tunnel_pid(&path, 12345).unwrap();
+        assert_eq!(read_tunnel_pid(&path).unwrap(), Some(12345));
+        remove_tunnel_pid(&path).unwrap();
+        assert_eq!(read_tunnel_pid(&path).unwrap(), None);
+    }
+}

--- a/src/tunnel/spawn.rs
+++ b/src/tunnel/spawn.rs
@@ -232,6 +232,13 @@ pub fn tunnel_runtime_state(tunnel_id: i64, local_port: u16, pid_dir: &Path) -> 
 }
 
 /// Spawn a detached tunnel child and record its PID under `data_dir/tunnels/`.
+///
+/// Known limitations (acceptable for the v1 CLI, single-user local use):
+/// - The stale-PID and port-bound checks are best-effort with no advisory
+///   lock, so two near-simultaneous `tunnel start <id>` invocations can race
+///   between the checks and the PID write and leak one ssh child.
+/// - PID liveness is a bare `kill(pid, 0)` with no start-time/identity check,
+///   so a recycled PID could read as alive (see also `stop_detached_tunnel`).
 pub fn spawn_detached_tunnel(
     tunnel: &Tunnel,
     host: &ManagedHost,
@@ -267,6 +274,11 @@ pub fn spawn_detached_tunnel(
 }
 
 /// Stop a CLI-detached tunnel via its PID file. Returns true when a live PID was signalled.
+///
+/// Known limitation: the PID file holds only a bare integer with no start-time
+/// or command identity, so in the rare case the OS recycled the recorded PID to
+/// an unrelated process this would signal that process. A future hardening would
+/// store and verify the process start time (Linux `/proc/<pid>/stat`).
 pub fn stop_detached_tunnel(data_dir: &Path, tunnel_id: i64) -> Result<bool> {
     let pid_dir = ensure_tunnel_pid_dir(data_dir)?;
     let pid_path = tunnel_pid_path(&pid_dir, tunnel_id);

--- a/tests/smoke/binary_starts.rs
+++ b/tests/smoke/binary_starts.rs
@@ -1,3 +1,4 @@
+mod cli_commands;
 mod resolver;
 mod run_app_quit;
 

--- a/tests/smoke/cli_commands.rs
+++ b/tests/smoke/cli_commands.rs
@@ -1,0 +1,128 @@
+//! Offline smoke tests for the hand-rolled CLI (`sshub <command>`).
+//!
+//! Every invocation runs against a fresh `tempfile::tempdir()` wired through
+//! `SSHUB_DATA_DIR` / `SSHUB_CONFIG_DIR` (and a fixture `SSHUB_SSH_CONFIG`) so the
+//! tests never touch the real user database, config, or `~/.ssh/config`. None of
+//! these commands reach the network, a TTY, or a live SSH host: they exercise
+//! argument parsing, per-command dispatch, and empty-database read paths only.
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+/// A fixture ssh_config so `host`/`tunnel` listing never reads the user's real
+/// `~/.ssh/config`. It is small and static, safe to resolve offline.
+fn fixture_ssh_config() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ssh_config")
+}
+
+/// Build a `sshub` command isolated to `dir` for data and config, with the SSH
+/// config pointed at the checked-in fixture. Callers append the subcommand args.
+fn sshub(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("sshub").unwrap();
+    cmd.env("SSHUB_DATA_DIR", dir)
+        .env("SSHUB_CONFIG_DIR", dir)
+        .env("SSHUB_SSH_CONFIG", fixture_ssh_config());
+    cmd
+}
+
+/// Fresh isolated data/config directory for one invocation.
+fn dir() -> TempDir {
+    tempfile::tempdir().unwrap()
+}
+
+#[test]
+fn unknown_command_exits_two() {
+    let d = dir();
+    sshub(d.path())
+        .arg("frobnicate")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("unknown command"));
+}
+
+#[test]
+fn audit_list_empty_exits_zero() {
+    let d = dir();
+    sshub(d.path()).args(["audit", "list"]).assert().success();
+}
+
+#[test]
+fn audit_stats_exits_zero_and_reports_ok() {
+    let d = dir();
+    sshub(d.path())
+        .args(["audit", "stats"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ok"));
+}
+
+#[test]
+fn audit_stats_include_retry_reports_retry() {
+    let d = dir();
+    sshub(d.path())
+        .args(["audit", "stats", "--include-retry"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("retry"));
+}
+
+#[test]
+fn audit_list_bogus_status_exits_two() {
+    let d = dir();
+    sshub(d.path())
+        .args(["audit", "list", "--status", "bogus"])
+        .assert()
+        .code(2);
+}
+
+#[test]
+fn host_list_exits_zero() {
+    let d = dir();
+    sshub(d.path()).args(["host", "list"]).assert().success();
+}
+
+#[test]
+fn tunnel_list_exits_zero() {
+    let d = dir();
+    sshub(d.path()).args(["tunnel", "list"]).assert().success();
+}
+
+#[test]
+fn sftp_without_subcommand_exits_two() {
+    let d = dir();
+    sshub(d.path()).arg("sftp").assert().code(2);
+}
+
+#[test]
+fn sftp_ls_without_host_exits_two() {
+    let d = dir();
+    sshub(d.path()).args(["sftp", "ls"]).assert().code(2);
+}
+
+#[test]
+fn audit_help_shows_per_command_help_not_global() {
+    let d = dir();
+    sshub(d.path())
+        .args(["audit", "--help"])
+        .assert()
+        .success()
+        // Unique to the per-command audit help; absent from the global `--help`.
+        .stdout(predicate::str::contains("inspect the connection audit log"))
+        .stdout(predicate::str::contains("stats"))
+        // Must NOT fall through to the global help header.
+        .stdout(predicate::str::contains("TUI SSH host launcher").not());
+}
+
+#[test]
+fn host_help_shows_per_command_help() {
+    let d = dir();
+    sshub(d.path())
+        .args(["host", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("manage launcher hosts"))
+        .stdout(predicate::str::contains("TUI SSH host launcher").not());
+}

--- a/tests/smoke/cli_commands.rs
+++ b/tests/smoke/cli_commands.rs
@@ -126,3 +126,110 @@ fn host_help_shows_per_command_help() {
         .stdout(predicate::str::contains("manage launcher hosts"))
         .stdout(predicate::str::contains("TUI SSH host launcher").not());
 }
+
+#[test]
+fn sync_exits_zero() {
+    let d = dir();
+    sshub(d.path()).arg("sync").assert().success();
+}
+
+#[test]
+fn tags_exits_zero() {
+    let d = dir();
+    sshub(d.path()).arg("tags").assert().success();
+}
+
+#[test]
+fn export_stdout_exits_zero() {
+    let d = dir();
+    sshub(d.path())
+        .args(["export", "--stdout"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn groups_exits_zero() {
+    let d = dir();
+    sshub(d.path()).arg("groups").assert().success();
+}
+
+#[test]
+fn group_list_exits_zero() {
+    let d = dir();
+    sshub(d.path()).args(["group", "list"]).assert().success();
+}
+
+#[test]
+fn identity_list_exits_zero() {
+    let d = dir();
+    sshub(d.path())
+        .args(["identity", "list"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn import_from_fixture_exits_zero() {
+    let d = dir();
+    // Importing from the fixture ssh_config: partial or no failures still exit 0.
+    sshub(d.path()).arg("import").assert().success();
+}
+
+#[test]
+fn completions_bash_prints_non_empty() {
+    let d = dir();
+    sshub(d.path())
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn completions_zsh_prints_non_empty() {
+    let d = dir();
+    sshub(d.path())
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn completions_fish_prints_non_empty() {
+    let d = dir();
+    sshub(d.path())
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn groups_all_forwards_flag_and_exits_zero() {
+    let d = dir();
+    // `groups --all` aliases to `group list --all`; the reserved-group filter
+    // still exits 0 on an empty database.
+    sshub(d.path()).args(["groups", "--all"]).assert().success();
+}
+
+#[test]
+fn host_delete_without_yes_exits_one() {
+    let d = dir();
+    // `--yes` is required before the host is even looked up, so a missing host
+    // without confirmation still exits 1.
+    sshub(d.path())
+        .args(["host", "delete", "--name", "doesnotexist"])
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn identity_delete_without_yes_exits_one() {
+    let d = dir();
+    sshub(d.path())
+        .args(["identity", "delete", "--name", "nope"])
+        .assert()
+        .code(1);
+}


### PR DESCRIPTION
Full headless CLI for issue #9: `sshub <command>` runs without the TUI.

Built and hardened in three phases (each a multi-agent workflow + orchestrator verification), landed as focused commits.

## Commands
- **host** list/show/connect/resolve/search/add/edit/rename/delete/duplicate (+ top-level aliases `connect`, `list`, `groups`)
- **group** CRUD, **identity** CRUD + agent-remove
- **tunnel** list/show/create/delete/start/stop (`start --foreground` with reconnect)
- **sftp** ls/get/put/rm/mkdir/rename/chmod (one-shot; ProxyJump rejected; `rm` needs `--yes`)
- **audit** list/stats (`--via connect|tunnel|agent`, `--include-retry`)
- **tags**, **sync**/**import**/**export**, **completions** bash|zsh|fish
- `--format plain|json` where applicable; per-command `--help`

Exit codes: `0` success, `1` operational failure, `2` usage/bad-flags. Destructive commands require `--yes` (`db purge` requires `--yes-i-am-stupid`).

## Refactors
- `src/tunnel.rs` -> `src/tunnel/{mod,spawn,audit}.rs`
- extracted `duplicate_legacy_to_launcher` -> `src/hosts/crud.rs`, `load_merged_hosts` -> `src/hosts/loader.rs`
- `main.rs` dispatch: subcommands before global flags / `--dry-run` / TUI; unknown command exits 2

## Review (phase 3)
Adversarial review across secrets, host-write, process-model, and inventory scopes plus verification of all 8 plan-critical items (7 honored; the tunnel TUI/CLI split is now documented). 11 findings confirmed and fixed, including:
- **security:** host names are now shell-escaped in generated completion scripts (were injectable when sourced)
- `host edit` no longer silently drops `--set-username`/`--set-os-icon`
- `tunnel start --foreground` no longer hangs after a non-keep-alive child dies
- legacy `host connect` now logs real username/via; empty stdin password and empty `--set-name` handled
Best-effort tunnel PID-file limitations (no advisory lock / PID recycling) are documented in code.

## Verification
`cargo build`, `cargo fmt --check`, `cargo clippy` clean (new code 0 warnings). Tests: 406 unit + 58 e2e + 36 smoke, all green.

Note: this PR includes interim openwiki CLI docs; the wiki will be regenerated separately (OpenWiki 0.2 OKF migration).

Closes #9 (issues do not auto-close against `development`; will close manually at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)