### PR TITLE
feat: broadcast mode — run a command across a group/tag fleet (#3)

### DIFF
--- a/docs/superpowers/specs/2026-07-19-broadcast-mode-design.md
+++ b/docs/superpowers/specs/2026-07-19-broadcast-mode-design.md
@@ -32,9 +32,12 @@ this rides the existing thread + mpsc worker pattern (`ping`, `sftp`, `os-detect
   `ssh_argv_for_entry`, splice `ConnectTimeout` + `BatchMode`, append the remote
   command as the final argv, capture stdout+stderr+exit. Inherits `~/.ssh/config`,
   ProxyJump, agent. **No PTY.**
-- **Auth (v1):** key/agent only (`BatchMode=yes`); hosts needing a password fail
-  fast with a clear reason. Stored-password support (`SSH_ASKPASS` + `PendingSecret`,
-  same path detect uses) is **Phase 2**.
+- **Auth:** key/agent (`BatchMode=yes`) **and stored-password hosts** — the
+  password/passphrase is resolved per host at target-pick time (`resolve_pending_secret`,
+  the same path connect/detect use) and answered via `SSH_ASKPASS` + `PendingSecret`
+  with `BatchMode=no`. Hosts with neither a key/agent nor a stored secret fail fast.
+  (Stored-password was pulled forward from Phase 2 — real fleets are password-based,
+  so key/agent-only made the feature unusable in practice.)
 - **Concurrency:** bounded worker pool, default **8** concurrent; the rest queue.
   A single number, easy to make configurable later.
 - **Audit (lightweight):** each host result is written via the existing
@@ -215,9 +218,10 @@ Purely cosmetic — if `dur` elapsed, the panel is simply at `to`.
 
 ## Phasing
 
-- **Phase 1 (this spec):** menu selection, preview barrier, background pool
-  (key/agent, BatchMode), live docked panel + slide animation + focus/zoom,
-  countdown auto-dismiss, lightweight audit lines, cancel.
-- **Phase 2 (deferred):** stored-password hosts via `SSH_ASKPASS`/`PendingSecret`;
-  optionally full-output audit drill-down (new `broadcast_runs`/`_results`
-  tables) if ephemeral output proves too limiting; configurable concurrency.
+- **Phase 1 (shipped):** menu selection, preview barrier, background pool,
+  live docked panel + slide animation + focus/zoom, countdown auto-dismiss,
+  lightweight audit lines, cancel, and **key/agent + stored-password auth**
+  (SSH_ASKPASS, pulled forward from Phase 2).
+- **Phase 2 (deferred):** optionally full-output audit drill-down (new
+  `broadcast_runs`/`_results` tables) if ephemeral output proves too limiting;
+  configurable concurrency.

--- a/docs/superpowers/specs/2026-07-19-broadcast-mode-design.md
+++ b/docs/superpowers/specs/2026-07-19-broadcast-mode-design.md
@@ -1,0 +1,223 @@
+# Broadcast mode: run a command on multiple hosts (#3)
+
+## Problem
+
+Fleet chores (check disk, restart an agent, read a version) require connecting
+host by host. A broadcast run over a group or tag selection turns that into one
+action: pick targets, type one command, run it non-interactively on all of them
+concurrently, and read an aggregated result. The app has no async runtime, so
+this rides the existing thread + mpsc worker pattern (`ping`, `sftp`, `os-detect`).
+
+## Decisions (locked with user)
+
+- **Target selection:** pick **one group OR one tag from a menu** ("Broadcast
+  to:"). No per-host multi-select in v1; the dry-run preview offers `[e] edit
+  targets` to deselect individual hosts before running.
+- **Barrier before running:** command prompt -> **dry-run preview** listing the
+  full target set + the command -> `[y]` confirm / `[e]` edit targets / `[N]`
+  cancel. Protects against an accidental fleet-wide `reboot`/`rm`.
+- **Not a modal — a background job + live docked widget.** On `[y]`, the preview
+  overlay **slides with a short animation** (~250 ms, ease-out) from the center
+  into a corner of the dashboard body and becomes a live **Broadcast panel**. The
+  run executes in the background; the user can switch tabs and come back.
+- **Focus/zoom integration (#18).** The Broadcast panel joins the panel
+  focus-ring as `PanelId::Broadcast`. `Alt`+arrows focus it; `z` / `Alt+Enter`
+  zoom it full-screen to read per-host output (scroll, failures first).
+- **Completion -> countdown -> auto-dismiss.** When every host is done, a
+  countdown bar (default 5 s) runs along the bottom of the panel; when it elapses
+  the panel slides/fades out. **Focusing or zooming the panel pauses the
+  countdown**, so output being read is never yanked away.
+- **Transport:** `ssh` subprocess with `BatchMode`, reusing the exact
+  arg-splicing from `src/osinfo/detect.rs::SshProbeRunner` — take
+  `ssh_argv_for_entry`, splice `ConnectTimeout` + `BatchMode`, append the remote
+  command as the final argv, capture stdout+stderr+exit. Inherits `~/.ssh/config`,
+  ProxyJump, agent. **No PTY.**
+- **Auth (v1):** key/agent only (`BatchMode=yes`); hosts needing a password fail
+  fast with a clear reason. Stored-password support (`SSH_ASKPASS` + `PendingSecret`,
+  same path detect uses) is **Phase 2**.
+- **Concurrency:** bounded worker pool, default **8** concurrent; the rest queue.
+  A single number, easy to make configurable later.
+- **Audit (lightweight):** each host result is written via the existing
+  `store.log_auth_event(via = "broadcast", status, note = "<cmd> (exit N)")`, so
+  runs show up in the Audit tab as one line per host. **Full stdout/stderr is
+  ephemeral** (live panel only) — no new tables in v1. A full-output audit
+  drill-down is explicitly out of scope.
+- **Cancel:** since the job is backgrounded, a cancel key (`x`) on the focused/
+  zoomed Broadcast panel aborts pending tasks and kills in-flight `ssh`
+  children. Auto-dismiss handles the finished case.
+
+## Non-goals (v1)
+
+- Grouping hosts by identical output / diff view.
+- A saved command library (we remember only the **last** command for convenience).
+- Per-host timeout overrides beyond the global connect + run timeouts.
+- More than one broadcast run at a time (v1 runs one; starting a new one while
+  one is live is disallowed with a notice).
+
+## UX flow
+
+```
+hosts tab
+  b
+   -> "Broadcast to:"  (menu: groups + tags)
+        pick #prod
+   -> cmd> sudo systemctl restart nginx
+   -> preview overlay:
+        Run `sudo systemctl restart nginx` on 6 hosts (#prod):
+          web-prod, web-staging, cache-1, cache-2, db-01, lb-1
+        [y] confirm   [e] edit targets   [N] cancel
+   -> y
+        (preview slides to bottom-right corner, becomes Broadcast panel)
+
+Broadcast panel (live, docked, background):
+  ┌─ cast: systemctl restart nginx · #prod · 4/6 ─┐
+  │ ⏳ web-prod   running                          │
+  │ ✓  cache-1    exit 0                           │
+  │ ✗  db-01      exit 255  ssh: connect refused   │
+  │ …                                              │
+  └─ Alt+↑↓ focus · z zoom · x cancel ────────────┘
+
+  all done -> ▁▁▁▁▁ countdown 5s ▁▁▁▁▁ -> slides out
+  (per-host summary lines already in Audit tab)
+```
+
+## Architecture
+
+### New module: `src/broadcast/`
+
+`mod.rs` owns the worker pool and pure types. No UI, no `App` dependency —
+testable in isolation like `osinfo::detect`.
+
+```rust
+pub struct BroadcastTask {
+    pub host_id: i64,
+    pub host_name: String,
+    pub argv: Vec<String>,   // ssh_argv_for_entry(entry), argv[0] == "ssh"
+}
+
+pub enum HostState { Pending, Running, Done { exit: i32 }, Failed { reason: String } }
+
+pub struct HostResult {
+    pub host_id: i64,
+    pub host_name: String,
+    pub state: HostState,
+    pub stdout: String,      // captured, live-only (not persisted in v1)
+    pub stderr: String,
+}
+
+pub enum BroadcastEvent {
+    Started { host_id: i64 },
+    Finished { host_id: i64, exit: i32, stdout: String, stderr: String },
+    Failed { host_id: i64, reason: String },
+}
+
+/// Spawn a bounded pool. `runner` is abstracted (like ProbeRunner) so tests
+/// inject canned output without spawning ssh. `cancel` kills in-flight work.
+pub fn spawn_broadcast(
+    tasks: Vec<BroadcastTask>,
+    command: String,
+    concurrency: usize,
+    cancel: Arc<AtomicBool>,
+    runner: Arc<dyn CommandRunner>,
+) -> Receiver<BroadcastEvent>;
+
+pub trait CommandRunner: Send + Sync {
+    /// Run `argv` + remote `command`, return (exit, stdout, stderr) or an error
+    /// reason. Honors `cancel` and a per-host run timeout.
+    fn run(&self, argv: &[String], command: &str, cancel: &AtomicBool)
+        -> Result<(i32, String, String), String>;
+}
+```
+
+Pool shape: K worker threads pull `BroadcastTask`s from a shared
+`Arc<Mutex<mpsc::Receiver<BroadcastTask>>>`; each sends `BroadcastEvent`s back on
+one `mpsc::Sender<BroadcastEvent>`. The real `SshCommandRunner` mirrors
+`detect::SshProbeRunner` (BatchMode splice, ConnectTimeout, capture), plus a run
+timeout that kills the child so one hung host never holds a slot forever.
+
+### App state
+
+```rust
+struct BroadcastState {
+    target_label: String,        // "#prod" or "group: production"
+    command: String,
+    results: Vec<HostResult>,    // one per target, updated from events
+    rx: Receiver<BroadcastEvent>,
+    cancel: Arc<AtomicBool>,
+    concurrency: usize,
+    phase: BroadcastPhase,       // Running | Settling { done_at: Instant }
+    anim: Option<SlideAnim>,     // entry slide; None once settled in place
+}
+// App: broadcast: Option<BroadcastState>
+```
+
+New `AppMode` variants drive the pre-run overlay stages: `BroadcastPickTarget`,
+`BroadcastCommand`, `BroadcastPreview`. Once running, the mode returns to Normal
+and the panel lives on the dashboard (background job) — it is NOT a mode.
+
+### Event draining
+
+The 50 ms poll loop drains `broadcast.rx` each tick (same as ping/sftp), applying
+`BroadcastEvent -> HostResult` via a **pure reducer** (`apply_event`, unit-tested).
+`results` stays in a stable per-target order (one row per host, updated in
+place); **failures-first is a render-time sort of a view**, not a mutation of
+`results`. When all results are terminal, set `phase = Settling { done_at: now }`
+and start the countdown; write each host's `log_auth_event`. Focus/zoom of the
+panel clears `done_at` back to a paused state; leaving it re-arms with a fresh
+`done_at`.
+
+### Rendering
+
+`src/tui/screens/broadcast.rs`:
+- pre-run overlay stages (menu / prompt / preview) — modal popups, reuse the
+  existing popup + text-input widgets.
+- the docked panel — a corner-anchored `Rect` in the dashboard body, drawn over
+  the normal panels, but registered in the #18 focus-ring so `Alt`+arrows and
+  `z`/`Alt+Enter` reach it. Zoomed view reuses the #18 zoom scaffolding
+  (`zoom_window`, scroll, reverse-highlight, failures-first sort).
+- the countdown bar — a thin gauge along the panel bottom driven by
+  `done_at.elapsed() / DISMISS`.
+
+### Animation
+
+A small **general tween helper** (new; `animation.rs` today is only the startup
+splash and is not reusable). `SlideAnim { from: Rect, to: Rect, start: Instant,
+dur: Duration }` with an `ease_out` fn; `rect_at(now)` lerps the panel rect.
+Driven by the existing per-tick re-render (20 fps over ~250 ms = ~5 frames).
+Purely cosmetic — if `dur` elapsed, the panel is simply at `to`.
+
+## Error handling
+
+- Spawn failure / non-zero exit / run timeout -> `HostState::Failed` row with the
+  reason; never aborts the whole run.
+- Empty target (group/tag with no hosts) -> notice, no panel.
+- Starting a broadcast while one is live -> notice ("a broadcast is already
+  running"), refuse.
+- Cancel -> `cancel` flag set, in-flight children killed, pending tasks skipped;
+  remaining rows marked failed ("cancelled").
+- ssh binary missing -> first host's spawn error surfaces as its reason (same as
+  detect today).
+
+## Testing (offline, no real ssh)
+
+- **Pool** (`spawn_broadcast` + fake `CommandRunner`): concurrency is bounded,
+  every task yields exactly one terminal event, cancel stops pending work,
+  failures are reported not panicked.
+- **Reducer** (`apply_event`): pure `BroadcastEvent -> Vec<HostResult>` — running/
+  done/failed transitions update the right row in place; order stays stable.
+- **View sort**: the render-time failures-first ordering is a pure fn over
+  `&[HostResult]`.
+- **Tween** (`rect_at`): endpoints and monotonic interpolation.
+- **e2e (TestBackend):** `b` -> menu -> pick -> command -> preview -> confirm ->
+  panel renders with rows; a canned runner drives rows to done; countdown appears.
+- **Audit:** after a run, `list_auth_events` contains one `via = "broadcast"` row
+  per host with the right status + note.
+
+## Phasing
+
+- **Phase 1 (this spec):** menu selection, preview barrier, background pool
+  (key/agent, BatchMode), live docked panel + slide animation + focus/zoom,
+  countdown auto-dismiss, lightweight audit lines, cancel.
+- **Phase 2 (deferred):** stored-password hosts via `SSH_ASKPASS`/`PendingSecret`;
+  optionally full-output audit drill-down (new `broadcast_runs`/`_results`
+  tables) if ephemeral output proves too limiting; configurable concurrency.

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -39,9 +39,11 @@ impl App {
             self.host_notice = Some("A broadcast run is already in progress.".into());
             return;
         }
-        if self.broadcast.take().is_some() && self.focused_panel == PanelId::Broadcast {
-            self.focused_panel = PanelId::default();
-            self.panel_zoomed = false;
+        // A finished panel still on screen: send it off with the exit slide
+        // rather than yanking it, then open the wizard over it. tick_broadcast
+        // removes it once the slide ends.
+        if self.broadcast.is_some() {
+            self.slide_broadcast_out();
         }
 
         // `self.groups` is the real user-group list (the reserved Favorites
@@ -343,6 +345,31 @@ impl App {
         // to inspect output, which pauses the countdown as intended.
     }
 
+    /// Send the docked panel off with the exit slide (dock -> off the right
+    /// edge) and mark it `Leaving`; `tick_broadcast` removes it once the slide
+    /// finishes. Used both by the auto-dismiss countdown and by re-opening the
+    /// wizard over a finished panel. No-op if there's no panel.
+    fn slide_broadcast_out(&mut self) {
+        let body =
+            crate::tui::dashboard_layout::dashboard_layout_zoomed(self.terminal_area, self.ui_zoom)
+                .body;
+        if let Some(bc) = self.broadcast.as_mut() {
+            let dock = crate::tui::screens::broadcast::docked_rect(body);
+            let mut exit = dock;
+            exit.x = body.x + body.width; // fully off to the right
+            bc.anim = Some(crate::tui::tween::SlideAnim::new(
+                dock,
+                exit,
+                crate::broadcast::ENTRY_ANIM,
+            ));
+            bc.phase = BroadcastPhase::Leaving;
+        }
+        if self.focused_panel == PanelId::Broadcast {
+            self.focused_panel = PanelId::default();
+            self.panel_zoomed = false;
+        }
+    }
+
     /// Poll-loop step for a live run: drain worker events, fold them into the
     /// row table, retire the entry animation, arm the completion countdown,
     /// write the one-shot audit trail, and drive settle/pause/dismiss.
@@ -408,12 +435,10 @@ impl App {
         }
 
         // Pause the countdown while the panel is focused (zoom keeps it focused);
-        // resume it when focus leaves; once it elapses, play an exit slide
-        // (dock -> off the right edge) and remove the panel when it finishes.
+        // resume it when focus leaves; once it elapses, play the exit slide and
+        // remove the panel when the slide finishes.
         let focused = self.focused_panel == PanelId::Broadcast;
-        let body =
-            crate::tui::dashboard_layout::dashboard_layout_zoomed(self.terminal_area, self.ui_zoom)
-                .body;
+        let mut start_exit = false;
         let mut dismiss = false;
         if let Some(bc) = self.broadcast.as_mut() {
             match bc.phase {
@@ -421,15 +446,7 @@ impl App {
                     if focused {
                         bc.phase = BroadcastPhase::Paused;
                     } else if done_at.elapsed() >= crate::broadcast::DISMISS {
-                        let dock = crate::tui::screens::broadcast::docked_rect(body);
-                        let mut exit = dock;
-                        exit.x = body.x + body.width; // slide fully off to the right
-                        bc.anim = Some(crate::tui::tween::SlideAnim::new(
-                            dock,
-                            exit,
-                            crate::broadcast::ENTRY_ANIM,
-                        ));
-                        bc.phase = BroadcastPhase::Leaving;
+                        start_exit = true;
                     }
                 }
                 BroadcastPhase::Paused => {
@@ -438,13 +455,16 @@ impl App {
                     }
                 }
                 BroadcastPhase::Leaving => {
-                    // anim is cleared above once done; remove the panel then.
+                    // anim is retired above once done; remove the panel then.
                     if bc.anim.is_none() {
                         dismiss = true;
                     }
                 }
                 BroadcastPhase::Running => {}
             }
+        }
+        if start_exit {
+            self.slide_broadcast_out();
         }
         if dismiss {
             self.broadcast = None;

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -1,0 +1,409 @@
+//! Broadcast-mode app wiring (issue #3): the pre-run wizard (pick target →
+//! command → preview) and the live background run's tick/cancel plumbing.
+//!
+//! The pure fan-out engine (pool, reducer, view helpers) lives in
+//! [`crate::broadcast`]; this module is the `App`-facing glue: it builds the
+//! wizard state, resolves a target to managed-host candidates, spawns the run,
+//! drains its events each poll tick, folds them into the row table, writes one
+//! audit row per host at completion, and drives the settle/pause/dismiss
+//! lifecycle of the docked panel.
+
+use super::*;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+impl App {
+    /// Open the broadcast wizard from the hosts tab. Refuses while a run is live
+    /// (one at a time). Builds the target menu from every group plus the sorted,
+    /// deduped set of host tags; if there's nothing to target, surfaces a notice
+    /// and stays put.
+    pub(crate) fn open_broadcast(&mut self) {
+        if self.broadcast.is_some() {
+            self.host_notice = Some("A broadcast run is already in progress.".into());
+            return;
+        }
+
+        // `self.groups` is the real user-group list (the reserved Favorites
+        // group is deliberately kept out of it), matching the group-manage view.
+        let mut options: Vec<BroadcastTarget> = self
+            .groups
+            .iter()
+            .map(|g| BroadcastTarget::Group {
+                id: g.id,
+                label: g.name.clone(),
+            })
+            .collect();
+
+        let mut tags: Vec<String> = self
+            .hosts
+            .iter()
+            .flat_map(|h| h.tags().iter().cloned())
+            .collect();
+        tags.sort();
+        tags.dedup();
+        for name in tags {
+            options.push(BroadcastTarget::Tag { name });
+        }
+
+        if options.is_empty() {
+            self.host_notice = Some("No groups or tags to broadcast to.".into());
+            return;
+        }
+
+        self.broadcast_setup = Some(BroadcastSetup {
+            options,
+            menu_selected: 0,
+            target_label: String::new(),
+            command: String::new(),
+            cursor: 0,
+            candidates: Vec::new(),
+            preview_selected: 0,
+            edit_targets: false,
+        });
+        self.mode = AppMode::BroadcastPickTarget;
+    }
+
+    /// Stage 1: the target-pick menu. Up/Down move the highlight (clamped),
+    /// Enter resolves the highlighted target to candidates and advances to the
+    /// command prompt, Esc closes the wizard.
+    pub(crate) fn handle_key_broadcast_pick(&mut self, key: KeyEvent) -> Result<()> {
+        match key.code {
+            KeyCode::Esc => {
+                self.broadcast_setup = None;
+                self.mode = AppMode::Normal;
+            }
+            _ if self.is_action(KeyAction::MoveDown, &key) => {
+                if let Some(s) = self.broadcast_setup.as_mut() {
+                    if s.menu_selected + 1 < s.options.len() {
+                        s.menu_selected += 1;
+                    }
+                }
+            }
+            _ if self.is_action(KeyAction::MoveUp, &key) => {
+                if let Some(s) = self.broadcast_setup.as_mut() {
+                    s.menu_selected = s.menu_selected.saturating_sub(1);
+                }
+            }
+            KeyCode::Enter => {
+                self.resolve_broadcast_candidates();
+                self.mode = AppMode::BroadcastCommand;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Fill `candidates` from the highlighted target: managed hosts only, kept in
+    /// host-list order, each selected by default. Also derives the display
+    /// `target_label` shown in the prompt / panel header.
+    fn resolve_broadcast_candidates(&mut self) {
+        let target = match self
+            .broadcast_setup
+            .as_ref()
+            .and_then(|s| s.options.get(s.menu_selected))
+        {
+            Some(t) => t.clone(),
+            None => return,
+        };
+
+        let target_label = match &target {
+            BroadcastTarget::Group { label, .. } => format!("group: {label}"),
+            BroadcastTarget::Tag { name } => format!("#{name}"),
+        };
+
+        let candidates: Vec<BroadcastCandidate> = self
+            .hosts
+            .iter()
+            .filter_map(|entry| {
+                let host_id = entry.managed_id()?;
+                let matches = match &target {
+                    BroadcastTarget::Group { id, .. } => entry.group_ids().contains(id),
+                    BroadcastTarget::Tag { name } => entry.tags().iter().any(|t| t == name),
+                };
+                if !matches {
+                    return None;
+                }
+                Some(BroadcastCandidate {
+                    host_id,
+                    host_name: entry.name().to_string(),
+                    argv: ssh_argv_for_entry(entry),
+                    selected: true,
+                })
+            })
+            .collect();
+
+        if let Some(s) = self.broadcast_setup.as_mut() {
+            s.candidates = candidates;
+            s.target_label = target_label;
+            s.preview_selected = 0;
+        }
+    }
+
+    /// Stage 2: single-line command entry. Mirrors the SFTP prompt's text-input
+    /// idiom (char / backspace / cursor keys). Enter on a non-empty command
+    /// advances to the preview barrier; Esc steps back to the target picker.
+    pub(crate) fn handle_key_broadcast_command(&mut self, key: KeyEvent) -> Result<()> {
+        match key.code {
+            KeyCode::Esc => {
+                self.mode = AppMode::BroadcastPickTarget;
+            }
+            KeyCode::Enter => {
+                let nonempty = self
+                    .broadcast_setup
+                    .as_ref()
+                    .is_some_and(|s| !s.command.trim().is_empty());
+                if nonempty {
+                    if let Some(s) = self.broadcast_setup.as_mut() {
+                        s.preview_selected = 0;
+                        s.edit_targets = false;
+                    }
+                    self.mode = AppMode::BroadcastPreview;
+                }
+            }
+            KeyCode::Backspace if key.modifiers.is_empty() => {
+                if let Some(s) = self.broadcast_setup.as_mut() {
+                    s.cursor = text_input::backspace_at(&mut s.command, s.cursor);
+                }
+            }
+            KeyCode::Left | KeyCode::Right | KeyCode::Home | KeyCode::End | KeyCode::Delete => {
+                if let Some(s) = self.broadcast_setup.as_mut() {
+                    let mut cursor = s.cursor;
+                    text_input::handle_cursor_key(key.code, &mut s.command, &mut cursor);
+                    s.cursor = cursor;
+                }
+            }
+            KeyCode::Char(c)
+                if (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)
+                    && !c.is_control() =>
+            {
+                if let Some(s) = self.broadcast_setup.as_mut() {
+                    s.cursor = text_input::insert_at(&mut s.command, s.cursor, c);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Stage 3: the preview barrier. In edit-targets mode Up/Down move the row
+    /// cursor and Space toggles a host's inclusion (`e`/Esc exit edit mode).
+    /// Otherwise `y` starts the run, `e` enters edit mode, and `n`/`N`/Esc close
+    /// the wizard.
+    pub(crate) fn handle_key_broadcast_preview(&mut self, key: KeyEvent) -> Result<()> {
+        let editing = self
+            .broadcast_setup
+            .as_ref()
+            .is_some_and(|s| s.edit_targets);
+
+        if editing {
+            match key.code {
+                _ if self.is_action(KeyAction::MoveDown, &key) => {
+                    if let Some(s) = self.broadcast_setup.as_mut() {
+                        if s.preview_selected + 1 < s.candidates.len() {
+                            s.preview_selected += 1;
+                        }
+                    }
+                }
+                _ if self.is_action(KeyAction::MoveUp, &key) => {
+                    if let Some(s) = self.broadcast_setup.as_mut() {
+                        s.preview_selected = s.preview_selected.saturating_sub(1);
+                    }
+                }
+                KeyCode::Char(' ') => {
+                    if let Some(s) = self.broadcast_setup.as_mut() {
+                        let idx = s.preview_selected;
+                        if let Some(c) = s.candidates.get_mut(idx) {
+                            c.selected = !c.selected;
+                        }
+                    }
+                }
+                KeyCode::Char('e') | KeyCode::Esc => {
+                    if let Some(s) = self.broadcast_setup.as_mut() {
+                        s.edit_targets = false;
+                    }
+                }
+                _ => {}
+            }
+        } else {
+            match key.code {
+                KeyCode::Char('y') => self.start_broadcast(),
+                KeyCode::Char('e') => {
+                    if let Some(s) = self.broadcast_setup.as_mut() {
+                        s.edit_targets = true;
+                    }
+                }
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                    self.broadcast_setup = None;
+                    self.mode = AppMode::Normal;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// Launch the run: turn the selected candidates into tasks, spawn the pool,
+    /// seed the result table, arm the entry slide (spawn → docked), and hand off
+    /// to the background panel. Refuses (notice + close) when nothing is
+    /// selected.
+    fn start_broadcast(&mut self) {
+        let Some(setup) = self.broadcast_setup.take() else {
+            return;
+        };
+
+        let tasks: Vec<crate::broadcast::BroadcastTask> = setup
+            .candidates
+            .iter()
+            .filter(|c| c.selected)
+            .map(|c| crate::broadcast::BroadcastTask {
+                host_id: c.host_id,
+                host_name: c.host_name.clone(),
+                argv: c.argv.clone(),
+            })
+            .collect();
+
+        if tasks.is_empty() {
+            self.host_notice = Some("No hosts selected for broadcast.".into());
+            self.mode = AppMode::Normal;
+            return;
+        }
+
+        let cancel = Arc::new(AtomicBool::new(false));
+        let rx = crate::broadcast::spawn_broadcast(
+            tasks.clone(),
+            setup.command.clone(),
+            crate::broadcast::DEFAULT_CONCURRENCY,
+            cancel.clone(),
+            Arc::new(crate::broadcast::SshCommandRunner::new()),
+        );
+        let results = crate::broadcast::seed_results(&tasks);
+
+        let body =
+            crate::tui::dashboard_layout::dashboard_layout_zoomed(self.terminal_area, self.ui_zoom)
+                .body;
+        let anim = Some(crate::tui::tween::SlideAnim::new(
+            crate::tui::screens::broadcast::spawn_rect(body),
+            crate::tui::screens::broadcast::docked_rect(body),
+            crate::broadcast::ENTRY_ANIM,
+        ));
+
+        self.broadcast = Some(BroadcastState {
+            target_label: setup.target_label,
+            command: setup.command,
+            results,
+            rx,
+            cancel,
+            concurrency: crate::broadcast::DEFAULT_CONCURRENCY,
+            phase: BroadcastPhase::Running,
+            anim,
+            audit_written: false,
+        });
+        self.broadcast_setup = None;
+        self.mode = AppMode::Normal;
+        self.focused_panel = PanelId::Broadcast;
+    }
+
+    /// Poll-loop step for a live run: drain worker events, fold them into the
+    /// row table, retire the entry animation, arm the completion countdown,
+    /// write the one-shot audit trail, and drive settle/pause/dismiss.
+    pub(crate) fn tick_broadcast(&mut self) -> Result<()> {
+        if self.broadcast.is_none() {
+            return Ok(());
+        }
+        // Capture the clock before the &mut borrows below (the phase timestamps
+        // read it, and the borrow checker won't let us call it mid-borrow).
+        let now = Instant::now();
+
+        // Drain the worker channel and fold each event into the result rows.
+        // Retire the entry slide once it finishes, and arm the countdown the
+        // first tick every row is terminal.
+        if let Some(bc) = self.broadcast.as_mut() {
+            let events: Vec<crate::broadcast::BroadcastEvent> =
+                std::iter::from_fn(|| bc.rx.try_recv().ok()).collect();
+            for ev in &events {
+                crate::broadcast::apply_event(&mut bc.results, ev);
+            }
+            if bc.anim.as_ref().is_some_and(|a| a.is_done(now)) {
+                bc.anim = None;
+            }
+            if bc.phase == BroadcastPhase::Running && crate::broadcast::all_terminal(&bc.results) {
+                bc.phase = BroadcastPhase::Settling { done_at: now };
+            }
+        }
+
+        // Audit once, at completion. Split the borrow: gather rows while holding
+        // &mut self.broadcast, flip the guard, then drop the borrow before
+        // touching self.store.
+        let mut audit_rows: Vec<(String, String, String)> = Vec::new();
+        if let Some(bc) = self.broadcast.as_mut() {
+            if !bc.audit_written && crate::broadcast::all_terminal(&bc.results) {
+                for r in &bc.results {
+                    // Use the canonical audit status vocabulary so broadcast
+                    // rows integrate with the stats query, the Ok/Fail audit
+                    // filters, and theme::status_color: "launched" (green/Ok)
+                    // for a clean exit, "fail" (red/Fail) otherwise.
+                    let (status, note) = match &r.state {
+                        crate::broadcast::HostState::Done { exit } => {
+                            let status = if *exit == 0 { "launched" } else { "fail" };
+                            (
+                                status.to_string(),
+                                format!("{} (exit {})", bc.command, exit),
+                            )
+                        }
+                        crate::broadcast::HostState::Failed { reason } => {
+                            ("fail".to_string(), format!("{} ({})", bc.command, reason))
+                        }
+                        // Unreachable once all_terminal holds; stay total anyway.
+                        _ => continue,
+                    };
+                    audit_rows.push((r.host_name.clone(), status, note));
+                }
+                bc.audit_written = true;
+            }
+        }
+        for (host, status, note) in audit_rows {
+            let _ = self
+                .store
+                .log_auth_event(&host, None, "broadcast", &status, &note, None);
+        }
+
+        // Pause the countdown while the panel is focused (zoom keeps it focused);
+        // resume it when focus leaves; dismiss once it elapses.
+        let focused = self.focused_panel == PanelId::Broadcast;
+        let mut dismiss = false;
+        if let Some(bc) = self.broadcast.as_mut() {
+            match bc.phase {
+                BroadcastPhase::Settling { done_at } => {
+                    if focused {
+                        bc.phase = BroadcastPhase::Paused;
+                    } else if done_at.elapsed() >= crate::broadcast::DISMISS {
+                        dismiss = true;
+                    }
+                }
+                BroadcastPhase::Paused => {
+                    if !focused {
+                        bc.phase = BroadcastPhase::Settling { done_at: now };
+                    }
+                }
+                BroadcastPhase::Running => {}
+            }
+        }
+        if dismiss {
+            self.broadcast = None;
+            if self.focused_panel == PanelId::Broadcast {
+                self.focused_panel = PanelId::default();
+                self.panel_zoomed = false;
+            }
+        }
+        Ok(())
+    }
+
+    /// Signal the run to cancel: workers finish killing in-flight children and
+    /// mark the rest `Failed{cancelled}`, which `tick_broadcast` then folds in.
+    pub(crate) fn cancel_broadcast(&mut self) {
+        if let Some(bc) = &self.broadcast {
+            bc.cancel.store(true, Ordering::Relaxed);
+        }
+    }
+}

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -32,7 +32,13 @@ impl App {
                 || (e >= crate::broadcast::TOAST_TTL
                     && e < crate::broadcast::TOAST_TTL + crate::broadcast::TOAST_ANIM)
         });
-        panel || toasts
+        // Toasts falling into the freed space after the panel was dismissed.
+        let dropping = !self.broadcast_toasts.is_empty()
+            && self.broadcast.is_none()
+            && self
+                .broadcast_panel_gone_at
+                .is_some_and(|g| now.saturating_duration_since(g) < crate::broadcast::TOAST_ANIM);
+        panel || toasts || dropping
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live
@@ -348,6 +354,7 @@ impl App {
             audit_written: false,
         });
         self.broadcast_setup = None;
+        self.broadcast_panel_gone_at = None;
         self.mode = AppMode::Normal;
         // Deliberately do NOT focus the panel: it runs in the background and,
         // once finished, the countdown auto-dismisses it. Focusing here would
@@ -526,6 +533,8 @@ impl App {
         }
         if dismiss {
             self.broadcast = None;
+            // Stamp the moment so lingering toasts animate down into the space.
+            self.broadcast_panel_gone_at = Some(now);
             if self.focused_panel == PanelId::Broadcast {
                 self.focused_panel = PanelId::default();
                 self.panel_zoomed = false;

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -319,7 +319,11 @@ impl App {
         });
         self.broadcast_setup = None;
         self.mode = AppMode::Normal;
-        self.focused_panel = PanelId::Broadcast;
+        // Deliberately do NOT focus the panel: it runs in the background and,
+        // once finished, the countdown auto-dismisses it. Focusing here would
+        // immediately pause that countdown (focus == "user is reading it"), so
+        // the panel would never leave on its own. The user can Alt+arrow onto it
+        // to inspect output, which pauses the countdown as intended.
     }
 
     /// Poll-loop step for a live run: drain worker events, fold them into the

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -122,6 +122,7 @@ impl App {
             BroadcastTarget::Tag { name } => format!("#{name}"),
         };
 
+        let store = self.password_store.as_ref();
         let candidates: Vec<BroadcastCandidate> = self
             .hosts
             .iter()
@@ -134,10 +135,15 @@ impl App {
                 if !matches {
                     return None;
                 }
+                // Resolve a stored password/passphrase now (same path connect +
+                // detect use); threaded into the run so password hosts auth via
+                // SSH_ASKPASS instead of failing under BatchMode.
+                let secret = resolve_pending_secret(entry, store).0;
                 Some(BroadcastCandidate {
                     host_id,
                     host_name: entry.name().to_string(),
                     argv: ssh_argv_for_entry(entry),
+                    secret,
                     selected: true,
                 })
             })
@@ -271,6 +277,7 @@ impl App {
                 host_id: c.host_id,
                 host_name: c.host_name.clone(),
                 argv: c.argv.clone(),
+                secret: c.secret.clone(),
             })
             .collect();
 

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -29,9 +29,19 @@ impl App {
     /// deduped set of host tags; if there's nothing to target, surfaces a notice
     /// and stays put.
     pub(crate) fn open_broadcast(&mut self) {
-        if self.broadcast.is_some() {
+        // Only an actively-running fleet blocks a new one. A finished panel
+        // (settling / paused / leaving) is just dropped so you can fire again.
+        if self
+            .broadcast
+            .as_ref()
+            .is_some_and(|b| !crate::broadcast::all_terminal(&b.results))
+        {
             self.host_notice = Some("A broadcast run is already in progress.".into());
             return;
+        }
+        if self.broadcast.take().is_some() && self.focused_panel == PanelId::Broadcast {
+            self.focused_panel = PanelId::default();
+            self.panel_zoomed = false;
         }
 
         // `self.groups` is the real user-group list (the reserved Favorites
@@ -250,6 +260,13 @@ impl App {
                         s.edit_targets = true;
                     }
                 }
+                // Back to the command prompt to edit the command (targets kept).
+                KeyCode::Char('c') => {
+                    if let Some(s) = self.broadcast_setup.as_mut() {
+                        s.cursor = s.command.chars().count();
+                    }
+                    self.mode = AppMode::BroadcastCommand;
+                }
                 KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
                     self.broadcast_setup = None;
                     self.mode = AppMode::Normal;
@@ -391,8 +408,12 @@ impl App {
         }
 
         // Pause the countdown while the panel is focused (zoom keeps it focused);
-        // resume it when focus leaves; dismiss once it elapses.
+        // resume it when focus leaves; once it elapses, play an exit slide
+        // (dock -> off the right edge) and remove the panel when it finishes.
         let focused = self.focused_panel == PanelId::Broadcast;
+        let body =
+            crate::tui::dashboard_layout::dashboard_layout_zoomed(self.terminal_area, self.ui_zoom)
+                .body;
         let mut dismiss = false;
         if let Some(bc) = self.broadcast.as_mut() {
             match bc.phase {
@@ -400,12 +421,26 @@ impl App {
                     if focused {
                         bc.phase = BroadcastPhase::Paused;
                     } else if done_at.elapsed() >= crate::broadcast::DISMISS {
-                        dismiss = true;
+                        let dock = crate::tui::screens::broadcast::docked_rect(body);
+                        let mut exit = dock;
+                        exit.x = body.x + body.width; // slide fully off to the right
+                        bc.anim = Some(crate::tui::tween::SlideAnim::new(
+                            dock,
+                            exit,
+                            crate::broadcast::ENTRY_ANIM,
+                        ));
+                        bc.phase = BroadcastPhase::Leaving;
                     }
                 }
                 BroadcastPhase::Paused => {
                     if !focused {
                         bc.phase = BroadcastPhase::Settling { done_at: now };
+                    }
+                }
+                BroadcastPhase::Leaving => {
+                    // anim is cleared above once done; remove the panel then.
+                    if bc.anim.is_none() {
+                        dismiss = true;
                     }
                 }
                 BroadcastPhase::Running => {}

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -14,6 +14,16 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 impl App {
+    /// True while the broadcast panel's entry slide is still playing. The main
+    /// loop polls at a higher frame rate while this holds so the ~350ms slide
+    /// looks smooth instead of stepping at the idle 20fps poll cadence.
+    pub(crate) fn animating(&self) -> bool {
+        self.broadcast
+            .as_ref()
+            .and_then(|b| b.anim)
+            .is_some_and(|a| !a.is_done(Instant::now()))
+    }
+
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live
     /// (one at a time). Builds the target menu from every group plus the sorted,
     /// deduped set of host tags; if there's nothing to target, surfaces a notice
@@ -218,7 +228,8 @@ impl App {
                         }
                     }
                 }
-                KeyCode::Char('e') | KeyCode::Esc => {
+                // "done" — leave edit mode back to the [y]/[e]/[N] barrier.
+                KeyCode::Enter | KeyCode::Char('e') | KeyCode::Esc => {
                     if let Some(s) = self.broadcast_setup.as_mut() {
                         s.edit_targets = false;
                     }

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -417,12 +417,14 @@ impl App {
                         stderr,
                         ..
                     } if *exit != 0 => {
-                        let t = stderr
-                            .lines()
-                            .map(str::trim)
-                            .find(|l| !l.is_empty())
-                            .map(str::to_string)
-                            .unwrap_or_else(|| format!("exit {exit}"));
+                        // Full stderr (trimmed) so the toast can show the whole
+                        // error, not just its first line.
+                        let s = stderr.trim();
+                        let t = if s.is_empty() {
+                            format!("exit {exit}")
+                        } else {
+                            s.to_string()
+                        };
                         (*host_id, t)
                     }
                     crate::broadcast::BroadcastEvent::Failed { host_id, reason } => {

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -18,10 +18,21 @@ impl App {
     /// loop polls at a higher frame rate while this holds so the ~350ms slide
     /// looks smooth instead of stepping at the idle 20fps poll cadence.
     pub(crate) fn animating(&self) -> bool {
-        self.broadcast
+        let now = Instant::now();
+        let panel = self
+            .broadcast
             .as_ref()
             .and_then(|b| b.anim)
-            .is_some_and(|a| !a.is_done(Instant::now()))
+            .is_some_and(|a| !a.is_done(now));
+        // A toast is animating during its slide-in (first TOAST_ANIM) or its
+        // slide-out (the TOAST_ANIM after TOAST_TTL).
+        let toasts = self.broadcast_toasts.iter().any(|t| {
+            let e = now.saturating_duration_since(t.born);
+            e < crate::broadcast::TOAST_ANIM
+                || (e >= crate::broadcast::TOAST_TTL
+                    && e < crate::broadcast::TOAST_TTL + crate::broadcast::TOAST_ANIM)
+        });
+        panel || toasts
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live
@@ -374,21 +385,62 @@ impl App {
     /// row table, retire the entry animation, arm the completion countdown,
     /// write the one-shot audit trail, and drive settle/pause/dismiss.
     pub(crate) fn tick_broadcast(&mut self) -> Result<()> {
-        if self.broadcast.is_none() {
-            return Ok(());
-        }
         // Capture the clock before the &mut borrows below (the phase timestamps
         // read it, and the borrow checker won't let us call it mid-borrow).
         let now = Instant::now();
 
+        // Expire error toasts whose slide-out has finished. Runs even with no
+        // live panel — a 10s toast can outlive the 6.5s panel.
+        self.broadcast_toasts.retain(|t| {
+            t.born.elapsed() < crate::broadcast::TOAST_TTL + crate::broadcast::TOAST_ANIM
+        });
+
+        if self.broadcast.is_none() {
+            return Ok(());
+        }
+
         // Drain the worker channel and fold each event into the result rows.
-        // Retire the entry slide once it finishes, and arm the countdown the
-        // first tick every row is terminal.
+        // Retire the entry slide once it finishes, arm the countdown the first
+        // tick every row is terminal, and spawn a toast per failed host.
+        let mut new_toasts: Vec<BroadcastToast> = Vec::new();
         if let Some(bc) = self.broadcast.as_mut() {
             let events: Vec<crate::broadcast::BroadcastEvent> =
                 std::iter::from_fn(|| bc.rx.try_recv().ok()).collect();
             for ev in &events {
                 crate::broadcast::apply_event(&mut bc.results, ev);
+            }
+            for ev in &events {
+                let (host_id, text) = match ev {
+                    crate::broadcast::BroadcastEvent::Finished {
+                        host_id,
+                        exit,
+                        stderr,
+                        ..
+                    } if *exit != 0 => {
+                        let t = stderr
+                            .lines()
+                            .map(str::trim)
+                            .find(|l| !l.is_empty())
+                            .map(str::to_string)
+                            .unwrap_or_else(|| format!("exit {exit}"));
+                        (*host_id, t)
+                    }
+                    crate::broadcast::BroadcastEvent::Failed { host_id, reason } => {
+                        (*host_id, reason.clone())
+                    }
+                    _ => continue,
+                };
+                let host = bc
+                    .results
+                    .iter()
+                    .find(|r| r.host_id == host_id)
+                    .map(|r| r.host_name.clone())
+                    .unwrap_or_default();
+                new_toasts.push(BroadcastToast {
+                    host,
+                    text,
+                    born: now,
+                });
             }
             if bc.anim.as_ref().is_some_and(|a| a.is_done(now)) {
                 bc.anim = None;
@@ -397,6 +449,7 @@ impl App {
                 bc.phase = BroadcastPhase::Settling { done_at: now };
             }
         }
+        self.broadcast_toasts.extend(new_toasts);
 
         // Audit once, at completion. Split the borrow: gather rows while holding
         // &mut self.broadcast, flip the guard, then drop the borrow before
@@ -412,10 +465,13 @@ impl App {
                     let (status, note) = match &r.state {
                         crate::broadcast::HostState::Done { exit } => {
                             let status = if *exit == 0 { "launched" } else { "fail" };
-                            (
-                                status.to_string(),
-                                format!("{} (exit {})", bc.command, exit),
-                            )
+                            // On failure, fold the first stderr line into the note
+                            // so the Audit tab records WHAT broke, not just the code.
+                            let note = match crate::broadcast::error_text(r) {
+                                Some(err) => format!("{} (exit {}: {})", bc.command, exit, err),
+                                None => format!("{} (exit {})", bc.command, exit),
+                            };
+                            (status.to_string(), note)
                         }
                         crate::broadcast::HostState::Failed { reason } => {
                             ("fail".to_string(), format!("{} ({})", bc.command, reason))

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -95,13 +95,22 @@ impl App {
             return Ok(());
         }
 
-        // Broadcast (#3). Route the cancel key to a live run before any other
-        // binding can claim it, then the opener. Cancel works regardless of which
-        // panel is focused (the footer advertises "x cancel" whenever a run is
-        // live, so it must fire everywhere). `open_broadcast` refuses when a run
-        // is already live, so this never starts a second one.
-        if self.broadcast.is_some() && self.is_action(KeyAction::BroadcastCancel, &key) {
-            self.cancel_broadcast();
+        // Broadcast (#3). The cancel key does double duty, claimed before any
+        // other binding: cancel a live run, or (nothing running) clear the error
+        // toasts. Works regardless of focus, matching the always-shown footer
+        // hint. `open_broadcast` refuses a second concurrent run.
+        if self.is_action(KeyAction::BroadcastCancel, &key)
+            && (self.broadcast.is_some() || !self.broadcast_toasts.is_empty())
+        {
+            if self
+                .broadcast
+                .as_ref()
+                .is_some_and(|b| !crate::broadcast::all_terminal(&b.results))
+            {
+                self.cancel_broadcast();
+            } else {
+                self.broadcast_toasts.clear();
+            }
             return Ok(());
         }
         if self.is_action(KeyAction::Broadcast, &key) {

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -70,6 +70,9 @@ impl App {
             AppMode::TagFilter => self.handle_key_tag_filter(key),
             AppMode::HostDetail => self.handle_key_host_detail(key),
             AppMode::TunnelForm => self.handle_key_tunnel_form(key),
+            AppMode::BroadcastPickTarget => self.handle_key_broadcast_pick(key),
+            AppMode::BroadcastCommand => self.handle_key_broadcast_command(key),
+            AppMode::BroadcastPreview => self.handle_key_broadcast_preview(key),
             AppMode::Connecting | AppMode::Session => self.handle_key_session(key),
             AppMode::Normal => match self.active_tab {
                 1 => self.handle_key_sftp(key),
@@ -89,6 +92,20 @@ impl App {
         }
 
         if self.try_tab_switch(&key)? {
+            return Ok(());
+        }
+
+        // Broadcast (#3). Route the cancel key to a live run before any other
+        // binding can claim it, then the opener. Cancel works regardless of which
+        // panel is focused (the footer advertises "x cancel" whenever a run is
+        // live, so it must fire everywhere). `open_broadcast` refuses when a run
+        // is already live, so this never starts a second one.
+        if self.broadcast.is_some() && self.is_action(KeyAction::BroadcastCancel, &key) {
+            self.cancel_broadcast();
+            return Ok(());
+        }
+        if self.is_action(KeyAction::Broadcast, &key) {
+            self.open_broadcast();
             return Ok(());
         }
 
@@ -285,6 +302,12 @@ impl App {
             return;
         }
         if let Some(next) = self.focused_panel.neighbor(dir) {
+            // The Broadcast panel only exists while a run is live (#3); its
+            // neighbor edges are always present in the grid, so skip the move
+            // when there's nothing to focus.
+            if next == PanelId::Broadcast && self.broadcast.is_none() {
+                return;
+            }
             self.focused_panel = next;
             self.panel_scroll.set(0);
             self.panel_sel = None;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -159,6 +159,10 @@ pub struct App {
     /// Transient error popups (issue #3), newest last; slide in from the right
     /// above the broadcast panel and expire after `TOAST_TTL`.
     pub broadcast_toasts: Vec<BroadcastToast>,
+    /// When the docked panel was dismissed, so lingering toasts can animate
+    /// *down* into the freed space instead of jumping. `None` while a panel is
+    /// present (or before any run).
+    pub broadcast_panel_gone_at: Option<std::time::Instant>,
     pub group_manage_selected: usize,
     pub group_notice: Option<String>,
     pub host_notice: Option<String>,
@@ -310,6 +314,7 @@ impl App {
             broadcast: None,
             broadcast_setup: None,
             broadcast_toasts: Vec::new(),
+            broadcast_panel_gone_at: None,
             group_manage_selected: 0,
             group_notice: None,
             host_notice: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -156,6 +156,9 @@ pub struct App {
     /// Pre-run broadcast wizard state (pick target / command / preview);
     /// `Some` only while an `AppMode::Broadcast*` stage is active.
     pub broadcast_setup: Option<BroadcastSetup>,
+    /// Transient error popups (issue #3), newest last; slide in from the right
+    /// above the broadcast panel and expire after `TOAST_TTL`.
+    pub broadcast_toasts: Vec<BroadcastToast>,
     pub group_manage_selected: usize,
     pub group_notice: Option<String>,
     pub host_notice: Option<String>,
@@ -306,6 +309,7 @@ impl App {
             zoomed_host_idx: std::cell::RefCell::new(Vec::new()),
             broadcast: None,
             broadcast_setup: None,
+            broadcast_toasts: Vec::new(),
             group_manage_selected: 0,
             group_notice: None,
             host_notice: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,5 @@
 mod audit;
+mod broadcast;
 mod connect;
 mod field_picker;
 mod groups;
@@ -149,6 +150,12 @@ pub struct App {
     /// `self.hosts` indices for the rows of a zoomed host-list panel (ping /
     /// recent), filled by their render so Enter connects the selected row.
     pub zoomed_host_idx: std::cell::RefCell<Vec<usize>>,
+    /// Live broadcast run (issue #3): `Some` while a fleet command runs or its
+    /// finished panel is settling. Owns the run's mpsc + cancel flag.
+    pub broadcast: Option<BroadcastState>,
+    /// Pre-run broadcast wizard state (pick target / command / preview);
+    /// `Some` only while an `AppMode::Broadcast*` stage is active.
+    pub broadcast_setup: Option<BroadcastSetup>,
     pub group_manage_selected: usize,
     pub group_notice: Option<String>,
     pub host_notice: Option<String>,
@@ -297,6 +304,8 @@ impl App {
             panel_sel: None,
             panel_sel_text: std::cell::RefCell::new(String::new()),
             zoomed_host_idx: std::cell::RefCell::new(Vec::new()),
+            broadcast: None,
+            broadcast_setup: None,
             group_manage_selected: 0,
             group_notice: None,
             host_notice: None,

--- a/src/app/tests/broadcast.rs
+++ b/src/app/tests/broadcast.rs
@@ -58,6 +58,7 @@ fn make_state(
             host_id: *id,
             host_name: name.to_string(),
             argv: vec!["ssh".to_string(), name.to_string()],
+            secret: None,
         })
         .collect();
     let results = crate::broadcast::seed_results(&bcast_tasks);

--- a/src/app/tests/broadcast.rs
+++ b/src/app/tests/broadcast.rs
@@ -1,0 +1,283 @@
+use super::*;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+
+use crate::broadcast::{BroadcastEvent, BroadcastTask, HostState};
+
+/// Build an `App` whose store holds a `prod` group with two managed hosts (one
+/// tagged `db`), so the broadcast wizard can resolve real targets/candidates.
+fn app_with_targets() -> App {
+    let store = test_store();
+    let g = store
+        .create_group(&crate::store::NewHostGroup {
+            name: "prod".into(),
+            sort_order: 0,
+            default_identity_id: None,
+            parent_id: None,
+        })
+        .unwrap();
+
+    let mut web = crate::store::NewHost::launcher("web", "10.0.0.1");
+    web.group_id = Some(g.id);
+    web.tags = vec!["db".into()];
+    store.create_host(&web).unwrap();
+
+    let mut api = crate::store::NewHost::launcher("api", "10.0.0.2");
+    api.group_id = Some(g.id);
+    store.create_host(&api).unwrap();
+
+    let mut app = App::new_with_deps(
+        AppConfig::default(),
+        AppDeps {
+            resolver: Box::new(MockResolver::new(vec![])),
+            metadata: Arc::new(MetadataDb::default()),
+            store: Arc::clone(&store),
+            password_store: Box::new(crate::credentials::NoopPasswordStore),
+        },
+    );
+    app.reload_hosts().unwrap();
+    app
+}
+
+/// Hand-construct a live `BroadcastState` (no real ssh): seeds `Pending` rows
+/// for the given `(host_id, host_name)` tasks and returns the state plus the
+/// event `Sender` and a clone of the shared cancel flag the test drives.
+fn make_state(
+    command: &str,
+    tasks: &[(i64, &str)],
+) -> (
+    BroadcastState,
+    mpsc::Sender<BroadcastEvent>,
+    Arc<AtomicBool>,
+) {
+    let (tx, rx) = mpsc::channel::<BroadcastEvent>();
+    let bcast_tasks: Vec<BroadcastTask> = tasks
+        .iter()
+        .map(|(id, name)| BroadcastTask {
+            host_id: *id,
+            host_name: name.to_string(),
+            argv: vec!["ssh".to_string(), name.to_string()],
+        })
+        .collect();
+    let results = crate::broadcast::seed_results(&bcast_tasks);
+    let cancel = Arc::new(AtomicBool::new(false));
+    let state = BroadcastState {
+        target_label: "group: prod".into(),
+        command: command.into(),
+        results,
+        rx,
+        cancel: Arc::clone(&cancel),
+        concurrency: 2,
+        phase: BroadcastPhase::Running,
+        anim: None,
+        audit_written: false,
+    };
+    (state, tx, cancel)
+}
+
+#[test]
+pub(crate) fn wizard_group_target_flow_pick_command_preview() {
+    let mut app = app_with_targets();
+
+    app.open_broadcast();
+    assert_eq!(app.mode, AppMode::BroadcastPickTarget);
+    let setup = app.broadcast_setup.as_ref().expect("wizard opened");
+    assert!(
+        setup
+            .options
+            .iter()
+            .any(|o| matches!(o, BroadcastTarget::Group { label, .. } if label == "prod")),
+        "group option present"
+    );
+    assert!(
+        setup
+            .options
+            .iter()
+            .any(|o| matches!(o, BroadcastTarget::Tag { name } if name == "db")),
+        "tag option present"
+    );
+
+    // Enter on the first option (group prod) resolves both managed hosts.
+    app.handle_key_broadcast_pick(key(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, AppMode::BroadcastCommand);
+    let setup = app.broadcast_setup.as_ref().unwrap();
+    assert_eq!(setup.target_label, "group: prod");
+    assert_eq!(setup.candidates.len(), 2);
+    assert!(
+        setup.candidates.iter().all(|c| c.selected),
+        "candidates selected by default"
+    );
+
+    // Type a command and cross the preview barrier.
+    for c in "uptime".chars() {
+        app.handle_key_broadcast_command(key_char(c)).unwrap();
+    }
+    assert_eq!(app.broadcast_setup.as_ref().unwrap().command, "uptime");
+    app.handle_key_broadcast_command(key(KeyCode::Enter))
+        .unwrap();
+    assert_eq!(app.mode, AppMode::BroadcastPreview);
+
+    // 'e' enters edit-targets; Space deselects the highlighted host.
+    app.handle_key_broadcast_preview(key_char('e')).unwrap();
+    assert!(app.broadcast_setup.as_ref().unwrap().edit_targets);
+    app.handle_key_broadcast_preview(key_char(' ')).unwrap();
+    assert!(
+        !app.broadcast_setup.as_ref().unwrap().candidates[0].selected,
+        "Space toggled the highlighted candidate off"
+    );
+
+    // 'e' leaves edit mode again; 'n' closes the whole wizard.
+    app.handle_key_broadcast_preview(key_char('e')).unwrap();
+    assert!(!app.broadcast_setup.as_ref().unwrap().edit_targets);
+    app.handle_key_broadcast_preview(key_char('n')).unwrap();
+    assert!(app.broadcast_setup.is_none());
+    assert_eq!(app.mode, AppMode::Normal);
+}
+
+#[test]
+pub(crate) fn wizard_tag_target_resolves_only_tagged_hosts() {
+    let mut app = app_with_targets();
+    app.open_broadcast();
+
+    // options == [Group prod, Tag db]; move down onto the tag row, then Enter.
+    app.handle_key_broadcast_pick(key(KeyCode::Down)).unwrap();
+    app.handle_key_broadcast_pick(key(KeyCode::Enter)).unwrap();
+
+    assert_eq!(app.mode, AppMode::BroadcastCommand);
+    let setup = app.broadcast_setup.as_ref().unwrap();
+    assert_eq!(setup.target_label, "#db");
+    assert_eq!(setup.candidates.len(), 1, "only the #db host matches");
+    assert_eq!(setup.candidates[0].host_name, "web");
+}
+
+#[test]
+pub(crate) fn wizard_pick_esc_closes() {
+    let mut app = app_with_targets();
+    app.open_broadcast();
+    app.handle_key_broadcast_pick(key(KeyCode::Esc)).unwrap();
+    assert!(app.broadcast_setup.is_none());
+    assert_eq!(app.mode, AppMode::Normal);
+}
+
+#[test]
+pub(crate) fn wizard_preview_esc_closes() {
+    let mut app = app_with_targets();
+    app.open_broadcast();
+    app.handle_key_broadcast_pick(key(KeyCode::Enter)).unwrap();
+    for c in "ls".chars() {
+        app.handle_key_broadcast_command(key_char(c)).unwrap();
+    }
+    app.handle_key_broadcast_command(key(KeyCode::Enter))
+        .unwrap();
+    assert_eq!(app.mode, AppMode::BroadcastPreview);
+
+    app.handle_key_broadcast_preview(key(KeyCode::Esc)).unwrap();
+    assert!(app.broadcast_setup.is_none());
+    assert_eq!(app.mode, AppMode::Normal);
+}
+
+#[test]
+pub(crate) fn open_broadcast_refuses_while_run_in_progress() {
+    let mut app = app_with_targets();
+    let (state, _tx, _cancel) = make_state("echo hi", &[(1, "web"), (2, "api")]);
+    app.broadcast = Some(state);
+
+    app.open_broadcast();
+
+    assert!(
+        app.broadcast_setup.is_none(),
+        "wizard must not open over a live run"
+    );
+    assert!(app.host_notice.is_some(), "surfaces a notice");
+    assert_eq!(app.mode, AppMode::Normal);
+}
+
+#[test]
+pub(crate) fn tick_broadcast_folds_events_settles_and_audits_once() {
+    let mut app = test_app(vec![]);
+    // Keep the panel unfocused so the settle countdown can't flip to Paused.
+    app.focused_panel = PanelId::Hosts;
+
+    let (state, tx, _cancel) = make_state("systemctl restart nginx", &[(1, "web"), (2, "api")]);
+    app.broadcast = Some(state);
+
+    tx.send(BroadcastEvent::Finished {
+        host_id: 1,
+        exit: 0,
+        stdout: "ok".into(),
+        stderr: String::new(),
+    })
+    .unwrap();
+    tx.send(BroadcastEvent::Failed {
+        host_id: 2,
+        reason: "connection refused".into(),
+    })
+    .unwrap();
+
+    app.tick_broadcast().unwrap();
+
+    let bc = app
+        .broadcast
+        .as_ref()
+        .expect("run stays docked while settling");
+    assert_eq!(bc.results[0].state, HostState::Done { exit: 0 });
+    assert!(matches!(bc.results[1].state, HostState::Failed { .. }));
+    assert!(
+        matches!(bc.phase, BroadcastPhase::Settling { .. }),
+        "all-terminal arms the settle countdown"
+    );
+    assert!(bc.audit_written, "audit guard flipped");
+
+    let events = app.store.list_auth_events(10).unwrap();
+    let bcast: Vec<_> = events
+        .iter()
+        .filter(|e| e.via.as_deref() == Some("broadcast"))
+        .collect();
+    assert_eq!(bcast.len(), 2, "one audit row per host");
+
+    let web = bcast.iter().find(|e| e.host_name == "web").unwrap();
+    assert_eq!(web.status, "launched");
+    assert!(
+        web.note
+            .as_deref()
+            .unwrap()
+            .contains("systemctl restart nginx"),
+        "command echoed in the note"
+    );
+
+    let api = bcast.iter().find(|e| e.host_name == "api").unwrap();
+    assert_eq!(api.status, "fail");
+    let api_note = api.note.as_deref().unwrap();
+    assert!(api_note.contains("systemctl restart nginx"));
+    assert!(
+        api_note.contains("connection refused"),
+        "reason in the note"
+    );
+
+    // A second tick must not duplicate the audit rows.
+    app.tick_broadcast().unwrap();
+    let again = app.store.list_auth_events(10).unwrap();
+    assert_eq!(
+        again
+            .iter()
+            .filter(|e| e.via.as_deref() == Some("broadcast"))
+            .count(),
+        2,
+        "audit is written exactly once"
+    );
+}
+
+#[test]
+pub(crate) fn cancel_broadcast_sets_the_shared_flag() {
+    let mut app = test_app(vec![]);
+    let (state, _tx, cancel) = make_state("id", &[(1, "web")]);
+    app.broadcast = Some(state);
+
+    assert!(!cancel.load(Ordering::Relaxed));
+    app.cancel_broadcast();
+    assert!(
+        cancel.load(Ordering::Relaxed),
+        "cancel flips the shared AtomicBool"
+    );
+}

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -70,6 +70,7 @@ pub(crate) fn legacy_meta(entry: &mut HostEntry) -> &mut crate::metadata::HostMe
     entry.legacy_mut().expect("legacy host").1
 }
 
+mod broadcast;
 mod host_crud;
 mod host_detail;
 mod host_form;

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -81,6 +81,10 @@ pub enum PanelId {
     Auth,
     Ping,
     SshLog,
+    /// Live broadcast run panel, docked bottom-right (issue #3). Only drawn +
+    /// focusable while `app.broadcast.is_some()`; the `focus_panel` guard in
+    /// `keys.rs` suppresses `neighbor()` hops to it when the run is absent.
+    Broadcast,
 }
 
 impl PanelId {
@@ -94,6 +98,7 @@ impl PanelId {
             PanelId::Auth => "auth events",
             PanelId::Ping => "ping",
             PanelId::SshLog => "ssh log",
+            PanelId::Broadcast => "broadcast",
         }
     }
 
@@ -130,11 +135,18 @@ impl PanelId {
             (Ping, Left) => Some(Latency),
             (Ping, Up) => Some(Auth),
             (Ping, Down) => Some(SshLog),
-            (Ping, Right) => None,
+            (Ping, Right) => Some(Broadcast),
             // Bottom strip (spans mid+right).
             (SshLog, Up) => Some(Latency),
             (SshLog, Left) => Some(Hosts),
+            (SshLog, Right) => Some(Broadcast),
             (SshLog, _) => None,
+            // Broadcast docked panel (bottom-right); only live when
+            // app.broadcast.is_some() — the orchestrator's focus_panel guard
+            // suppresses these when it's absent.
+            (Broadcast, Left) => Some(SshLog),
+            (Broadcast, Up) => Some(Ping),
+            (Broadcast, _) => None,
         }
     }
 }
@@ -175,6 +187,25 @@ mod panel_id_tests {
             PanelId::SshLog.neighbor(FocusDir::Up),
             Some(PanelId::Latency)
         );
+        // Broadcast docks bottom-right: reachable from the ssh-log strip and
+        // the ping panel, and hops back left/up into the grid.
+        assert_eq!(
+            PanelId::SshLog.neighbor(FocusDir::Right),
+            Some(PanelId::Broadcast)
+        );
+        assert_eq!(
+            PanelId::Ping.neighbor(FocusDir::Right),
+            Some(PanelId::Broadcast)
+        );
+        assert_eq!(
+            PanelId::Broadcast.neighbor(FocusDir::Left),
+            Some(PanelId::SshLog)
+        );
+        assert_eq!(
+            PanelId::Broadcast.neighbor(FocusDir::Up),
+            Some(PanelId::Ping)
+        );
+        assert_eq!(PanelId::Broadcast.neighbor(FocusDir::Right), None);
     }
 
     #[test]
@@ -316,6 +347,69 @@ pub enum AppMode {
     Connecting,
     /// Live embedded SSH session; PTY drives the fullscreen view.
     Session,
+    /// Broadcast wizard stage 1: pick a target (group / tag menu).
+    BroadcastPickTarget,
+    /// Broadcast wizard stage 2: single-line command input.
+    BroadcastCommand,
+    /// Broadcast wizard stage 3: target preview + [y]/[e]/[N] barrier.
+    BroadcastPreview,
+}
+
+/// Live background-run state; App holds `broadcast: Option<BroadcastState>`.
+///
+/// No derive attribute at all — not even `Debug` — because
+/// `std::sync::mpsc::Receiver` is not `Debug`, and this type is deliberately
+/// neither `Clone` nor `Copy` (it owns the run's channel + cancel flag).
+pub struct BroadcastState {
+    pub target_label: String, // "#prod" / "group: production"
+    pub command: String,
+    pub results: Vec<crate::broadcast::HostResult>,
+    pub rx: std::sync::mpsc::Receiver<crate::broadcast::BroadcastEvent>,
+    pub cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    pub concurrency: usize,
+    pub phase: BroadcastPhase,
+    pub anim: Option<crate::tui::tween::SlideAnim>, // entry slide; None once settled
+    pub audit_written: bool, // guard: log_auth_event fires once at completion
+}
+
+/// Lifecycle phase of a live broadcast run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BroadcastPhase {
+    Running,
+    Settling { done_at: std::time::Instant }, // countdown armed
+    Paused,                                   // focused/zoomed after completion
+}
+
+/// A pickable broadcast target (menu row).
+#[derive(Debug, Clone)]
+pub enum BroadcastTarget {
+    Group { id: i64, label: String },
+    Tag { name: String },
+}
+
+/// One resolved target host in the preview (managed hosts only; entries with no
+/// managed id are excluded upstream).
+#[derive(Debug, Clone)]
+pub struct BroadcastCandidate {
+    pub host_id: i64,
+    pub host_name: String,
+    pub argv: Vec<String>,
+    pub selected: bool, // toggled in edit-targets
+}
+
+/// Pre-run wizard state; App holds `broadcast_setup: Option<BroadcastSetup>`.
+/// The active AppMode variant (PickTarget/Command/Preview) names the stage.
+///
+/// No derive attribute at all — deliberately neither `Clone` nor `Copy`.
+pub struct BroadcastSetup {
+    pub options: Vec<BroadcastTarget>,
+    pub menu_selected: usize,
+    pub target_label: String, // filled once a target is chosen
+    pub command: String,
+    pub cursor: usize,
+    pub candidates: Vec<BroadcastCandidate>, // resolved on target pick
+    pub preview_selected: usize,             // highlighted row in edit-targets
+    pub edit_targets: bool,                  // preview [e] entered per-host deselect
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -394,6 +394,10 @@ pub struct BroadcastCandidate {
     pub host_id: i64,
     pub host_name: String,
     pub argv: Vec<String>,
+    /// Stored credential for this host (phase 2), resolved when the target is
+    /// picked; threaded into the run so password hosts authenticate via
+    /// SSH_ASKPASS. `None` => key/agent only.
+    pub secret: Option<crate::session::PendingSecret>,
     pub selected: bool, // toggled in edit-targets
 }
 

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -372,6 +372,16 @@ pub struct BroadcastState {
     pub audit_written: bool, // guard: log_auth_event fires once at completion
 }
 
+/// A transient error popup (issue #3): one failed host's error text, slides in
+/// from the right above the broadcast panel and auto-expires. Geometry + slide
+/// progress are derived from `born` at render time (no stored anim state).
+#[derive(Debug, Clone)]
+pub struct BroadcastToast {
+    pub host: String,
+    pub text: String,
+    pub born: std::time::Instant,
+}
+
 /// Lifecycle phase of a live broadcast run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BroadcastPhase {

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -378,6 +378,7 @@ pub enum BroadcastPhase {
     Running,
     Settling { done_at: std::time::Instant }, // countdown armed
     Paused,                                   // focused/zoomed after completion
+    Leaving,                                  // exit slide playing, remove when done
 }
 
 /// A pickable broadcast target (menu row).

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -27,7 +27,7 @@ pub const DEFAULT_CONCURRENCY: usize = 8;
 /// Countdown length before a finished panel auto-dismisses.
 pub const DISMISS: Duration = Duration::from_secs(5);
 /// Entry slide duration (center -> corner).
-pub const ENTRY_ANIM: Duration = Duration::from_millis(250);
+pub const ENTRY_ANIM: Duration = Duration::from_millis(350);
 /// Per-host ssh connect timeout (seconds) and run cap.
 pub const CONNECT_TIMEOUT_SECS: u32 = 8;
 pub const RUN_TIMEOUT: Duration = Duration::from_secs(60);

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -43,6 +43,10 @@ pub struct BroadcastTask {
     pub host_name: String,
     /// `ssh_argv_for_entry(entry)`; `argv[0] == "ssh"`.
     pub argv: Vec<String>,
+    /// Stored credential answered via `SSH_ASKPASS` (same path a live session
+    /// uses). `Some` => `BatchMode=no`; `None` => key/agent only (`BatchMode=yes`,
+    /// fail fast on a password prompt).
+    pub secret: Option<crate::session::PendingSecret>,
 }
 
 /// Per-host lifecycle state, folded from [`BroadcastEvent`]s by [`apply_event`].
@@ -101,6 +105,7 @@ pub trait CommandRunner: Send + Sync {
         &self,
         argv: &[String],
         command: &str,
+        secret: Option<&crate::session::PendingSecret>,
         cancel: &AtomicBool,
     ) -> Result<(i32, String, String), String>;
 }
@@ -138,6 +143,7 @@ impl CommandRunner for SshCommandRunner {
         &self,
         argv: &[String],
         command: &str,
+        secret: Option<&crate::session::PendingSecret>,
         cancel: &AtomicBool,
     ) -> Result<(i32, String, String), String> {
         if argv.is_empty() {
@@ -147,16 +153,23 @@ impl CommandRunner for SshCommandRunner {
             return Err("cancelled".to_string());
         }
 
-        // Splice BatchMode-friendly options right after the program name and
-        // append the remote command as the final argument. Key/agent only in
-        // v1: force BatchMode=yes so ssh fails fast instead of blocking on a
-        // password prompt (ConnectTimeout only bounds the TCP connect).
+        // Splice non-interactive options right after the program name and append
+        // the remote command as the final argument. With a stored secret we run
+        // BatchMode=no and answer the prompt via SSH_ASKPASS (exactly like a live
+        // session); without one, BatchMode=yes so ssh fails fast instead of
+        // blocking on a /dev/tty password prompt (ConnectTimeout only bounds the
+        // TCP connect).
+        let batchmode = if secret.is_some() {
+            "BatchMode=no"
+        } else {
+            "BatchMode=yes"
+        };
         let connect_timeout = format!("ConnectTimeout={}", self.connect_timeout_secs);
         let mut full: Vec<String> = Vec::with_capacity(argv.len() + 8);
         full.push(argv[0].clone());
         for opt in [
             "-o",
-            "BatchMode=yes",
+            batchmode,
             "-o",
             &connect_timeout,
             "-o",
@@ -167,13 +180,28 @@ impl CommandRunner for SshCommandRunner {
         full.extend(argv[1..].iter().cloned());
         full.push(command.to_string());
 
-        let mut child = Command::new(&full[0])
-            .args(&full[1..])
+        let mut cmd = Command::new(&full[0]);
+        cmd.args(&full[1..])
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| format!("spawn ssh: {e}"))?;
+            .stderr(Stdio::piped());
+
+        // Stage the stored secret through SSH_ASKPASS. The guard owns an
+        // owner-only temp file removed on drop, so keep it alive until the child
+        // has exited (i.e. for the whole poll loop below).
+        let mut _askpass = None;
+        if let Some(secret) = secret {
+            if let Ok(exe) = std::env::current_exe() {
+                if let Ok(guard) = crate::session::askpass::AskpassSecret::new(secret.value()) {
+                    for (k, v) in guard.env(&exe) {
+                        cmd.env(k, v);
+                    }
+                    _askpass = Some(guard);
+                }
+            }
+        }
+
+        let mut child = cmd.spawn().map_err(|e| format!("spawn ssh: {e}"))?;
 
         // Drain both pipes on their own threads so a chatty host can't deadlock
         // by filling a pipe buffer while we block on the other.
@@ -341,7 +369,7 @@ fn broadcast_worker(
             return;
         }
 
-        let ev = match runner.run(&task.argv, command, cancel) {
+        let ev = match runner.run(&task.argv, command, task.secret.as_ref(), cancel) {
             Ok((exit, stdout, stderr)) => BroadcastEvent::Finished {
                 host_id: task.host_id,
                 exit,
@@ -434,6 +462,7 @@ mod tests {
             host_id: id,
             host_name: name.to_string(),
             argv: vec!["ssh".to_string(), name.to_string()],
+            secret: None,
         }
     }
 
@@ -464,6 +493,7 @@ mod tests {
             &self,
             argv: &[String],
             command: &str,
+            _secret: Option<&crate::session::PendingSecret>,
             cancel: &AtomicBool,
         ) -> Result<(i32, String, String), String> {
             self.started.fetch_add(1, Ordering::SeqCst);
@@ -673,6 +703,7 @@ mod tests {
                 &self,
                 _argv: &[String],
                 _command: &str,
+                _secret: Option<&crate::session::PendingSecret>,
                 _cancel: &AtomicBool,
             ) -> Result<(i32, String, String), String> {
                 Err("nope".to_string())
@@ -836,7 +867,7 @@ mod tests {
             "definitely-not-a-real-ssh-binary-xyzzy".to_string(),
             "host".to_string(),
         ];
-        let res = runner.run(&argv, "true", &cancel);
+        let res = runner.run(&argv, "true", None, &cancel);
         assert!(res.is_err());
     }
 
@@ -844,7 +875,67 @@ mod tests {
     fn real_runner_short_circuits_on_precancel() {
         let runner = SshCommandRunner::new();
         let cancel = AtomicBool::new(true);
-        let res = runner.run(&["ssh".to_string(), "host".to_string()], "true", &cancel);
+        let res = runner.run(
+            &["ssh".to_string(), "host".to_string()],
+            "true",
+            None,
+            &cancel,
+        );
         assert_eq!(res, Err("cancelled".to_string()));
+    }
+
+    #[test]
+    fn secret_is_threaded_per_task_to_the_runner() {
+        use std::sync::atomic::AtomicUsize;
+
+        // Records how many tasks reached the runner carrying a stored secret.
+        struct SecretSpy {
+            with_secret: Arc<AtomicUsize>,
+        }
+        impl CommandRunner for SecretSpy {
+            fn run(
+                &self,
+                _argv: &[String],
+                _command: &str,
+                secret: Option<&crate::session::PendingSecret>,
+                _cancel: &AtomicBool,
+            ) -> Result<(i32, String, String), String> {
+                if secret.is_some() {
+                    self.with_secret.fetch_add(1, Ordering::SeqCst);
+                }
+                Ok((0, String::new(), String::new()))
+            }
+        }
+
+        let with_secret = Arc::new(AtomicUsize::new(0));
+        let tasks = vec![
+            BroadcastTask {
+                host_id: 1,
+                host_name: "pw-host".into(),
+                argv: vec!["ssh".into(), "pw-host".into()],
+                secret: Some(crate::session::PendingSecret::Password("hunter2".into())),
+            },
+            BroadcastTask {
+                host_id: 2,
+                host_name: "key-host".into(),
+                argv: vec!["ssh".into(), "key-host".into()],
+                secret: None,
+            },
+        ];
+        let rx = spawn_broadcast(
+            tasks,
+            "true".into(),
+            2,
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(SecretSpy {
+                with_secret: Arc::clone(&with_secret),
+            }),
+        );
+        let _drained: Vec<_> = rx.iter().collect();
+        assert_eq!(
+            with_secret.load(Ordering::SeqCst),
+            1,
+            "only the host with a stored secret hands one to the runner"
+        );
     }
 }

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -25,7 +25,7 @@ use std::time::{Duration, Instant};
 /// Default bounded pool width.
 pub const DEFAULT_CONCURRENCY: usize = 8;
 /// Countdown length before a finished panel auto-dismisses.
-pub const DISMISS: Duration = Duration::from_secs(30);
+pub const DISMISS: Duration = Duration::from_millis(6500);
 /// Entry slide duration (center -> corner).
 pub const ENTRY_ANIM: Duration = Duration::from_millis(600);
 /// Per-host ssh connect timeout (seconds) and run cap.

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -25,9 +25,9 @@ use std::time::{Duration, Instant};
 /// Default bounded pool width.
 pub const DEFAULT_CONCURRENCY: usize = 8;
 /// Countdown length before a finished panel auto-dismisses.
-pub const DISMISS: Duration = Duration::from_secs(5);
+pub const DISMISS: Duration = Duration::from_secs(30);
 /// Entry slide duration (center -> corner).
-pub const ENTRY_ANIM: Duration = Duration::from_millis(350);
+pub const ENTRY_ANIM: Duration = Duration::from_millis(600);
 /// Per-host ssh connect timeout (seconds) and run cap.
 pub const CONNECT_TIMEOUT_SECS: u32 = 8;
 pub const RUN_TIMEOUT: Duration = Duration::from_secs(60);

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -28,6 +28,10 @@ pub const DEFAULT_CONCURRENCY: usize = 8;
 pub const DISMISS: Duration = Duration::from_millis(6500);
 /// Entry slide duration (center -> corner).
 pub const ENTRY_ANIM: Duration = Duration::from_millis(600);
+/// How long an error toast stays before it slides away.
+pub const TOAST_TTL: Duration = Duration::from_secs(10);
+/// Error-toast slide-in / slide-out duration.
+pub const TOAST_ANIM: Duration = Duration::from_millis(300);
 /// Per-host ssh connect timeout (seconds) and run cap.
 pub const CONNECT_TIMEOUT_SECS: u32 = 8;
 pub const RUN_TIMEOUT: Duration = Duration::from_secs(60);
@@ -454,6 +458,22 @@ pub fn is_failure(r: &HostResult) -> bool {
 /// Number of failed hosts (ssh failure or non-zero exit) in a finished/partial run.
 pub fn failure_count(results: &[HostResult]) -> usize {
     results.iter().filter(|r| is_failure(r)).count()
+}
+
+/// Human-readable error text for a failed result: the ssh failure reason, or the
+/// first non-empty stderr line for a non-zero exit. `None` for a clean/unfinished
+/// row. Shared by the audit note and the error toasts.
+pub fn error_text(r: &HostResult) -> Option<String> {
+    match &r.state {
+        HostState::Failed { reason } => Some(reason.clone()),
+        HostState::Done { exit } if *exit != 0 => r
+            .stderr
+            .lines()
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .map(str::to_string),
+        _ => None,
+    }
 }
 
 /// Render-time view ordering (does NOT mutate `results`): indices into

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -1,0 +1,850 @@
+//! Broadcast mode (#3): run one command across many hosts concurrently.
+//!
+//! This module is **pure** — no `App`, no TUI dependency. It owns the shared
+//! value types ([`BroadcastTask`], [`HostState`], [`HostResult`],
+//! [`BroadcastEvent`]), the [`CommandRunner`] transport seam, a real
+//! [`SshCommandRunner`] (mirroring [`crate::osinfo::detect::SshProbeRunner`]'s
+//! arg splice), a bounded worker pool ([`spawn_broadcast`]), and the pure
+//! reducer / view helpers the UI layer drives.
+//!
+//! The pool rides the crate's established thread + mpsc worker shape (see
+//! [`crate::ping`], [`crate::sftp::worker`]): `K = min(concurrency, tasks)`
+//! worker threads pull [`BroadcastTask`]s off a shared
+//! `Arc<Mutex<Receiver<BroadcastTask>>>` and emit [`BroadcastEvent`]s on a
+//! single `Sender`. The UI drains those events in the poll loop and folds them
+//! into a `Vec<HostResult>` via [`apply_event`].
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Default bounded pool width.
+pub const DEFAULT_CONCURRENCY: usize = 8;
+/// Countdown length before a finished panel auto-dismisses.
+pub const DISMISS: Duration = Duration::from_secs(5);
+/// Entry slide duration (center -> corner).
+pub const ENTRY_ANIM: Duration = Duration::from_millis(250);
+/// Per-host ssh connect timeout (seconds) and run cap.
+pub const CONNECT_TIMEOUT_SECS: u32 = 8;
+pub const RUN_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// How often the [`SshCommandRunner`] poll loop wakes to check `cancel` /
+/// run-timeout / child exit while a remote command is in flight.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// One host to run the broadcast command against.
+#[derive(Debug, Clone)]
+pub struct BroadcastTask {
+    pub host_id: i64,
+    pub host_name: String,
+    /// `ssh_argv_for_entry(entry)`; `argv[0] == "ssh"`.
+    pub argv: Vec<String>,
+}
+
+/// Per-host lifecycle state, folded from [`BroadcastEvent`]s by [`apply_event`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostState {
+    Pending,
+    Running,
+    Done { exit: i32 },
+    Failed { reason: String },
+}
+
+impl HostState {
+    /// Terminal = `Done` | `Failed`.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, HostState::Done { .. } | HostState::Failed { .. })
+    }
+}
+
+/// One row in the aggregated result table.
+#[derive(Debug, Clone)]
+pub struct HostResult {
+    pub host_id: i64,
+    pub host_name: String,
+    pub state: HostState,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// Event emitted by a pool worker for one task. Exactly one *terminal* event
+/// (`Finished` or `Failed`) is emitted per task; `Started` is optional/leading.
+#[derive(Debug, Clone)]
+pub enum BroadcastEvent {
+    Started {
+        host_id: i64,
+    },
+    Finished {
+        host_id: i64,
+        exit: i32,
+        stdout: String,
+        stderr: String,
+    },
+    Failed {
+        host_id: i64,
+        reason: String,
+    },
+}
+
+/// How a broadcast command is executed against one host. Abstracted (like
+/// [`crate::osinfo::detect::ProbeRunner`]) so tests inject canned output without
+/// spawning `ssh`.
+pub trait CommandRunner: Send + Sync {
+    /// Run `argv` + the remote `command`; honor `cancel` and the run timeout.
+    /// `Ok((exit, stdout, stderr))` when the process completed (any exit code),
+    /// `Err(reason)` when it could not (spawn failure, timeout, cancel).
+    fn run(
+        &self,
+        argv: &[String],
+        command: &str,
+        cancel: &AtomicBool,
+    ) -> Result<(i32, String, String), String>;
+}
+
+/// Real runner: shells out to `ssh` with the same non-interactive option splice
+/// as [`crate::osinfo::detect::SshProbeRunner`]
+/// (`-o BatchMode=yes -o ConnectTimeout=N -o StrictHostKeyChecking=accept-new`
+/// after `argv[0]`, the remote command appended as the final argv). Pipes
+/// stdout/stderr, enforces `run_timeout` + `cancel` via a `try_wait` poll loop
+/// that kills the child (reader threads joined after the kill). Key/agent only
+/// — no `SSH_ASKPASS` in v1, so `BatchMode=yes` makes a password-needing host
+/// fail fast instead of blocking on `/dev/tty`.
+pub struct SshCommandRunner {
+    pub connect_timeout_secs: u32,
+    pub run_timeout: Duration,
+}
+
+impl SshCommandRunner {
+    pub fn new() -> Self {
+        Self {
+            connect_timeout_secs: CONNECT_TIMEOUT_SECS,
+            run_timeout: RUN_TIMEOUT,
+        }
+    }
+}
+
+impl Default for SshCommandRunner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandRunner for SshCommandRunner {
+    fn run(
+        &self,
+        argv: &[String],
+        command: &str,
+        cancel: &AtomicBool,
+    ) -> Result<(i32, String, String), String> {
+        if argv.is_empty() {
+            return Err("empty ssh argv".to_string());
+        }
+        if cancel.load(Ordering::Relaxed) {
+            return Err("cancelled".to_string());
+        }
+
+        // Splice BatchMode-friendly options right after the program name and
+        // append the remote command as the final argument. Key/agent only in
+        // v1: force BatchMode=yes so ssh fails fast instead of blocking on a
+        // password prompt (ConnectTimeout only bounds the TCP connect).
+        let connect_timeout = format!("ConnectTimeout={}", self.connect_timeout_secs);
+        let mut full: Vec<String> = Vec::with_capacity(argv.len() + 8);
+        full.push(argv[0].clone());
+        for opt in [
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            &connect_timeout,
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+        ] {
+            full.push(opt.to_string());
+        }
+        full.extend(argv[1..].iter().cloned());
+        full.push(command.to_string());
+
+        let mut child = Command::new(&full[0])
+            .args(&full[1..])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("spawn ssh: {e}"))?;
+
+        // Drain both pipes on their own threads so a chatty host can't deadlock
+        // by filling a pipe buffer while we block on the other.
+        let stdout_reader = child.stdout.take().map(spawn_pipe_reader);
+        let stderr_reader = child.stderr.take().map(spawn_pipe_reader);
+
+        // Poll for exit, honoring cancel + run timeout by killing the child.
+        let start = Instant::now();
+        let mut fail_reason: Option<String> = None;
+        let exit_status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break Some(status),
+                Ok(None) => {}
+                Err(e) => {
+                    fail_reason = Some(format!("wait ssh: {e}"));
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break None;
+                }
+            }
+            if cancel.load(Ordering::Relaxed) {
+                fail_reason = Some("cancelled".to_string());
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+            if start.elapsed() >= self.run_timeout {
+                fail_reason = Some("timed out".to_string());
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+            thread::sleep(POLL_INTERVAL);
+        };
+
+        // Killing the child closes the pipes, so the reader threads finish.
+        let stdout = stdout_reader.map(join_pipe_reader).unwrap_or_default();
+        let stderr = stderr_reader.map(join_pipe_reader).unwrap_or_default();
+
+        if let Some(reason) = fail_reason {
+            return Err(reason);
+        }
+        // `exit_status` is Some here (the only None paths set `fail_reason`).
+        let exit = exit_status.and_then(|s| s.code()).unwrap_or(-1);
+        Ok((exit, stdout, stderr))
+    }
+}
+
+/// Spawn a thread that reads a child pipe to EOF into a `String`
+/// (lossy UTF-8), returning its join handle.
+fn spawn_pipe_reader<R: Read + Send + 'static>(mut pipe: R) -> thread::JoinHandle<String> {
+    thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = pipe.read_to_end(&mut buf);
+        String::from_utf8_lossy(&buf).into_owned()
+    })
+}
+
+/// Join a pipe-reader thread, tolerating a panicked reader (empty string).
+fn join_pipe_reader(handle: thread::JoinHandle<String>) -> String {
+    handle.join().unwrap_or_default()
+}
+
+/// Seed one `Pending` row per task, in task order (stable per-target order).
+pub fn seed_results(tasks: &[BroadcastTask]) -> Vec<HostResult> {
+    tasks
+        .iter()
+        .map(|t| HostResult {
+            host_id: t.host_id,
+            host_name: t.host_name.clone(),
+            state: HostState::Pending,
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+        .collect()
+}
+
+/// Bounded pool: `min(concurrency, tasks.len())` worker threads pull tasks from
+/// a shared `Arc<Mutex<Receiver<BroadcastTask>>>`, each emitting events on one
+/// `Sender<BroadcastEvent>`.
+///
+/// GUARANTEE: exactly one terminal event (`Finished` OR `Failed`) per task,
+/// including under cancel — un-started tasks emit `Failed{reason:"cancelled"}`
+/// and in-flight children are killed → `Failed`.
+pub fn spawn_broadcast(
+    tasks: Vec<BroadcastTask>,
+    command: String,
+    concurrency: usize,
+    cancel: Arc<AtomicBool>,
+    runner: Arc<dyn CommandRunner>,
+) -> Receiver<BroadcastEvent> {
+    let (event_tx, event_rx) = mpsc::channel::<BroadcastEvent>();
+
+    let n_workers = concurrency.max(1).min(tasks.len());
+    if n_workers == 0 {
+        // No tasks: return an already-exhausted receiver (event_tx drops here).
+        return event_rx;
+    }
+
+    // Preload every task into a channel, drop the sender: workers then get each
+    // task once, and an empty+disconnected `recv()` (never blocks) ends them.
+    let (task_tx, task_rx) = mpsc::channel::<BroadcastTask>();
+    for task in tasks {
+        // Send into an unbounded channel with a live receiver: cannot fail.
+        let _ = task_tx.send(task);
+    }
+    drop(task_tx);
+    let shared_rx = Arc::new(Mutex::new(task_rx));
+
+    for _ in 0..n_workers {
+        let shared_rx = Arc::clone(&shared_rx);
+        let event_tx = event_tx.clone();
+        let cancel = Arc::clone(&cancel);
+        let runner = Arc::clone(&runner);
+        let command = command.clone();
+        thread::spawn(move || {
+            broadcast_worker(&shared_rx, &event_tx, &cancel, runner.as_ref(), &command);
+        });
+    }
+    // Drop our own handle so the channel closes once every worker exits.
+    drop(event_tx);
+
+    event_rx
+}
+
+/// One pool worker: pull tasks until the shared queue is empty, running each
+/// (or short-circuiting to a `cancelled` failure once the flag is set).
+fn broadcast_worker(
+    shared_rx: &Arc<Mutex<Receiver<BroadcastTask>>>,
+    event_tx: &Sender<BroadcastEvent>,
+    cancel: &AtomicBool,
+    runner: &dyn CommandRunner,
+    command: &str,
+) {
+    loop {
+        // Pull one task. `recv()` never blocks here: the sender was dropped, so
+        // it returns immediately with a task or an Err (empty + disconnected).
+        let task = {
+            let guard = shared_rx.lock().unwrap_or_else(|e| e.into_inner());
+            guard.recv()
+        };
+        let Ok(task) = task else {
+            return; // queue drained
+        };
+
+        // Once cancelled, drain the rest of the queue marking each cancelled —
+        // this keeps the one-terminal-event-per-task guarantee.
+        if cancel.load(Ordering::Relaxed) {
+            let ev = BroadcastEvent::Failed {
+                host_id: task.host_id,
+                reason: "cancelled".to_string(),
+            };
+            if event_tx.send(ev).is_err() {
+                return; // UI gone
+            }
+            continue;
+        }
+
+        if event_tx
+            .send(BroadcastEvent::Started {
+                host_id: task.host_id,
+            })
+            .is_err()
+        {
+            return;
+        }
+
+        let ev = match runner.run(&task.argv, command, cancel) {
+            Ok((exit, stdout, stderr)) => BroadcastEvent::Finished {
+                host_id: task.host_id,
+                exit,
+                stdout,
+                stderr,
+            },
+            Err(reason) => BroadcastEvent::Failed {
+                host_id: task.host_id,
+                reason,
+            },
+        };
+        if event_tx.send(ev).is_err() {
+            return;
+        }
+    }
+}
+
+/// Pure reducer: mutate the matching row (by `host_id`) in place. Length +
+/// order unchanged. `Started`→`Running`, `Finished`→`Done{exit}`+stdout/stderr,
+/// `Failed`→`Failed{reason}`. A row already terminal is not resurrected by a
+/// stray `Started`.
+pub fn apply_event(results: &mut [HostResult], event: &BroadcastEvent) {
+    match event {
+        BroadcastEvent::Started { host_id } => {
+            if let Some(row) = results.iter_mut().find(|r| r.host_id == *host_id) {
+                if !row.state.is_terminal() {
+                    row.state = HostState::Running;
+                }
+            }
+        }
+        BroadcastEvent::Finished {
+            host_id,
+            exit,
+            stdout,
+            stderr,
+        } => {
+            if let Some(row) = results.iter_mut().find(|r| r.host_id == *host_id) {
+                row.state = HostState::Done { exit: *exit };
+                row.stdout = stdout.clone();
+                row.stderr = stderr.clone();
+            }
+        }
+        BroadcastEvent::Failed { host_id, reason } => {
+            if let Some(row) = results.iter_mut().find(|r| r.host_id == *host_id) {
+                row.state = HostState::Failed {
+                    reason: reason.clone(),
+                };
+            }
+        }
+    }
+}
+
+/// True once every row is terminal.
+pub fn all_terminal(results: &[HostResult]) -> bool {
+    results.iter().all(|r| r.state.is_terminal())
+}
+
+/// Render-order rank: Failed(0) < Running(1) < Pending(2) < Done(3), so
+/// failures surface first and unfinished work sits above completed rows.
+fn state_rank(state: &HostState) -> u8 {
+    match state {
+        HostState::Failed { .. } => 0,
+        HostState::Running => 1,
+        HostState::Pending => 2,
+        HostState::Done { .. } => 3,
+    }
+}
+
+/// Render-time view ordering (does NOT mutate `results`): indices into
+/// `results` sorted by [`state_rank`] via a STABLE sort, so ties keep input
+/// order.
+pub fn failures_first(results: &[HostResult]) -> Vec<usize> {
+    let mut idx: Vec<usize> = (0..results.len()).collect();
+    idx.sort_by_key(|&i| state_rank(&results[i].state));
+    idx
+}
+
+/// Count of `Done` + `Failed` for the "N/total" header badge.
+pub fn done_count(results: &[HostResult]) -> usize {
+    results.iter().filter(|r| r.state.is_terminal()).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    fn task(id: i64, name: &str) -> BroadcastTask {
+        BroadcastTask {
+            host_id: id,
+            host_name: name.to_string(),
+            argv: vec!["ssh".to_string(), name.to_string()],
+        }
+    }
+
+    /// Fake runner that tracks live concurrency (peak) and can be told to fail
+    /// specific hosts. Sleeps briefly so overlap is observable.
+    struct FakeRunner {
+        live: AtomicUsize,
+        peak: AtomicUsize,
+        fail_ids: Vec<i64>,
+        sleep: Duration,
+        started: AtomicUsize,
+    }
+
+    impl FakeRunner {
+        fn new() -> Self {
+            Self {
+                live: AtomicUsize::new(0),
+                peak: AtomicUsize::new(0),
+                fail_ids: Vec::new(),
+                sleep: Duration::from_millis(20),
+                started: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl CommandRunner for FakeRunner {
+        fn run(
+            &self,
+            argv: &[String],
+            command: &str,
+            cancel: &AtomicBool,
+        ) -> Result<(i32, String, String), String> {
+            self.started.fetch_add(1, Ordering::SeqCst);
+            let now = self.live.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak.fetch_max(now, Ordering::SeqCst);
+            thread::sleep(self.sleep);
+            self.live.fetch_sub(1, Ordering::SeqCst);
+
+            if cancel.load(Ordering::Relaxed) {
+                return Err("cancelled".to_string());
+            }
+            // host_id is not passed to run(); key the failure off argv (the
+            // host name we baked in as argv[1]).
+            let name = argv.get(1).cloned().unwrap_or_default();
+            if self.fail_ids.iter().any(|id| name == id.to_string()) {
+                return Err(format!("boom {name}"));
+            }
+            Ok((0, format!("out:{name}:{command}"), String::new()))
+        }
+    }
+
+    /// Collect every event from a receiver until the pool's senders all drop.
+    fn drain(rx: Receiver<BroadcastEvent>) -> Vec<BroadcastEvent> {
+        rx.into_iter().collect()
+    }
+
+    #[test]
+    fn is_terminal_classifies_states() {
+        assert!(!HostState::Pending.is_terminal());
+        assert!(!HostState::Running.is_terminal());
+        assert!(HostState::Done { exit: 0 }.is_terminal());
+        assert!(HostState::Failed { reason: "x".into() }.is_terminal());
+    }
+
+    #[test]
+    fn seed_results_one_pending_per_task_in_order() {
+        let tasks = vec![task(1, "a"), task(2, "b"), task(3, "c")];
+        let seeded = seed_results(&tasks);
+        assert_eq!(seeded.len(), 3);
+        assert_eq!(
+            seeded.iter().map(|r| r.host_id).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert!(seeded.iter().all(|r| r.state == HostState::Pending));
+    }
+
+    #[test]
+    fn pool_bounds_concurrency() {
+        let tasks = (0..12).map(|i| task(i, &i.to_string())).collect::<Vec<_>>();
+        let runner = Arc::new(FakeRunner::new());
+        let cancel = Arc::new(AtomicBool::new(false));
+        let rx = spawn_broadcast(
+            tasks,
+            "uptime".to_string(),
+            3,
+            Arc::clone(&cancel),
+            Arc::clone(&runner) as Arc<dyn CommandRunner>,
+        );
+        let events = drain(rx);
+        // Every task started and finished.
+        assert_eq!(runner.started.load(Ordering::SeqCst), 12);
+        assert!(runner.peak.load(Ordering::SeqCst) <= 3, "peak must be <= 3");
+        // 12 Started + 12 terminal.
+        let terminal = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    BroadcastEvent::Finished { .. } | BroadcastEvent::Failed { .. }
+                )
+            })
+            .count();
+        assert_eq!(terminal, 12);
+    }
+
+    #[test]
+    fn concurrency_clamped_to_task_count() {
+        // concurrency > tasks: still one terminal per task, no panic.
+        let tasks = vec![task(1, "1"), task(2, "2")];
+        let runner = Arc::new(FakeRunner::new());
+        let cancel = Arc::new(AtomicBool::new(false));
+        let rx = spawn_broadcast(
+            tasks,
+            "id".to_string(),
+            8,
+            cancel,
+            runner as Arc<dyn CommandRunner>,
+        );
+        let terminal = drain(rx)
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    BroadcastEvent::Finished { .. } | BroadcastEvent::Failed { .. }
+                )
+            })
+            .count();
+        assert_eq!(terminal, 2);
+    }
+
+    #[test]
+    fn empty_tasks_yields_no_events() {
+        let runner = Arc::new(FakeRunner::new());
+        let cancel = Arc::new(AtomicBool::new(false));
+        let rx = spawn_broadcast(
+            Vec::new(),
+            "x".to_string(),
+            8,
+            cancel,
+            runner as Arc<dyn CommandRunner>,
+        );
+        assert!(drain(rx).is_empty());
+    }
+
+    #[test]
+    fn exactly_one_terminal_event_per_task() {
+        let tasks = (0..6).map(|i| task(i, &i.to_string())).collect::<Vec<_>>();
+        let mut runner = FakeRunner::new();
+        runner.fail_ids = vec![2, 4];
+        let runner = Arc::new(runner);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let rx = spawn_broadcast(
+            tasks,
+            "cmd".to_string(),
+            4,
+            cancel,
+            runner as Arc<dyn CommandRunner>,
+        );
+        let events = drain(rx);
+
+        // Each host id has exactly one terminal event.
+        for id in 0..6 {
+            let terminal = events
+                .iter()
+                .filter(|e| match e {
+                    BroadcastEvent::Finished { host_id, .. } => *host_id == id,
+                    BroadcastEvent::Failed { host_id, .. } => *host_id == id,
+                    _ => false,
+                })
+                .count();
+            assert_eq!(terminal, 1, "host {id} must have one terminal event");
+        }
+        // The two failing hosts reported Failed, not Finished.
+        for id in [2, 4] {
+            assert!(events.iter().any(|e| matches!(
+                e,
+                BroadcastEvent::Failed { host_id, reason } if *host_id == id && reason.starts_with("boom")
+            )));
+        }
+    }
+
+    #[test]
+    fn cancel_before_start_marks_all_terminal() {
+        let tasks = (0..8).map(|i| task(i, &i.to_string())).collect::<Vec<_>>();
+        let runner = Arc::new(FakeRunner::new());
+        let cancel = Arc::new(AtomicBool::new(true)); // cancelled from the start
+        let rx = spawn_broadcast(
+            tasks,
+            "cmd".to_string(),
+            2,
+            Arc::clone(&cancel),
+            runner as Arc<dyn CommandRunner>,
+        );
+        let events = drain(rx);
+
+        // No task actually ran; every one produced a terminal Failed(cancelled).
+        for id in 0..8 {
+            let terminal = events
+                .iter()
+                .filter(|e| matches!(e, BroadcastEvent::Failed { host_id, .. } if *host_id == id))
+                .count();
+            assert_eq!(terminal, 1);
+        }
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, BroadcastEvent::Finished { .. })));
+    }
+
+    #[test]
+    fn cancel_reflected_across_all_rows_via_reducer() {
+        // Fold cancel events through seed + apply_event → every row terminal.
+        let tasks = (0..5).map(|i| task(i, &i.to_string())).collect::<Vec<_>>();
+        let runner = Arc::new(FakeRunner::new());
+        let cancel = Arc::new(AtomicBool::new(true));
+        let mut results = seed_results(&tasks);
+        let rx = spawn_broadcast(
+            tasks,
+            "cmd".to_string(),
+            3,
+            cancel,
+            runner as Arc<dyn CommandRunner>,
+        );
+        for ev in drain(rx).iter() {
+            apply_event(&mut results, ev);
+        }
+        assert!(all_terminal(&results));
+        assert_eq!(done_count(&results), 5);
+    }
+
+    #[test]
+    fn failures_reported_not_panicked() {
+        // A runner that always errors must not bring down the pool; every row
+        // ends Failed.
+        struct AlwaysErr;
+        impl CommandRunner for AlwaysErr {
+            fn run(
+                &self,
+                _argv: &[String],
+                _command: &str,
+                _cancel: &AtomicBool,
+            ) -> Result<(i32, String, String), String> {
+                Err("nope".to_string())
+            }
+        }
+        let tasks = (0..4).map(|i| task(i, &i.to_string())).collect::<Vec<_>>();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let rx = spawn_broadcast(
+            tasks,
+            "cmd".to_string(),
+            2,
+            cancel,
+            Arc::new(AlwaysErr) as Arc<dyn CommandRunner>,
+        );
+        let events = drain(rx);
+        let failed = events
+            .iter()
+            .filter(|e| matches!(e, BroadcastEvent::Failed { .. }))
+            .count();
+        assert_eq!(failed, 4);
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, BroadcastEvent::Finished { .. })));
+    }
+
+    #[test]
+    fn apply_event_transitions_the_right_row_in_place() {
+        let tasks = vec![task(10, "a"), task(20, "b"), task(30, "c")];
+        let mut results = seed_results(&tasks);
+
+        apply_event(&mut results, &BroadcastEvent::Started { host_id: 20 });
+        assert_eq!(results[0].state, HostState::Pending);
+        assert_eq!(results[1].state, HostState::Running);
+        assert_eq!(results[2].state, HostState::Pending);
+
+        apply_event(
+            &mut results,
+            &BroadcastEvent::Finished {
+                host_id: 20,
+                exit: 0,
+                stdout: "hi".into(),
+                stderr: String::new(),
+            },
+        );
+        assert_eq!(results[1].state, HostState::Done { exit: 0 });
+        assert_eq!(results[1].stdout, "hi");
+
+        apply_event(
+            &mut results,
+            &BroadcastEvent::Failed {
+                host_id: 30,
+                reason: "boom".into(),
+            },
+        );
+        assert_eq!(
+            results[2].state,
+            HostState::Failed {
+                reason: "boom".into()
+            }
+        );
+
+        // Length + order preserved; ids untouched.
+        assert_eq!(
+            results.iter().map(|r| r.host_id).collect::<Vec<_>>(),
+            vec![10, 20, 30]
+        );
+    }
+
+    #[test]
+    fn apply_event_does_not_resurrect_terminal_row() {
+        let tasks = vec![task(1, "a")];
+        let mut results = seed_results(&tasks);
+        apply_event(
+            &mut results,
+            &BroadcastEvent::Failed {
+                host_id: 1,
+                reason: "dead".into(),
+            },
+        );
+        // A late/stray Started must not flip a Failed row back to Running.
+        apply_event(&mut results, &BroadcastEvent::Started { host_id: 1 });
+        assert_eq!(
+            results[0].state,
+            HostState::Failed {
+                reason: "dead".into()
+            }
+        );
+    }
+
+    #[test]
+    fn apply_event_ignores_unknown_host_id() {
+        let tasks = vec![task(1, "a")];
+        let mut results = seed_results(&tasks);
+        apply_event(&mut results, &BroadcastEvent::Started { host_id: 999 });
+        assert_eq!(results[0].state, HostState::Pending);
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn failures_first_orders_by_rank_stably() {
+        let mk = |id: i64, state: HostState| HostResult {
+            host_id: id,
+            host_name: id.to_string(),
+            state,
+            stdout: String::new(),
+            stderr: String::new(),
+        };
+        let results = vec![
+            mk(1, HostState::Done { exit: 0 }),
+            mk(2, HostState::Running),
+            mk(3, HostState::Failed { reason: "x".into() }),
+            mk(4, HostState::Pending),
+            mk(5, HostState::Failed { reason: "y".into() }),
+            mk(6, HostState::Done { exit: 1 }),
+        ];
+        let order = failures_first(&results);
+        let ids: Vec<i64> = order.iter().map(|&i| results[i].host_id).collect();
+        // Failed(3,5) < Running(2) < Pending(4) < Done(1,6); ties keep input order.
+        assert_eq!(ids, vec![3, 5, 2, 4, 1, 6]);
+    }
+
+    #[test]
+    fn all_terminal_and_done_count() {
+        let tasks = vec![task(1, "a"), task(2, "b")];
+        let mut results = seed_results(&tasks);
+        assert!(!all_terminal(&results));
+        assert_eq!(done_count(&results), 0);
+
+        apply_event(
+            &mut results,
+            &BroadcastEvent::Finished {
+                host_id: 1,
+                exit: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            },
+        );
+        assert!(!all_terminal(&results));
+        assert_eq!(done_count(&results), 1);
+
+        apply_event(
+            &mut results,
+            &BroadcastEvent::Failed {
+                host_id: 2,
+                reason: "x".into(),
+            },
+        );
+        assert!(all_terminal(&results));
+        assert_eq!(done_count(&results), 2);
+    }
+
+    #[test]
+    fn real_runner_reports_spawn_failure() {
+        // A bogus program name can't spawn → Err, no panic. (No network.)
+        let runner = SshCommandRunner {
+            connect_timeout_secs: 1,
+            run_timeout: Duration::from_secs(1),
+        };
+        let cancel = AtomicBool::new(false);
+        let argv = vec![
+            "definitely-not-a-real-ssh-binary-xyzzy".to_string(),
+            "host".to_string(),
+        ];
+        let res = runner.run(&argv, "true", &cancel);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn real_runner_short_circuits_on_precancel() {
+        let runner = SshCommandRunner::new();
+        let cancel = AtomicBool::new(true);
+        let res = runner.run(&["ssh".to_string(), "host".to_string()], "true", &cancel);
+        assert_eq!(res, Err("cancelled".to_string()));
+    }
+}

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -427,15 +427,33 @@ pub fn all_terminal(results: &[HostResult]) -> bool {
     results.iter().all(|r| r.state.is_terminal())
 }
 
-/// Render-order rank: Failed(0) < Running(1) < Pending(2) < Done(3), so
-/// failures surface first and unfinished work sits above completed rows.
+/// Render-order rank: failures(0) < Running(1) < Pending(2) < clean exit(3), so
+/// anything that went wrong surfaces first and unfinished work sits above the
+/// clean completions. A **non-zero exit code counts as a failure** — the remote
+/// command ran but reported an error — not just ssh-level failures.
 fn state_rank(state: &HostState) -> u8 {
     match state {
         HostState::Failed { .. } => 0,
+        HostState::Done { exit } if *exit != 0 => 0,
         HostState::Running => 1,
         HostState::Pending => 2,
         HostState::Done { .. } => 3,
     }
+}
+
+/// A host result counts as a failure when ssh itself failed OR the remote
+/// command returned a non-zero exit code.
+pub fn is_failure(r: &HostResult) -> bool {
+    match r.state {
+        HostState::Failed { .. } => true,
+        HostState::Done { exit } => exit != 0,
+        HostState::Pending | HostState::Running => false,
+    }
+}
+
+/// Number of failed hosts (ssh failure or non-zero exit) in a finished/partial run.
+pub fn failure_count(results: &[HostResult]) -> usize {
+    results.iter().filter(|r| is_failure(r)).count()
 }
 
 /// Render-time view ordering (does NOT mutate `results`): indices into
@@ -821,8 +839,27 @@ mod tests {
         ];
         let order = failures_first(&results);
         let ids: Vec<i64> = order.iter().map(|&i| results[i].host_id).collect();
-        // Failed(3,5) < Running(2) < Pending(4) < Done(1,6); ties keep input order.
-        assert_eq!(ids, vec![3, 5, 2, 4, 1, 6]);
+        // Failures first — ssh-failed (3,5) AND non-zero exit (6) — then
+        // Running(2) < Pending(4) < clean exit(1); ties keep input order.
+        assert_eq!(ids, vec![3, 5, 6, 2, 4, 1]);
+    }
+
+    #[test]
+    fn failure_count_includes_nonzero_exits() {
+        let mk = |state| HostResult {
+            host_id: 0,
+            host_name: String::new(),
+            state,
+            stdout: String::new(),
+            stderr: String::new(),
+        };
+        let results = vec![
+            mk(HostState::Done { exit: 0 }),
+            mk(HostState::Done { exit: 1 }),
+            mk(HostState::Failed { reason: "x".into() }),
+            mk(HostState::Running),
+        ];
+        assert_eq!(failure_count(&results), 2); // exit 1 + ssh failure
     }
 
     #[test]

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -355,6 +355,16 @@ macro_rules! kb_defaults {
             vec![$($key.to_string()),*]
         }
     };
+    (@fn broadcast $($key:literal),* $(,)?) => {
+        fn default_kb_broadcast() -> Vec<String> {
+            vec![$($key.to_string()),*]
+        }
+    };
+    (@fn broadcast_cancel $($key:literal),* $(,)?) => {
+        fn default_kb_broadcast_cancel() -> Vec<String> {
+            vec![$($key.to_string()),*]
+        }
+    };
 }
 
 kb_defaults! {
@@ -427,6 +437,8 @@ kb_defaults! {
     focus_panel_right => ["Alt+Right"],
     focus_panel_up => ["Alt+Up"],
     focus_panel_down => ["Alt+Down"],
+    broadcast => ["b"],
+    broadcast_cancel => ["x"],
 }
 /// An action whose keybinding is user-configurable and editable in the UI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -500,11 +512,13 @@ pub enum KeyAction {
     FocusPanelRight,
     FocusPanelUp,
     FocusPanelDown,
+    Broadcast,
+    BroadcastCancel,
 }
 
 impl KeyAction {
     /// All editable actions, in display order.
-    pub const ALL: [KeyAction; 69] = [
+    pub const ALL: [KeyAction; 71] = [
         KeyAction::Save,
         KeyAction::Quit,
         KeyAction::Help,
@@ -574,6 +588,8 @@ impl KeyAction {
         KeyAction::FocusPanelRight,
         KeyAction::FocusPanelUp,
         KeyAction::FocusPanelDown,
+        KeyAction::Broadcast,
+        KeyAction::BroadcastCancel,
     ];
 
     pub fn label(self) -> &'static str {
@@ -647,6 +663,8 @@ impl KeyAction {
             KeyAction::FocusPanelRight => "Focus panel right",
             KeyAction::FocusPanelUp => "Focus panel up",
             KeyAction::FocusPanelDown => "Focus panel down",
+            KeyAction::Broadcast => "Broadcast command",
+            KeyAction::BroadcastCancel => "Cancel broadcast",
         }
     }
 }
@@ -792,6 +810,10 @@ pub struct KeybindsConfig {
     pub focus_panel_up: Vec<String>,
     #[serde(default = "default_kb_focus_panel_down")]
     pub focus_panel_down: Vec<String>,
+    #[serde(default = "default_kb_broadcast")]
+    pub broadcast: Vec<String>,
+    #[serde(default = "default_kb_broadcast_cancel")]
+    pub broadcast_cancel: Vec<String>,
 }
 
 impl Default for KeybindsConfig {
@@ -866,6 +888,8 @@ impl Default for KeybindsConfig {
             focus_panel_right: default_kb_focus_panel_right(),
             focus_panel_up: default_kb_focus_panel_up(),
             focus_panel_down: default_kb_focus_panel_down(),
+            broadcast: default_kb_broadcast(),
+            broadcast_cancel: default_kb_broadcast_cancel(),
         }
     }
 }
@@ -942,6 +966,8 @@ impl KeybindsConfig {
             KeyAction::FocusPanelRight => default_kb_focus_panel_right(),
             KeyAction::FocusPanelUp => default_kb_focus_panel_up(),
             KeyAction::FocusPanelDown => default_kb_focus_panel_down(),
+            KeyAction::Broadcast => default_kb_broadcast(),
+            KeyAction::BroadcastCancel => default_kb_broadcast_cancel(),
         }
     }
 
@@ -1063,6 +1089,8 @@ impl KeybindsConfig {
             KeyAction::FocusPanelRight => &self.focus_panel_right,
             KeyAction::FocusPanelUp => &self.focus_panel_up,
             KeyAction::FocusPanelDown => &self.focus_panel_down,
+            KeyAction::Broadcast => &self.broadcast,
+            KeyAction::BroadcastCancel => &self.broadcast_cancel,
         }
     }
 
@@ -1137,6 +1165,8 @@ impl KeybindsConfig {
             KeyAction::FocusPanelRight => self.focus_panel_right = binds,
             KeyAction::FocusPanelUp => self.focus_panel_up = binds,
             KeyAction::FocusPanelDown => self.focus_panel_down = binds,
+            KeyAction::Broadcast => self.broadcast = binds,
+            KeyAction::BroadcastCancel => self.broadcast_cancel = binds,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod broadcast;
 pub mod cli;
 pub mod config;
 pub mod credentials;
@@ -357,6 +358,9 @@ fn poll_keys_and_watcher(app: &mut App) -> Result<()> {
             app.apply_os_detect(ev)?;
         }
     }
+
+    // Drive the live broadcast run (drain worker events, settle/dismiss panel).
+    app.tick_broadcast()?;
 
     // Check tunnel health and drive keep-alive reconnects.
     let _ = app.tick_tunnels();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,14 @@ fn apply_auto_quit(app: &mut App, auto_quit: Option<&str>) -> Result<()> {
 }
 
 fn poll_keys_and_watcher(app: &mut App) -> Result<()> {
-    if event::poll(POLL_INTERVAL)? {
+    // While a panel animation is playing, shorten the poll window so the render
+    // loop redraws at ~60fps and the slide is smooth; otherwise idle at 20fps.
+    let poll_window = if app.animating() {
+        std::time::Duration::from_millis(16)
+    } else {
+        POLL_INTERVAL
+    };
+    if event::poll(poll_window)? {
         // Drain everything already queued: one event per 50ms frame makes
         // paste into an embedded session crawl at ~20 chars/sec.
         loop {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -504,6 +504,8 @@ fn footer_keybinds(app: &App) -> Vec<(String, &'static str)> {
         if app.focused_panel == crate::app::PanelId::Broadcast {
             binds.push(("z".into(), "zoom"));
         }
+    } else if !app.broadcast_toasts.is_empty() {
+        binds.push(("x".into(), "clear errors"));
     }
     if matches!(
         app.mode,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,6 +4,7 @@ pub mod layout;
 pub mod screens;
 pub mod text;
 pub mod theme;
+pub mod tween;
 pub mod widgets;
 
 use ratatui::layout::Rect;
@@ -156,6 +157,24 @@ fn render_inner(frame: &mut Frame, app: &App) {
         _ => render_hosts_body(frame, &areas, app),
     }
 
+    // ── Broadcast mode (#3): docked live panel floats over the dashboard ──
+    // While a broadcast runs it lives in the bottom-right as a floating panel
+    // (or full-body when zoomed + focused). Other panels are not moved, just
+    // covered. The wizard overlays are handled in the mode match below.
+    if let Some(bc) = app.broadcast.as_ref() {
+        let body = dashboard_layout::dashboard_layout_zoomed(frame.area(), app.ui_zoom).body;
+        if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Broadcast {
+            screens::broadcast::render_broadcast_zoomed(frame, body, app);
+        } else {
+            let rect = bc
+                .anim
+                .map(|a| a.rect_at(std::time::Instant::now()))
+                .unwrap_or_else(|| screens::broadcast::docked_rect(body));
+            let focused = app.focused_panel == crate::app::PanelId::Broadcast;
+            screens::broadcast::render_broadcast_panel(frame, rect, app, focused);
+        }
+    }
+
     // Horizontal rule 3: above footer (bold)
     let rule3 = row_in(area, areas.footer.y.saturating_sub(1));
     widgets::footer::render_hrule(frame, rule3, true);
@@ -233,6 +252,9 @@ fn render_inner(frame: &mut Frame, app: &App) {
         AppMode::ConfirmQuit => render_confirm_quit_popup(frame, app),
         AppMode::ImportPrompt => render_import_prompt_popup(frame, app),
         AppMode::SftpPrompt => render_sftp_prompt_popup(frame, app),
+        AppMode::BroadcastPickTarget => screens::broadcast::render_pick_target(frame, app),
+        AppMode::BroadcastCommand => screens::broadcast::render_command_prompt(frame, app),
+        AppMode::BroadcastPreview => screens::broadcast::render_preview(frame, app),
         _ => {}
     }
 }
@@ -469,6 +491,21 @@ fn footer_keybinds(app: &App) -> Vec<(String, &'static str)> {
     if app.active_tab == 0 && app.panel_zoomed {
         binds.push(("drag".into(), "copy"));
     }
+    // Broadcast mode (#3): running panel gets a cancel hint (and a zoom hint
+    // once focused); an active wizard step gets next/cancel.
+    if app.broadcast.is_some() {
+        binds.push(("x".into(), "cancel"));
+        if app.focused_panel == crate::app::PanelId::Broadcast {
+            binds.push(("z".into(), "zoom"));
+        }
+    }
+    if matches!(
+        app.mode,
+        AppMode::BroadcastPickTarget | AppMode::BroadcastCommand | AppMode::BroadcastPreview
+    ) {
+        binds.push(("\u{21b5}".into(), "next"));
+        binds.push(("Esc".into(), "cancel"));
+    }
     if !app.sessions.is_empty() {
         binds.extend(app.config.keybinds.session_footer_hints());
     }
@@ -493,7 +530,10 @@ fn render_zoom_toast(frame: &mut Frame, footer: Rect, notice: &str) {
 
 fn render_hosts_body(frame: &mut Frame, areas: &dashboard_layout::DashboardAreas, app: &App) {
     // Issue #18: a zoomed panel takes over the whole dashboard body.
-    if app.panel_zoomed {
+    // Broadcast (#3) is a floating panel drawn from render_inner instead, so a
+    // zoomed Broadcast must not be handled here (it has no home in the hosts
+    // grid) — let render_inner's broadcast block own it.
+    if app.panel_zoomed && app.focused_panel != crate::app::PanelId::Broadcast {
         render_zoomed_panel(frame, areas.body, app);
         return;
     }
@@ -530,6 +570,7 @@ fn render_zoomed_panel(frame: &mut Frame, area: Rect, app: &App) {
         PanelId::Auth => widgets::right_stack::render_auth_panel(frame.buffer_mut(), area, app),
         PanelId::Ping => widgets::right_stack::render_ping_panel(frame.buffer_mut(), area, app),
         PanelId::SshLog => widgets::middle_stack::render_ssh_log_panel(frame, area, app),
+        PanelId::Broadcast => screens::broadcast::render_broadcast_zoomed(frame, area, app),
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -174,6 +174,12 @@ fn render_inner(frame: &mut Frame, app: &App) {
             screens::broadcast::render_broadcast_panel(frame, rect, app, focused);
         }
     }
+    // Error toasts stack above the docked panel (and can outlive it), so draw
+    // them whenever any exist — not only while the panel is present.
+    if !app.broadcast_toasts.is_empty() {
+        let body = dashboard_layout::dashboard_layout_zoomed(frame.area(), app.ui_zoom).body;
+        screens::broadcast::render_broadcast_toasts(frame, body, app);
+    }
 
     // Horizontal rule 3: above footer (bold)
     let rule3 = row_in(area, areas.footer.y.saturating_sub(1));

--- a/src/tui/screens/broadcast.rs
+++ b/src/tui/screens/broadcast.rs
@@ -105,7 +105,19 @@ fn draw_host_row(
 /// Header title + count badge shared by the docked and zoomed views.
 fn header_parts(bc: &crate::app::BroadcastState) -> (String, String) {
     let title = format!("cast: {} \u{00b7} {}", bc.command, bc.target_label);
-    let badge = format!("{}/{}", done_count(&bc.results), bc.results.len());
+    let fails = crate::broadcast::failure_count(&bc.results);
+    let badge = if fails > 0 {
+        // Surface the failure count right in the title bar so errors are obvious
+        // at a glance even when the failing rows scroll out of a short panel.
+        format!(
+            "{}/{} \u{00b7} {}\u{2717}",
+            done_count(&bc.results),
+            bc.results.len(),
+            fails
+        )
+    } else {
+        format!("{}/{}", done_count(&bc.results), bc.results.len())
+    };
     (title, badge)
 }
 

--- a/src/tui/screens/broadcast.rs
+++ b/src/tui/screens/broadcast.rs
@@ -565,7 +565,7 @@ pub fn render_preview(frame: &mut Frame, app: &App) {
     let hint = if setup.edit_targets {
         "\u{2191}/\u{2193} move \u{00b7} Space toggle \u{00b7} Enter done \u{00b7} Esc cancel"
     } else {
-        "[y] confirm   [e] edit targets   [N] cancel"
+        "[y] confirm   [e] edit targets   [c] edit command   [N] cancel"
     };
     let hint_y = bottom.saturating_sub(1);
     frame.buffer_mut().set_string(

--- a/src/tui/screens/broadcast.rs
+++ b/src/tui/screens/broadcast.rs
@@ -372,14 +372,20 @@ pub fn render_broadcast_toasts(frame: &mut Frame, body: Rect, app: &App) {
     let now = Instant::now();
 
     // Anchor: stack grows upward from `stack_bottom`. With the panel present that
-    // is just above it; once it's gone, drop the toasts down to the panel's old
-    // bottom so they fall into the freed space instead of floating high.
-    let panel_present = app.broadcast.is_some();
-    let mut cur_bottom = if panel_present {
-        dock.y
+    // is just above it (dock.y); once it's gone, the toasts fall down into the
+    // freed space (dock.y + dock.height). The transition animates over TOAST_ANIM
+    // from the moment the panel was dismissed.
+    let top_anchor = dock.y;
+    let low_anchor = dock.y + dock.height;
+    let anchor = if app.broadcast.is_some() {
+        top_anchor
+    } else if let Some(gone) = app.broadcast_panel_gone_at {
+        let t = now.saturating_duration_since(gone).as_secs_f32() / TOAST_ANIM.as_secs_f32();
+        lerp_u16(top_anchor, low_anchor, ease_out(t.clamp(0.0, 1.0)))
     } else {
-        dock.y + dock.height
+        low_anchor
     };
+    let mut cur_bottom = anchor;
 
     for toast in app.broadcast_toasts.iter().rev() {
         let lines = wrap_line_count(&toast.text, inner_w).clamp(1, MAX_TOAST_LINES);
@@ -395,10 +401,10 @@ pub fn render_broadcast_toasts(frame: &mut Frame, body: Rect, app: &App) {
         let elapsed = now.saturating_duration_since(toast.born);
         let x = if elapsed >= TOAST_TTL {
             let t = (elapsed - TOAST_TTL).as_secs_f32() / TOAST_ANIM.as_secs_f32();
-            lerp_x(target_x, off_right, ease_out(t.clamp(0.0, 1.0)))
+            lerp_u16(target_x, off_right, ease_out(t.clamp(0.0, 1.0)))
         } else {
             let t = elapsed.as_secs_f32() / TOAST_ANIM.as_secs_f32();
-            lerp_x(off_right, target_x, ease_out(t.clamp(0.0, 1.0)))
+            lerp_u16(off_right, target_x, ease_out(t.clamp(0.0, 1.0)))
         };
         if x >= off_right {
             continue; // fully off-screen this frame
@@ -426,7 +432,7 @@ pub fn render_broadcast_toasts(frame: &mut Frame, body: Rect, app: &App) {
 }
 
 /// Round a horizontal lerp between two columns.
-fn lerp_x(a: u16, b: u16, t: f32) -> u16 {
+fn lerp_u16(a: u16, b: u16, t: f32) -> u16 {
     (a as f32 + (b as f32 - a as f32) * t).round() as u16
 }
 

--- a/src/tui/screens/broadcast.rs
+++ b/src/tui/screens/broadcast.rs
@@ -16,9 +16,12 @@ use ratatui::layout::Rect;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
+use std::time::Instant;
+
 use crate::app::App;
-use crate::broadcast::{done_count, failures_first, HostState, DISMISS};
+use crate::broadcast::{done_count, failures_first, HostState, DISMISS, TOAST_ANIM, TOAST_TTL};
 use crate::tui::theme;
+use crate::tui::tween::ease_out;
 use crate::tui::widgets::panel_box::{put_clamped, render_panel_box, zoom_window};
 
 // ── Per-host row presentation ───────────────────────────────
@@ -348,6 +351,68 @@ pub fn spawn_rect(body: Rect) -> Rect {
     let x = body.x + body.width.saturating_sub(d.width) / 2;
     let y = body.y + body.height.saturating_sub(d.height) / 2;
     Rect::new(x, y, d.width, d.height)
+}
+
+/// Error toasts (issue #3): one small popup per failed host, stacked upward from
+/// just above the docked panel, sliding in from the right and out again after
+/// `TOAST_TTL`. Newest sits closest to the panel; older toasts climb until they
+/// run out of body height (then they're just not drawn).
+pub fn render_broadcast_toasts(frame: &mut Frame, body: Rect, app: &App) {
+    if app.broadcast_toasts.is_empty() {
+        return;
+    }
+    let dock = docked_rect(body);
+    let h: u16 = 3;
+    let w = dock.width;
+    let target_x = dock.x;
+    let off_right = body.x + body.width; // fully off the right edge
+    let now = Instant::now();
+
+    for (k, toast) in app.broadcast_toasts.iter().rev().enumerate() {
+        let top = dock.y as i32 - (k as i32 + 1) * h as i32;
+        if top < body.y as i32 {
+            break; // stack reached the top of the body
+        }
+        let y = top as u16;
+
+        // Slide progress from `born`: in for the first TOAST_ANIM, hold, then out
+        // once past TOAST_TTL. No stored state — all derived from elapsed time.
+        let elapsed = now.saturating_duration_since(toast.born);
+        let x = if elapsed >= TOAST_TTL {
+            let t = (elapsed - TOAST_TTL).as_secs_f32() / TOAST_ANIM.as_secs_f32();
+            lerp_x(target_x, off_right, ease_out(t.clamp(0.0, 1.0)))
+        } else {
+            let t = elapsed.as_secs_f32() / TOAST_ANIM.as_secs_f32();
+            lerp_x(off_right, target_x, ease_out(t.clamp(0.0, 1.0)))
+        };
+        if x >= off_right {
+            continue; // fully off-screen this frame
+        }
+        let vis_w = w.min(off_right - x);
+        if vis_w < 6 {
+            continue;
+        }
+        let rect = Rect::new(x, y, vis_w, h);
+
+        frame.render_widget(Clear, rect);
+        let title =
+            crate::tui::text::ellipsize(&format!(" \u{2717} {} ", toast.host), vis_w as usize);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme::red())
+            .title(Span::styled(title, theme::red()));
+        let inner = block.inner(rect);
+        frame.render_widget(block, rect);
+        let para = Paragraph::new(toast.text.as_str())
+            .style(theme::dim())
+            .wrap(Wrap { trim: true });
+        frame.render_widget(para, inner);
+    }
+}
+
+/// Round a horizontal lerp between two columns.
+fn lerp_x(a: u16, b: u16, t: f32) -> u16 {
+    (a as f32 + (b as f32 - a as f32) * t).round() as u16
 }
 
 // ── Pre-run overlay stages ──────────────────────────────────

--- a/src/tui/screens/broadcast.rs
+++ b/src/tui/screens/broadcast.rs
@@ -1,0 +1,577 @@
+//! Broadcast mode (issue #3) render layer — pure draw functions.
+//!
+//! Two families of surfaces:
+//!  * pre-run overlay stages (`render_pick_target` / `render_command_prompt` /
+//!    `render_preview`) — modal popups over the hosts dashboard, mirroring the
+//!    `render_sftp_prompt_popup` idiom (Clear + Block/Paragraph);
+//!  * the live docked panel (`render_broadcast_panel`) plus its full-screen
+//!    zoomed view (`render_broadcast_zoomed`) and the countdown gauge
+//!    (`render_countdown_bar`), driven by the #18 panel focus/zoom machinery.
+//!
+//! Nothing here mutates `App` except the `zoom_window` scroll write-back that
+//! issue #18 panels already use.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+
+use crate::app::App;
+use crate::broadcast::{done_count, failures_first, HostState, DISMISS};
+use crate::tui::theme;
+use crate::tui::widgets::panel_box::{put_clamped, render_panel_box, zoom_window};
+
+// ── Per-host row presentation ───────────────────────────────
+
+/// Glyph + style + short status label for one host state. Single-cell glyphs
+/// keep the row columns aligned across terminals (no emoji double-width).
+fn state_row(state: &HostState) -> (&'static str, Style, String) {
+    match state {
+        HostState::Pending => ("\u{25cb}", theme::mute(), "pending".to_string()),
+        HostState::Running => ("\u{25cf}", theme::amber(), "running".to_string()),
+        HostState::Done { exit: 0 } => ("\u{2713}", theme::green(), "exit 0".to_string()),
+        HostState::Done { exit } => ("\u{2717}", theme::red(), format!("exit {exit}")),
+        HostState::Failed { .. } => ("\u{2717}", theme::red(), "failed".to_string()),
+    }
+}
+
+/// Trailing detail (failure reason / stderr snippet) shown after the status
+/// label. Empty for healthy/pending/running rows.
+fn state_detail(result: &crate::broadcast::HostResult) -> String {
+    match &result.state {
+        HostState::Failed { reason } => reason.clone(),
+        HostState::Done { exit } if *exit != 0 => result
+            .stderr
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or("")
+            .to_string(),
+        _ => String::new(),
+    }
+}
+
+/// Draw a single host row into `buf` at row `y`, inside `[inner_x, right_lim)`.
+fn draw_host_row(
+    buf: &mut Buffer,
+    y: u16,
+    inner_x: u16,
+    right_lim: u16,
+    result: &crate::broadcast::HostResult,
+) {
+    if inner_x >= right_lim {
+        return;
+    }
+    let inner_w = (right_lim - inner_x) as usize;
+    let (glyph, gstyle, label) = state_row(&result.state);
+
+    // Glyph column (1 cell + space).
+    buf.set_string(inner_x, y, glyph, gstyle);
+    let mut col = inner_x + 2;
+    if col >= right_lim {
+        return;
+    }
+
+    // Host name — left column, roughly a third of the width, min 8.
+    let name_w = (inner_w / 3).clamp(8, 22).min((right_lim - col) as usize);
+    col += put_clamped(buf, col, y, &result.host_name, theme::text(), name_w);
+    // Pad the name column so the status labels line up.
+    while col < inner_x + 2 + name_w as u16 && col < right_lim {
+        buf.set_string(col, y, " ", theme::text());
+        col += 1;
+    }
+    col += 1;
+    if col >= right_lim {
+        return;
+    }
+
+    // Status label, coloured like the glyph.
+    col += put_clamped(buf, col, y, &label, gstyle, (right_lim - col) as usize);
+    col += 1;
+
+    // Optional failure detail in dim.
+    let detail = state_detail(result);
+    if !detail.is_empty() && col < right_lim {
+        put_clamped(
+            buf,
+            col,
+            y,
+            &detail,
+            theme::dim(),
+            (right_lim - col) as usize,
+        );
+    }
+}
+
+/// Header title + count badge shared by the docked and zoomed views.
+fn header_parts(bc: &crate::app::BroadcastState) -> (String, String) {
+    let title = format!("cast: {} \u{00b7} {}", bc.command, bc.target_label);
+    let badge = format!("{}/{}", done_count(&bc.results), bc.results.len());
+    (title, badge)
+}
+
+// ── Live docked panel ───────────────────────────────────────
+
+/// Live docked panel drawn into `area` (already positioned/animated by the
+/// caller). `focused` drives the accent border (issue #18). Header
+/// `cast: <cmd> · <target> · N/total`, per-host rows (`failures_first`), and a
+/// countdown gauge along the bottom when Settling.
+pub fn render_broadcast_panel(frame: &mut Frame, area: Rect, app: &App, focused: bool) {
+    let Some(bc) = app.broadcast.as_ref() else {
+        return;
+    };
+    if area.width < 4 || area.height < 3 {
+        return;
+    }
+
+    // Float overlay: wipe the cells beneath first so the dashboard grid behind
+    // the docked panel never bleeds through empty interior rows / trailing cells.
+    frame.render_widget(Clear, area);
+    let (title, badge) = header_parts(bc);
+    render_panel_box(frame.buffer_mut(), area, &title, Some(&badge), focused);
+
+    let inner_x = area.x + 2;
+    let right_lim = area.x + area.width - 1; // last col is the border
+    let bottom = area.y + area.height - 1; // border row
+
+    // When settling, reserve the last inner row for the countdown gauge.
+    let settling_frac = match &bc.phase {
+        crate::app::BroadcastPhase::Settling { done_at } => {
+            let elapsed = done_at.elapsed().as_secs_f32();
+            Some((elapsed / DISMISS.as_secs_f32()).clamp(0.0, 1.0))
+        }
+        _ => None,
+    };
+    let rows_bottom = if settling_frac.is_some() {
+        bottom.saturating_sub(1)
+    } else {
+        bottom
+    };
+
+    let order = failures_first(&bc.results);
+    let capacity = rows_bottom.saturating_sub(area.y + 1) as usize;
+    for (y, &idx) in (area.y + 1..rows_bottom).zip(order.iter()) {
+        draw_host_row(frame.buffer_mut(), y, inner_x, right_lim, &bc.results[idx]);
+    }
+    // More hosts than rows — replace the last visible row with an overflow marker.
+    if order.len() > capacity && rows_bottom > area.y + 1 {
+        put_clamped(
+            frame.buffer_mut(),
+            inner_x,
+            rows_bottom - 1,
+            "\u{2026}",
+            theme::dim(),
+            (right_lim - inner_x) as usize,
+        );
+    }
+
+    if let Some(frac) = settling_frac {
+        let bar = Rect::new(inner_x, bottom.saturating_sub(1), right_lim - inner_x, 1);
+        render_countdown_bar(frame, bar, frac);
+    }
+}
+
+// ── Zoomed full-body view (issue #18) ───────────────────────
+
+/// Zoomed full-body view: a selectable failures-first host list on top, and the
+/// selected host's stdout/stderr in a detail pane below. Scroll via
+/// `zoom_window(app, len, visible)`.
+pub fn render_broadcast_zoomed(frame: &mut Frame, area: Rect, app: &App) {
+    let Some(bc) = app.broadcast.as_ref() else {
+        return;
+    };
+    if area.width < 6 || area.height < 4 {
+        return;
+    }
+
+    frame.render_widget(Clear, area);
+    let (title, badge) = header_parts(bc);
+    render_panel_box(frame.buffer_mut(), area, &title, Some(&badge), true);
+
+    let inner_x = area.x + 2;
+    let right_lim = area.x + area.width - 1;
+    let inner_w = (right_lim - inner_x) as usize;
+    let bottom = area.y + area.height - 1;
+
+    let order = failures_first(&bc.results);
+    let len = order.len();
+
+    // Split the inner body: ~55% for the list, the rest for the detail pane.
+    let inner_h = bottom.saturating_sub(area.y + 1) as usize;
+    let list_h = ((inner_h * 55) / 100).clamp(1, inner_h.max(1));
+    let visible = list_h.max(1);
+
+    let (first, sel) = zoom_window(app, len, visible);
+
+    // ── Host list ───────────────────────────────────────────
+    for (row, &idx) in order.iter().enumerate().skip(first).take(visible) {
+        let y = area.y + 1 + (row - first) as u16;
+        if y >= area.y + 1 + list_h as u16 || y >= bottom {
+            break;
+        }
+        draw_host_row(frame.buffer_mut(), y, inner_x, right_lim, &bc.results[idx]);
+        if row == sel {
+            for col in inner_x..right_lim {
+                if let Some(cell) = frame.buffer_mut().cell_mut((col, y)) {
+                    cell.modifier.insert(Modifier::REVERSED);
+                }
+            }
+        }
+    }
+
+    // ── Divider ─────────────────────────────────────────────
+    let div_y = area.y + 1 + list_h as u16;
+    if div_y < bottom {
+        let sep: String = "\u{2500}".repeat(inner_w);
+        frame
+            .buffer_mut()
+            .set_string(inner_x, div_y, &sep, theme::dim());
+    }
+
+    // ── Detail pane for the selected host ───────────────────
+    if len == 0 {
+        return;
+    }
+    let selected = &bc.results[order[sel.min(len - 1)]];
+    let mut dy = div_y + 1;
+    if dy >= bottom {
+        return;
+    }
+
+    let head = format!("{} \u{2014} output", selected.host_name);
+    put_clamped(
+        frame.buffer_mut(),
+        inner_x,
+        dy,
+        &head,
+        theme::bright(),
+        inner_w,
+    );
+    dy += 1;
+
+    let push_block = |frame: &mut Frame, dy: &mut u16, tag: &str, body: &str, tag_style: Style| {
+        if body.trim().is_empty() || *dy >= bottom {
+            return;
+        }
+        put_clamped(frame.buffer_mut(), inner_x, *dy, tag, tag_style, inner_w);
+        *dy += 1;
+        for line in body.lines() {
+            if *dy >= bottom {
+                break;
+            }
+            put_clamped(
+                frame.buffer_mut(),
+                inner_x + 2,
+                *dy,
+                line,
+                theme::text(),
+                inner_w.saturating_sub(2),
+            );
+            *dy += 1;
+        }
+    };
+
+    push_block(frame, &mut dy, "stdout:", &selected.stdout, theme::mute());
+    push_block(frame, &mut dy, "stderr:", &selected.stderr, theme::red());
+
+    if selected.stdout.trim().is_empty() && selected.stderr.trim().is_empty() && dy < bottom {
+        put_clamped(
+            frame.buffer_mut(),
+            inner_x,
+            dy,
+            "(no output)",
+            theme::dim(),
+            inner_w,
+        );
+    }
+}
+
+// ── Countdown gauge ─────────────────────────────────────────
+
+/// Thin countdown gauge along a 1-row `area`. `frac` in [0,1] = elapsed/DISMISS;
+/// the filled portion depletes as the countdown runs out.
+pub fn render_countdown_bar(frame: &mut Frame, area: Rect, frac: f32) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let frac = frac.clamp(0.0, 1.0);
+    let remaining_secs = (DISMISS.as_secs_f32() * (1.0 - frac)).ceil() as u32;
+    let label = format!(" dismiss {remaining_secs}s ");
+    let label_w = label.chars().count() as u16;
+
+    let total = area.width;
+    let bar_w = total.saturating_sub(label_w);
+    let filled = ((bar_w as f32) * (1.0 - frac)).round() as u16;
+
+    let buf = frame.buffer_mut();
+    let y = area.y;
+    // Filled (remaining) portion in cyan, spent portion in dim.
+    for i in 0..bar_w {
+        let ch = if i < filled { "\u{2501}" } else { "\u{2500}" };
+        let style = if i < filled {
+            theme::cyan()
+        } else {
+            theme::dim()
+        };
+        buf.set_string(area.x + i, y, ch, style);
+    }
+    if label_w > 0 && bar_w < total {
+        buf.set_string(area.x + bar_w, y, &label, theme::mute());
+    }
+}
+
+// ── Docked / spawn geometry (shared with the orchestrator) ──
+
+/// Resting docked rect: bottom-right corner of the dashboard body.
+pub fn docked_rect(body: Rect) -> Rect {
+    let w = 54u16.min(body.width.saturating_sub(2)).max(20);
+    let h = 13u16.min(body.height.saturating_sub(2)).max(6);
+    let x = body.x + body.width.saturating_sub(w).saturating_sub(1);
+    let y = body.y + body.height.saturating_sub(h).saturating_sub(1);
+    Rect::new(x, y, w, h)
+}
+
+/// Entry-slide start rect: centered over the body (same size as `docked_rect`).
+pub fn spawn_rect(body: Rect) -> Rect {
+    let d = docked_rect(body);
+    let x = body.x + body.width.saturating_sub(d.width) / 2;
+    let y = body.y + body.height.saturating_sub(d.height) / 2;
+    Rect::new(x, y, d.width, d.height)
+}
+
+// ── Pre-run overlay stages ──────────────────────────────────
+
+/// Centered popup rect helper, clamped to the frame.
+fn popup_rect(frame: &Frame, w_pct: u16, min_w: u16, h: u16) -> Rect {
+    let area = frame.area();
+    let w = (area.width * w_pct / 100).max(min_w).min(area.width);
+    let h = h.min(area.height);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    Rect::new(x, y, w, h)
+}
+
+/// "Broadcast to:" menu — pick a group or tag as the target set.
+pub fn render_pick_target(frame: &mut Frame, app: &App) {
+    let Some(setup) = app.broadcast_setup.as_ref() else {
+        return;
+    };
+
+    let list_rows = setup.options.len().clamp(1, 12) as u16;
+    let popup = popup_rect(frame, 60, 40, list_rows + 4);
+
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(Span::styled(" Broadcast to ", theme::heading()))
+            .border_style(theme::popup_border()),
+        popup,
+    );
+
+    let row_x = popup.x + 2;
+    let inner_w = popup.width.saturating_sub(4) as usize;
+    let list_top = popup.y + 1;
+    let visible = popup.height.saturating_sub(3) as usize;
+
+    let buf = frame.buffer_mut();
+    if setup.options.is_empty() {
+        buf.set_string(row_x, list_top, "(no groups or tags)", theme::mute());
+    } else {
+        let scroll = setup
+            .menu_selected
+            .saturating_sub(visible.saturating_sub(1));
+        for (i, opt) in setup.options.iter().skip(scroll).take(visible).enumerate() {
+            let idx = scroll + i;
+            let ry = list_top + i as u16;
+            let is_sel = idx == setup.menu_selected;
+            let text = match opt {
+                crate::app::BroadcastTarget::Group { label, .. } => {
+                    format!("group: {label}")
+                }
+                crate::app::BroadcastTarget::Tag { name } => format!("#{name}"),
+            };
+            if is_sel {
+                let blank = " ".repeat(popup.width.saturating_sub(2) as usize);
+                buf.set_string(popup.x + 1, ry, &blank, theme::selected());
+            }
+            let marker = if is_sel { "\u{203a} " } else { "  " };
+            let style = if is_sel {
+                theme::selected()
+            } else {
+                theme::text()
+            };
+            buf.set_string(
+                row_x,
+                ry,
+                crate::tui::text::ellipsize(&format!("{marker}{text}"), inner_w),
+                style,
+            );
+        }
+    }
+
+    let hint_y = popup.y + popup.height.saturating_sub(2);
+    buf.set_string(
+        row_x,
+        hint_y,
+        crate::tui::text::ellipsize(
+            "\u{2191}/\u{2193} select \u{00b7} Enter \u{00b7} Esc cancel",
+            inner_w,
+        ),
+        theme::mute(),
+    );
+}
+
+/// "cmd>" single-line command prompt for the chosen target.
+pub fn render_command_prompt(frame: &mut Frame, app: &App) {
+    let Some(setup) = app.broadcast_setup.as_ref() else {
+        return;
+    };
+
+    let popup = popup_rect(frame, 70, 44, 7);
+
+    let lines = vec![
+        Line::from(Span::styled(
+            format!("Command to run on {}:", setup.target_label),
+            theme::text(),
+        )),
+        Line::from(Span::styled(
+            format!(
+                "cmd> {}",
+                crate::text_input::with_cursor(&setup.command, setup.cursor)
+            ),
+            theme::bright(),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Enter: preview  \u{2502}  Esc: cancel",
+            theme::dim(),
+        )),
+    ];
+
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Paragraph::new(lines).wrap(Wrap { trim: false }).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(Span::styled(" Broadcast command ", theme::heading()))
+                .border_style(theme::popup_border()),
+        ),
+        popup,
+    );
+}
+
+/// Dry-run preview: the resolved target list + command, with the
+/// `[y]` / `[e]` / `[N]` barrier. `[e]` toggles per-host deselect.
+pub fn render_preview(frame: &mut Frame, app: &App) {
+    let Some(setup) = app.broadcast_setup.as_ref() else {
+        return;
+    };
+
+    let selected_count = setup.candidates.iter().filter(|c| c.selected).count();
+    let list_rows = setup.candidates.len().clamp(1, 14) as u16;
+    let popup = popup_rect(frame, 74, 50, list_rows + 6);
+
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(Span::styled(" Broadcast preview ", theme::heading()))
+            .border_style(theme::popup_border()),
+        popup,
+    );
+
+    let row_x = popup.x + 2;
+    let inner_w = popup.width.saturating_sub(4) as usize;
+    let mut y = popup.y + 1;
+    let bottom = popup.y + popup.height - 1;
+
+    // Summary line.
+    let summary = format!(
+        "Run `{}` on {} host{} ({}):",
+        setup.command,
+        selected_count,
+        if selected_count == 1 { "" } else { "s" },
+        setup.target_label,
+    );
+    {
+        let buf = frame.buffer_mut();
+        buf.set_string(
+            row_x,
+            y,
+            crate::tui::text::ellipsize(&summary, inner_w),
+            theme::text(),
+        );
+    }
+    y += 2;
+
+    // Target list. In edit mode, show checkboxes + highlight the cursor row.
+    let list_bottom = bottom.saturating_sub(2);
+    let visible = list_bottom.saturating_sub(y) as usize;
+    let scroll = if setup.edit_targets {
+        setup
+            .preview_selected
+            .saturating_sub(visible.saturating_sub(1))
+    } else {
+        0
+    };
+
+    let buf = frame.buffer_mut();
+    if setup.candidates.is_empty() {
+        buf.set_string(row_x, y, "(no managed hosts in target)", theme::mute());
+    } else {
+        for (i, cand) in setup
+            .candidates
+            .iter()
+            .skip(scroll)
+            .take(visible)
+            .enumerate()
+        {
+            let idx = scroll + i;
+            let ry = y + i as u16;
+            if ry >= list_bottom {
+                break;
+            }
+            let is_cursor = setup.edit_targets && idx == setup.preview_selected;
+            let checkbox = if setup.edit_targets {
+                if cand.selected {
+                    "[\u{2713}] "
+                } else {
+                    "[ ] "
+                }
+            } else {
+                "\u{00b7} "
+            };
+            let name_style = if !cand.selected {
+                theme::dim()
+            } else if is_cursor {
+                theme::selected()
+            } else {
+                theme::text()
+            };
+            if is_cursor {
+                let blank = " ".repeat(popup.width.saturating_sub(2) as usize);
+                buf.set_string(popup.x + 1, ry, &blank, theme::selected());
+            }
+            buf.set_string(
+                row_x,
+                ry,
+                crate::tui::text::ellipsize(&format!("{checkbox}{}", cand.host_name), inner_w),
+                name_style,
+            );
+        }
+    }
+
+    // Barrier hint.
+    let hint = if setup.edit_targets {
+        "\u{2191}/\u{2193} move \u{00b7} Space toggle \u{00b7} Enter done \u{00b7} Esc cancel"
+    } else {
+        "[y] confirm   [e] edit targets   [N] cancel"
+    };
+    let hint_y = bottom.saturating_sub(1);
+    frame.buffer_mut().set_string(
+        row_x,
+        hint_y,
+        crate::tui::text::ellipsize(hint, inner_w),
+        theme::mute(),
+    );
+}

--- a/src/tui/screens/broadcast.rs
+++ b/src/tui/screens/broadcast.rs
@@ -353,27 +353,42 @@ pub fn spawn_rect(body: Rect) -> Rect {
     Rect::new(x, y, d.width, d.height)
 }
 
-/// Error toasts (issue #3): one small popup per failed host, stacked upward from
-/// just above the docked panel, sliding in from the right and out again after
-/// `TOAST_TTL`. Newest sits closest to the panel; older toasts climb until they
-/// run out of body height (then they're just not drawn).
+/// Max wrapped text lines a toast shows (older content is clipped by the box).
+const MAX_TOAST_LINES: usize = 6;
+
+/// Error toasts (issue #3): one popup per failed host, sliding in from the right
+/// and out again after `TOAST_TTL`. They stack **up from just above the docked
+/// panel** while it's on screen, and **down into the vacated bottom-right** once
+/// the panel is gone. Each box is sized to wrap its full error text (capped).
 pub fn render_broadcast_toasts(frame: &mut Frame, body: Rect, app: &App) {
     if app.broadcast_toasts.is_empty() {
         return;
     }
     let dock = docked_rect(body);
-    let h: u16 = 3;
     let w = dock.width;
+    let inner_w = w.saturating_sub(2) as usize; // inside the borders
     let target_x = dock.x;
     let off_right = body.x + body.width; // fully off the right edge
     let now = Instant::now();
 
-    for (k, toast) in app.broadcast_toasts.iter().rev().enumerate() {
-        let top = dock.y as i32 - (k as i32 + 1) * h as i32;
-        if top < body.y as i32 {
-            break; // stack reached the top of the body
+    // Anchor: stack grows upward from `stack_bottom`. With the panel present that
+    // is just above it; once it's gone, drop the toasts down to the panel's old
+    // bottom so they fall into the freed space instead of floating high.
+    let panel_present = app.broadcast.is_some();
+    let mut cur_bottom = if panel_present {
+        dock.y
+    } else {
+        dock.y + dock.height
+    };
+
+    for toast in app.broadcast_toasts.iter().rev() {
+        let lines = wrap_line_count(&toast.text, inner_w).clamp(1, MAX_TOAST_LINES);
+        let height = lines as u16 + 2; // borders
+        if cur_bottom < body.y + height {
+            break; // no room left above
         }
-        let y = top as u16;
+        let y = cur_bottom - height;
+        cur_bottom = y; // the next (older) toast sits above this one
 
         // Slide progress from `born`: in for the first TOAST_ANIM, hold, then out
         // once past TOAST_TTL. No stored state — all derived from elapsed time.
@@ -392,7 +407,7 @@ pub fn render_broadcast_toasts(frame: &mut Frame, body: Rect, app: &App) {
         if vis_w < 6 {
             continue;
         }
-        let rect = Rect::new(x, y, vis_w, h);
+        let rect = Rect::new(x, y, vis_w, height);
 
         frame.render_widget(Clear, rect);
         let title =
@@ -413,6 +428,31 @@ pub fn render_broadcast_toasts(frame: &mut Frame, body: Rect, app: &App) {
 /// Round a horizontal lerp between two columns.
 fn lerp_x(a: u16, b: u16, t: f32) -> u16 {
     (a as f32 + (b as f32 - a as f32) * t).round() as u16
+}
+
+/// Greedy word-wrap line count for `text` at `width` (matches `Wrap{trim}` well
+/// enough to size a toast box). Blank input still counts as one line.
+fn wrap_line_count(text: &str, width: usize) -> usize {
+    if width == 0 {
+        return 1;
+    }
+    let mut lines = 0usize;
+    for para in text.split('\n') {
+        let mut col = 0usize;
+        for word in para.split_whitespace() {
+            let wl = word.chars().count();
+            if col == 0 {
+                col = wl;
+            } else if col + 1 + wl <= width {
+                col += 1 + wl;
+            } else {
+                lines += 1;
+                col = wl;
+            }
+        }
+        lines += 1; // the paragraph's final (or only/empty) line
+    }
+    lines.max(1)
 }
 
 // ── Pre-run overlay stages ──────────────────────────────────

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit;
+pub mod broadcast;
 pub mod field_picker;
 pub mod group_form;
 pub mod group_manage;

--- a/src/tui/tween.rs
+++ b/src/tui/tween.rs
@@ -1,0 +1,186 @@
+//! Tiny dependency-free tween helpers for panel slide animations.
+//!
+//! `SlideAnim` interpolates a `Rect` from `from` to `to` over `dur`, using a
+//! cubic ease-out curve. Depends only on `ratatui::layout::Rect` + `std::time`.
+
+use std::time::{Duration, Instant};
+
+use ratatui::layout::Rect;
+
+/// A rect slide from `from` to `to`, eased over `dur` starting at `start`.
+#[derive(Debug, Clone, Copy)]
+pub struct SlideAnim {
+    pub from: Rect,
+    pub to: Rect,
+    pub start: Instant,
+    pub dur: Duration,
+}
+
+impl SlideAnim {
+    /// Construct a slide whose clock starts now.
+    pub fn new(from: Rect, to: Rect, dur: Duration) -> Self {
+        Self {
+            from,
+            to,
+            start: Instant::now(),
+            dur,
+        }
+    }
+
+    /// Eased-lerp rect at `now`. Returns exactly `to` once `dur` has elapsed
+    /// (and exactly `from` at `t == 0`).
+    pub fn rect_at(&self, now: Instant) -> Rect {
+        if self.dur.is_zero() {
+            return self.to;
+        }
+        let elapsed = now.saturating_duration_since(self.start);
+        if elapsed >= self.dur {
+            return self.to;
+        }
+        let t = elapsed.as_secs_f32() / self.dur.as_secs_f32();
+        rect_lerp(self.from, self.to, ease_out(t))
+    }
+
+    /// True once `dur` has elapsed since `start`.
+    pub fn is_done(&self, now: Instant) -> bool {
+        now.saturating_duration_since(self.start) >= self.dur
+    }
+}
+
+/// Cubic ease-out on `t` clamped to `[0, 1]` -> `[0, 1]`: `1 - (1 - t)^3`.
+pub fn ease_out(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    let inv = 1.0 - t;
+    1.0 - inv * inv * inv
+}
+
+/// Per-field linear interpolation of a `Rect` at (already-eased) `t`, rounded.
+///
+/// `t` is clamped to `[0, 1]`; each `u16` field is interpolated independently
+/// and rounded to the nearest integer.
+pub fn rect_lerp(from: Rect, to: Rect, t: f32) -> Rect {
+    let t = t.clamp(0.0, 1.0);
+    Rect {
+        x: lerp_u16(from.x, to.x, t),
+        y: lerp_u16(from.y, to.y, t),
+        width: lerp_u16(from.width, to.width, t),
+        height: lerp_u16(from.height, to.height, t),
+    }
+}
+
+/// Linearly interpolate one `u16` field and round to nearest.
+fn lerp_u16(a: u16, b: u16, t: f32) -> u16 {
+    let a = a as f32;
+    let b = b as f32;
+    (a + (b - a) * t).round().clamp(0.0, u16::MAX as f32) as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(x: u16, y: u16, w: u16, h: u16) -> Rect {
+        Rect {
+            x,
+            y,
+            width: w,
+            height: h,
+        }
+    }
+
+    #[test]
+    fn ease_out_endpoints() {
+        assert_eq!(ease_out(0.0), 0.0);
+        assert_eq!(ease_out(1.0), 1.0);
+    }
+
+    #[test]
+    fn ease_out_clamps_out_of_range() {
+        assert_eq!(ease_out(-1.0), 0.0);
+        assert_eq!(ease_out(2.0), 1.0);
+    }
+
+    #[test]
+    fn ease_out_monotonic() {
+        let mut prev = ease_out(0.0);
+        let mut t = 0.0;
+        while t <= 1.0 {
+            let cur = ease_out(t);
+            assert!(cur >= prev, "ease_out not monotonic at t={t}");
+            prev = cur;
+            t += 0.05;
+        }
+    }
+
+    #[test]
+    fn ease_out_is_ahead_of_linear() {
+        // Ease-out front-loads progress: it should exceed linear in the middle.
+        assert!(ease_out(0.5) > 0.5);
+    }
+
+    #[test]
+    fn rect_lerp_endpoints() {
+        let from = rect(0, 0, 10, 4);
+        let to = rect(20, 10, 30, 8);
+        assert_eq!(rect_lerp(from, to, 0.0), from);
+        assert_eq!(rect_lerp(from, to, 1.0), to);
+    }
+
+    #[test]
+    fn rect_lerp_midpoint() {
+        let from = rect(0, 0, 10, 4);
+        let to = rect(20, 10, 30, 8);
+        assert_eq!(rect_lerp(from, to, 0.5), rect(10, 5, 20, 6));
+    }
+
+    #[test]
+    fn rect_lerp_clamps_t() {
+        let from = rect(0, 0, 10, 4);
+        let to = rect(20, 10, 30, 8);
+        assert_eq!(rect_lerp(from, to, -1.0), from);
+        assert_eq!(rect_lerp(from, to, 2.0), to);
+    }
+
+    #[test]
+    fn rect_at_endpoints() {
+        let from = rect(10, 10, 40, 12);
+        let to = rect(60, 20, 20, 6);
+        let dur = Duration::from_millis(250);
+        let anim = SlideAnim::new(from, to, dur);
+
+        // t == 0 -> exactly `from`.
+        assert_eq!(anim.rect_at(anim.start), from);
+        // elapsed >= dur -> exactly `to`.
+        assert_eq!(anim.rect_at(anim.start + dur), to);
+        assert_eq!(anim.rect_at(anim.start + dur + Duration::from_secs(1)), to);
+    }
+
+    #[test]
+    fn rect_at_between_endpoints() {
+        let from = rect(0, 0, 40, 12);
+        let to = rect(60, 20, 20, 6);
+        let dur = Duration::from_millis(200);
+        let anim = SlideAnim::new(from, to, dur);
+        let mid = anim.rect_at(anim.start + Duration::from_millis(100));
+        // Strictly between the endpoints on the moving x axis.
+        assert!(mid.x > from.x && mid.x < to.x, "x={} not between", mid.x);
+    }
+
+    #[test]
+    fn rect_at_zero_duration_is_target() {
+        let from = rect(0, 0, 40, 12);
+        let to = rect(60, 20, 20, 6);
+        let anim = SlideAnim::new(from, to, Duration::ZERO);
+        assert_eq!(anim.rect_at(anim.start), to);
+    }
+
+    #[test]
+    fn is_done_transitions() {
+        let from = rect(0, 0, 40, 12);
+        let to = rect(60, 20, 20, 6);
+        let dur = Duration::from_millis(250);
+        let anim = SlideAnim::new(from, to, dur);
+        assert!(!anim.is_done(anim.start));
+        assert!(anim.is_done(anim.start + dur));
+    }
+}

--- a/src/tui/widgets/status_bar.rs
+++ b/src/tui/widgets/status_bar.rs
@@ -31,6 +31,9 @@ fn mode_label(mode: AppMode) -> &'static str {
         AppMode::SftpPrompt => "SFTP",
         AppMode::Connecting => "Connecting",
         AppMode::Session => "Session",
+        AppMode::BroadcastPickTarget => "Broadcast",
+        AppMode::BroadcastCommand => "Broadcast",
+        AppMode::BroadcastPreview => "Broadcast",
     }
 }
 

--- a/tests/e2e/broadcast.rs
+++ b/tests/e2e/broadcast.rs
@@ -1,0 +1,170 @@
+//! Offline e2e for broadcast mode (#3): drives the pre-run wizard (pick target →
+//! command → preview) through the real key handlers and asserts on the rendered
+//! `TestBackend` buffer. Stops BEFORE pressing `y`, which would spawn a real
+//! `SshCommandRunner` (actual ssh) — everything up to the barrier is pure UI.
+
+use std::sync::Arc;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::Terminal;
+
+use sshub::app::{App, AppDeps, AppMode};
+use sshub::config::AppConfig;
+use sshub::metadata::MetadataDb;
+use sshub::ssh::{HostResolver, SshHost};
+use sshub::store::{LauncherStore, NewHost};
+
+/// No ssh_config hosts: the only managed hosts come from the store below.
+struct EmptyResolver;
+
+impl HostResolver for EmptyResolver {
+    fn list_hosts(&self) -> anyhow::Result<Vec<String>> {
+        Ok(vec![])
+    }
+
+    fn resolve_host(&self, name: &str) -> anyhow::Result<SshHost> {
+        Ok(SshHost::new(name))
+    }
+}
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::empty())
+}
+
+fn key_char(c: char) -> KeyEvent {
+    KeyEvent::new(KeyCode::Char(c), KeyModifiers::empty())
+}
+
+fn type_text(app: &mut App, text: &str) {
+    for c in text.chars() {
+        app.handle_key(key_char(c)).unwrap();
+    }
+}
+
+/// Two managed hosts sharing the tag `web`, so the broadcast target menu offers
+/// `#web` and both hosts resolve as candidates.
+fn app_with_tagged_hosts() -> App {
+    let store = Arc::new(LauncherStore::open_in_memory().unwrap());
+    for (name, addr) in [("web-1", "10.0.0.1"), ("web-2", "10.0.0.2")] {
+        store
+            .create_host(&NewHost {
+                tags: vec!["web".to_string()],
+                ..NewHost::launcher(name, addr)
+            })
+            .unwrap();
+    }
+
+    let mut app = App::new_with_deps(
+        AppConfig::default(),
+        AppDeps {
+            resolver: Box::new(EmptyResolver),
+            metadata: Arc::new(MetadataDb::default()),
+            store,
+            password_store: Box::new(sshub::credentials::NoopPasswordStore),
+        },
+    );
+    app.reload_hosts().unwrap();
+    app
+}
+
+/// Draw the app into an offline `TestBackend` and return the rendered buffer.
+fn render_to_buffer(app: &App) -> Buffer {
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| sshub::tui::render(frame, app))
+        .unwrap();
+    terminal.backend().buffer().clone()
+}
+
+/// True if `needle` appears within any single rendered row.
+fn buffer_contains(buffer: &Buffer, needle: &str) -> bool {
+    let area = buffer.area;
+    for y in area.y..area.y + area.height {
+        let line: String = (area.x..area.x + area.width)
+            .map(|x| buffer[(x, y)].symbol())
+            .collect();
+        if line.contains(needle) {
+            return true;
+        }
+    }
+    false
+}
+
+#[test]
+fn broadcast_wizard_pick_command_preview_then_esc() {
+    let mut app = app_with_tagged_hosts();
+    assert_eq!(app.hosts.len(), 2);
+
+    // 'b' opens the wizard on the target-pick stage.
+    app.handle_key(key_char('b')).unwrap();
+    assert_eq!(app.mode, AppMode::BroadcastPickTarget);
+    assert!(app.broadcast_setup.is_some());
+
+    // Stage 1 render: the "Broadcast to" menu lists the shared tag target.
+    let pick = render_to_buffer(&app);
+    assert!(
+        buffer_contains(&pick, "Broadcast to"),
+        "target picker title missing"
+    );
+    assert!(buffer_contains(&pick, "#web"), "tag target #web missing");
+
+    // Enter picks the highlighted target (the only option, `#web`) and advances
+    // to the command prompt.
+    app.handle_key(key(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, AppMode::BroadcastCommand);
+
+    // Type the command and render the prompt.
+    type_text(&mut app, "uptime");
+    let cmd = render_to_buffer(&app);
+    assert!(
+        buffer_contains(&cmd, "uptime"),
+        "typed command not echoed in the prompt"
+    );
+    assert!(
+        buffer_contains(&cmd, "#web"),
+        "target label missing from the command prompt"
+    );
+
+    // Enter advances to the preview barrier (does NOT start the run yet).
+    app.handle_key(key(KeyCode::Enter)).unwrap();
+    assert_eq!(app.mode, AppMode::BroadcastPreview);
+    // No run has been spawned — the wizard is still staged, panel is absent.
+    assert!(app.broadcast.is_none());
+    assert!(app.broadcast_setup.is_some());
+
+    // Stage 3 render: the command, both target host names, and the [y]/[e]/[N]
+    // barrier are all shown.
+    let preview = render_to_buffer(&app);
+    assert!(
+        buffer_contains(&preview, "uptime"),
+        "command missing from preview"
+    );
+    assert!(
+        buffer_contains(&preview, "web-1"),
+        "host web-1 missing from preview"
+    );
+    assert!(
+        buffer_contains(&preview, "web-2"),
+        "host web-2 missing from preview"
+    );
+    assert!(
+        buffer_contains(&preview, "[y]"),
+        "confirm barrier [y] missing"
+    );
+    assert!(buffer_contains(&preview, "[e]"), "edit barrier [e] missing");
+    assert!(
+        buffer_contains(&preview, "[N]"),
+        "cancel barrier [N] missing"
+    );
+
+    // STOP before pressing 'y' (that spawns real ssh). Esc from the preview
+    // closes the wizard cleanly: back to Normal, staged setup cleared, and still
+    // no live run.
+    app.handle_key(key(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, AppMode::Normal);
+    assert!(app.broadcast_setup.is_none());
+    assert!(app.broadcast.is_none());
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,3 +1,4 @@
+mod broadcast;
 mod config_reload;
 mod connect_managed;
 mod first_run;


### PR DESCRIPTION
Implements #3. Design spec: `docs/superpowers/specs/2026-07-19-broadcast-mode-design.md`.

Pick a **group or tag**, type **one command**, and run it non-interactively over SSH on every target **concurrently** (bounded pool, default 8). The preview barrier lists the full target set + command with `[y]/[e] edit targets/[N]`. On confirm the panel **slides into the bottom-right corner** and runs in the **background** as a live docked panel that plugs into the #18 panel focus/zoom (`Alt`+arrows to focus, `z`/`Alt+Enter` to zoom for per-host output). Failures surface first; a countdown auto-dismisses the finished panel unless it's focused. `x` cancels a live run.

## Built via the full multi-agent flow
plan → validate → leaf builders → integrate → seam-validate → test → adversarial review, with the orchestrator running the authoritative build/verify and applying review fixes.

## Highlights
- **Engine** (`src/broadcast/`): bounded worker pool (thread+mpsc, mirrors `ping`/`sftp`), pure `apply_event` reducer, `failures_first` view sort, `SshCommandRunner` mirroring `osinfo::detect` (BatchMode + ConnectTimeout + run-timeout child-kill). Injectable `CommandRunner` for offline tests.
- **UI**: `src/tui/tween.rs` slide animation (driven by the existing 50ms tick), `src/tui/screens/broadcast.rs` wizard + docked/zoomed panel + countdown gauge.
- **Audit**: each host result -> `log_auth_event(via="broadcast", ...)` with canonical `launched`/`fail` status, so runs show up (and count) correctly in the Audit tab.
- **Auth (v1)**: key/agent only (BatchMode). Stored-password + full-output audit drill-down are **phase 2** (documented in the spec).

## Review fixes applied
- audit status now uses the canonical `launched`/`fail` vocabulary (was `success`/`failed`, which the stats query miscounted and the Ok/Fail filters/status-colors ignored);
- docked panel `Clear`s its rect first (no dashboard bleed-through);
- `x` cancel works regardless of focus (matches the always-shown footer hint).

## Verification
- `cargo build` + `cargo clippy --all-targets` clean (broadcast/tween add no warnings)
- `cargo fmt --check` clean
- full suite green: **445 lib** (broadcast engine + wizard/tick/audit unit tests) + **59 e2e** (new wizard TestBackend drive) + 42 smoke, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Written by Claude Opus 4.8 (Claude Code) on behalf of the maintainer._