### PR TITLE
test: fix macOS CI flake from $HOME test race

### DIFF
--- a/src/app/tests/misc.rs
+++ b/src/app/tests/misc.rs
@@ -27,6 +27,7 @@ pub(crate) fn keyevent_to_spec_roundtrips() {
 
 #[test]
 pub(crate) fn pasted_key_material_is_written_to_a_file_on_save() {
+    let _home = crate::test_env::lock_home();
     let dir = tempfile::tempdir().unwrap();
     std::env::set_var("HOME", dir.path());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,6 +414,24 @@ fn install_panic_hook() {
 }
 
 #[cfg(test)]
+pub(crate) mod test_env {
+    use std::sync::{Mutex, MutexGuard};
+
+    /// Serializes tests that mutate the process-global `$HOME`. Environment
+    /// variables are shared across the whole test binary and cargo runs tests in
+    /// parallel, so concurrent setters corrupted each other's `$HOME` mid-test
+    /// (a flaky `keyfile`/`resolver` failure that surfaced on macOS). Hold the
+    /// returned guard for the entire test body.
+    static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    pub(crate) fn lock_home() -> MutexGuard<'static, ()> {
+        HOME_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::metadata::MetadataStore;

--- a/src/ssh/keyfile.rs
+++ b/src/ssh/keyfile.rs
@@ -251,6 +251,7 @@ mod tests {
 
     #[test]
     fn writes_key_with_owner_only_perms_and_dedups() {
+        let _home = crate::test_env::lock_home();
         let dir = tempfile::tempdir().unwrap();
         std::env::set_var("HOME", dir.path());
 

--- a/src/ssh/resolver.rs
+++ b/src/ssh/resolver.rs
@@ -287,11 +287,18 @@ mod tests {
 
     #[test]
     fn expand_tilde_replaces_home_prefix() {
+        let _home = crate::test_env::lock_home();
+        let prev = std::env::var_os("HOME");
         std::env::set_var("HOME", "/tmp/test-home");
         assert_eq!(
             expand_tilde("~/.ssh/config"),
             PathBuf::from("/tmp/test-home/.ssh/config")
         );
+        // Restore so this fixed value can't leak into other tests.
+        match prev {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`ssh::keyfile::tests::writes_key_with_owner_only_perms_and_dedups` intermittently fails on `macos-latest` CI (`assertion left == right failed` at `src/ssh/keyfile.rs:272`, the dedup `assert_eq!(p1, p2)`). It is not a regression from #26/#27 (neither touched `keyfile.rs`).

## Root cause

`write_key_material` reads the process-global `$HOME` on each call. Three unit tests mutate `$HOME` (`ssh/keyfile.rs`, `ssh/resolver.rs::expand_tilde_replaces_home_prefix`, `app/tests/misc.rs`) and cargo runs tests in parallel, so a concurrent setter could change `$HOME` between the keyfile test's two `write_key_material` calls, sending the second write to a different `~/.ssh` and breaking the dedup equality. macOS scheduling exposed the race. `expand_tilde_replaces_home_prefix` additionally set `$HOME=/tmp/test-home` permanently, leaking into other tests.

## Fix

- Add a shared `test_env::lock_home()` mutex (`src/lib.rs`) and acquire it in all three `$HOME`-mutating tests so they can't run concurrently.
- Restore the previous `$HOME` in the resolver test instead of leaving a fixed value behind.

Test-only; no product code changed. `cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test --lib` (428 passed) are green locally. The macOS CI check on this PR is the real confirmation.

_Written by Claude Opus 4.8 (Claude Code) on behalf of the maintainer._

🤖 Generated with [Claude Code](https://claude.com/claude-code)