### PR TITLE
ci: Strix AI penetration-test scan on PRs

### DIFF
--- a/.github/workflows/strix-pentest.yml
+++ b/.github/workflows/strix-pentest.yml
@@ -7,7 +7,7 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/strix-pentest.yml
+++ b/.github/workflows/strix-pentest.yml
@@ -7,7 +7,7 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -17,5 +17,6 @@ jobs:
       - name: Run Strix
         env:
           STRIX_LLM: ${{ secrets.STRIX_LLM }}
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          # Reuse the existing OPENROUTER_API_KEY secret for Strix's LLM_API_KEY.
+          LLM_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: strix -n -t ./ --scan-mode quick

--- a/.github/workflows/strix-pentest.yml
+++ b/.github/workflows/strix-pentest.yml
@@ -1,0 +1,21 @@
+name: strix-penetration-test
+
+on:
+  pull_request:
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Strix
+        run: curl -sSL https://strix.ai/install | bash
+
+      - name: Run Strix
+        env:
+          STRIX_LLM: ${{ secrets.STRIX_LLM }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: strix -n -t ./ --scan-mode quick


### PR DESCRIPTION
Adds `.github/workflows/strix-pentest.yml` — runs [usestrix/strix](https://github.com/usestrix/strix) in quick scan mode against the working tree on every pull request.

Changed one thing from the provided snippet: `actions/checkout` pinned to **v4** (the other workflows use v4; there is no `@v6` tag, so it would fail to resolve).

## Before this works, configure two repo secrets
- `STRIX_LLM` - the model id Strix should use
- `LLM_API_KEY` - the API key for that model

Settings -> Secrets and variables -> Actions.

## Notes worth a look
- **Secrets on `pull_request`**: PRs from forks do not receive secrets, so the scan would no-op there. Our PRs are all same-repo (`feature/* -> development`), so it works. If you want fork PRs scanned, switch to `pull_request_target` (and accept its extra care around untrusted code).
- **`curl ... | bash`**: the install runs an unpinned remote script at CI time (supply-chain surface). It is the tool's documented install; if you want it hardened later, pin to a released installer / checksum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Written by Claude Opus 4.8 (Claude Code) on behalf of the maintainer._