### PR TITLE
feat(motion): motion pass across the TUI, plus SFTP fixes and a second remote pane

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to SSHub are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **UI motion pass** (issue #35) - the interface moves instead of cutting
+  between states. Popups drop in from off the top and are thrown back up on
+  close; tab bodies slide; a zoomed panel morphs out of its grid slot; the
+  full-screen host view slides in on connect and off on the way out; the SFTP
+  tab slides between its picker, "connecting…" and browser states, with the two
+  panes meeting in the middle and parting again. The host list scrolls under
+  the cursor rather than jumping half a panel, its highlight wipes in, and a
+  group's rows are revealed one at a time as it folds. Status is legible in
+  motion too: a host's dot flashes when its ping class changes, a reconnecting
+  tunnel's dot breathes, the header tally counts to its new values, a fresh
+  ping reading grows into the latency graph, and the SFTP queue has a progress
+  bar that sweeps between the worker's chunked updates. Everything is gated on
+  the existing `appearance.disable_animation` reduced-motion toggle, and the
+  frame rate only rises while something is actually animating.
+- **SFTP between two servers** - the left pane can be pointed at a second host
+  with `o` (and back to local files with `O`), so two servers sit side by side
+  with their own connections, listings and file operations. Transfers between
+  them are relayed through a local temp file, one leg at a time, since libssh2
+  has no server-to-server copy; an item only leaves the queue once it lands on
+  the far end, so a failure part-way keeps it for a retry.
+- **SFTP queue stays open during a transfer** - files can be staged while the
+  queue runs and roll into the next pass when the current one finishes. The
+  local pane stays browsable meanwhile.
+- **SFTP `..` row** - both panes list their parent directory as a selectable
+  row, so walking up no longer depends on knowing about `Backspace`.
+
+### Fixed
+
+- **SFTP could not leave the login directory** - `Backspace` did nothing on a
+  fresh remote pane, because the parent of the server-resolved `"."` is the
+  empty path, which the server rejects as a listing target.
+- **SFTP staged from the wrong pane** - `←` queued whatever the *remote* cursor
+  sat on whichever pane had focus, so browsing locally and reaching for `←`
+  queued an entry you weren't looking at, and queued it again after every local
+  `cd`. The arrows still point at the destination; the source is now the
+  focused pane.
+- **A failed SFTP transfer retried itself forever** - a worker follows an error
+  with its usual completion event, which the queue's auto-continue read as
+  "start the next pass". Failed runs now stop and wait for the user, and both
+  workers are told to cancel.
+- **An unreachable SFTP host opened a blank browser** - it now fails into a
+  modal popup, with a connect timeout instead of an open-ended wait.
+
 ## [0.10.0] - 2026-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The settings overlay (`Ctrl+H`) — toggle an opaque background, OS logos, quit 
 
 - **Embedded SSH sessions** — connect opens an in-TUI PTY; detach with Ctrl+D and return to the dashboard while SSH keeps running; multiple session tabs
 - **Hosts** — browse, search, and connect. Fuzzy search with `/`, multi-tag AND filter with `#`, favorites, nested groups, manual sort order
-- **SFTP file transfer** — a dual-pane browser (remote / local) with a staged transfer queue: navigate both sides, queue uploads and downloads (files or whole folders, transferred recursively), and run them with a progress bar. Manage files in place too: delete (`d`), new folder (`n`), rename/move (`R`), and change permissions (`M`, octal chmod)
+- **SFTP file transfer** — a dual-pane browser with a staged transfer queue: navigate both sides, queue uploads and downloads (files or whole folders, transferred recursively), and run them with a progress bar. Files can be staged while the queue runs. The left pane is your local filesystem by default, or point it at a **second server** with `o` (`O` sends it back to local) to move files between two hosts — relayed through a local temp file, since SSH has no server-to-server copy. Manage files in place too: delete (`d`), new folder (`n`), rename/move (`R`), and change permissions (`M`, octal chmod)
 - **OS auto-detection** — on first connect a background probe detects the remote distro and the host card renders its logo (Braille art in brand colors), just like Termius
 - **Multiple groups & Favorites** — a host can belong to several groups at once; a reserved Favorites group and a ★ marker in the list, toggled with `f`
 - **Tunnels** — define and manage SSH tunnels (local/remote/dynamic SOCKS). Start, stop, and monitor from the TUI. Per-tunnel **keep alive** auto-starts on launch and reconnects dropped forwards with exponential backoff (configurable in `config.toml`).
@@ -246,6 +246,23 @@ Defaults below. Rebind any action with **Ctrl+K** (saved to `config.toml`). Pres
 | `Shift+I`          | Import from ssh config    |
 | `Shift+E`          | Export to ssh config      |
 | `Shift+T`          | Import from Termius       |
+
+### SFTP (tab 2)
+
+| Key                | Action                                              |
+|--------------------|-----------------------------------------------------|
+| `Enter`            | Connect to host · enter directory (`..` walks up)    |
+| `Tab`              | Switch focus between the panes                       |
+| `Backspace`        | Up one directory                                     |
+| `←` / `→`          | Stage the focused pane's selection toward the other  |
+| `c` / `u`          | Run the queue / unstage the last transfer            |
+| `o` / `O`          | Left pane to a second server / back to local files   |
+| `d`                | Delete (recursive)                                   |
+| `n` / `R` / `M`    | New folder / rename / chmod                          |
+| `r`                | Refresh both panes                                   |
+| `s`                | Open an SSH session to this host                     |
+| `/`                | Filter the focused pane                              |
+| `Esc`              | Disconnect, back to the picker                       |
 
 ### Tunnels (tab 3)
 

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -43,7 +43,11 @@ impl App {
                 .is_some_and(|g| now.saturating_duration_since(g) < crate::broadcast::TOAST_ANIM);
         // Panel zoom morph (#35).
         let zoom = self.zoom_anim.is_some_and(|a| !a.is_done(now));
-        panel || toasts || dropping || zoom
+        // Tab-switch body slide (#35).
+        let tab = self
+            .tab_switch
+            .is_some_and(|s| now.saturating_duration_since(s.at) < crate::tui::TAB_ANIM);
+        panel || toasts || dropping || zoom || tab
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -47,13 +47,13 @@ impl App {
         let tab = self
             .tab_switch
             .is_some_and(|s| now.saturating_duration_since(s.at) < crate::tui::TAB_ANIM);
-        // Popup open slide (#35): any overlay mode within its animation window.
-        let popup = !matches!(
-            self.mode,
-            AppMode::Normal | AppMode::Connecting | AppMode::Session
-        ) && now.saturating_duration_since(self.mode_entered_at)
-            < crate::tui::POPUP_ANIM;
-        panel || toasts || dropping || zoom || tab || popup
+        // Popup open/close slide (#35).
+        let popup_open = crate::app::is_overlay_mode(self.mode)
+            && now.saturating_duration_since(self.mode_entered_at) < crate::tui::POPUP_ANIM;
+        let popup_close = self
+            .popup_closing_at
+            .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::POPUP_ANIM);
+        panel || toasts || dropping || zoom || tab || popup_open || popup_close
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -47,7 +47,13 @@ impl App {
         let tab = self
             .tab_switch
             .is_some_and(|s| now.saturating_duration_since(s.at) < crate::tui::TAB_ANIM);
-        panel || toasts || dropping || zoom || tab
+        // Popup open slide (#35): any overlay mode within its animation window.
+        let popup = !matches!(
+            self.mode,
+            AppMode::Normal | AppMode::Connecting | AppMode::Session
+        ) && now.saturating_duration_since(self.mode_entered_at)
+            < crate::tui::POPUP_ANIM;
+        panel || toasts || dropping || zoom || tab || popup
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -41,7 +41,9 @@ impl App {
             && self
                 .broadcast_panel_gone_at
                 .is_some_and(|g| now.saturating_duration_since(g) < crate::broadcast::TOAST_ANIM);
-        panel || toasts || dropping
+        // Panel zoom morph (#35).
+        let zoom = self.zoom_anim.is_some_and(|a| !a.is_done(now));
+        panel || toasts || dropping || zoom
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -18,6 +18,9 @@ impl App {
     /// loop polls at a higher frame rate while this holds so the ~350ms slide
     /// looks smooth instead of stepping at the idle 20fps poll cadence.
     pub(crate) fn animating(&self) -> bool {
+        if !self.motion_enabled() {
+            return false;
+        }
         let now = Instant::now();
         let panel = self
             .broadcast

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,11 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // A fresh sparkline column still growing in (#35).
+        let spark = self
+            .ping_sample
+            .values()
+            .any(|(_, at)| now.saturating_duration_since(*at) < crate::tui::PING_FLASH);
         // Header counters still counting toward their real values (#35).
         let stats = self.header_stats_moving.get();
         // A status dot still flashing after its ping class changed (#35).
@@ -106,6 +111,7 @@ impl App {
             || fold
             || flash
             || stats
+            || spark
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -53,10 +53,13 @@ impl App {
         let popup_close = self
             .popup_closing_at
             .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::POPUP_ANIM);
-        // Full-screen session enter slide (#35).
+        // Full-screen session enter / exit slide (#35).
         let session = self
             .session_enter_at
-            .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+            .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM)
+            || self
+                .session_exit_at
+                .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
         panel || toasts || dropping || zoom || tab || popup_open || popup_close || session
     }
 

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,8 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // Header counters still counting toward their real values (#35).
+        let stats = self.header_stats_moving.get();
         // A status dot still flashing after its ping class changed (#35).
         let flash = self
             .ping_flash
@@ -103,6 +105,7 @@ impl App {
             || selection
             || fold
             || flash
+            || stats
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -53,7 +53,11 @@ impl App {
         let popup_close = self
             .popup_closing_at
             .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::POPUP_ANIM);
-        panel || toasts || dropping || zoom || tab || popup_open || popup_close
+        // Full-screen session enter slide (#35).
+        let session = self
+            .session_enter_at
+            .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        panel || toasts || dropping || zoom || tab || popup_open || popup_close || session
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,7 +60,11 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
-        panel || toasts || dropping || zoom || tab || popup_open || popup_close || session
+        // SFTP tab sub-state slide (#35).
+        let sftp = self
+            .sftp_anim
+            .is_some_and(|(_, at)| now.saturating_duration_since(at) < crate::tui::SFTP_ANIM);
+        panel || toasts || dropping || zoom || tab || popup_open || popup_close || session || sftp
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,8 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // Host list still catching up to its scroll target (#35).
+        let scroll = self.host_scroll_moving.get();
         // Zoom toast riding in from the right edge (#35).
         let notice = self
             .host_notice_at
@@ -83,6 +85,7 @@ impl App {
             || session_tab
             || sftp
             || notice
+            || scroll
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,10 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // Zoom toast riding in from the right edge (#35).
+        let notice = self
+            .host_notice_at
+            .is_some_and(|at| now.saturating_duration_since(at) < crate::broadcast::TOAST_ANIM);
         // Slide between two embedded session tabs (#35).
         let session_tab = self
             .session_tab_switch
@@ -78,6 +82,7 @@ impl App {
             || session
             || session_tab
             || sftp
+            || notice
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,8 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // SFTP progress bar still sweeping toward the reported figure (#35).
+        let progress = self.sftp_progress_moving.get();
         // A fresh sparkline column still growing in (#35).
         let spark = self
             .ping_sample
@@ -112,6 +114,7 @@ impl App {
             || flash
             || stats
             || spark
+            || progress
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,12 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // An SFTP pane still sliding to its new directory (#35).
+        let nav = self
+            .sftp_nav
+            .iter()
+            .flatten()
+            .any(|(_, at)| now.saturating_duration_since(*at) < crate::tui::SFTP_NAV_ANIM);
         // A staged transfer's row still flying into the queue strip (#35).
         let queue = self
             .sftp_queue_at
@@ -120,6 +126,7 @@ impl App {
             || spark
             || progress
             || queue
+            || nav
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,11 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // A status dot still flashing after its ping class changed (#35).
+        let flash = self
+            .ping_flash
+            .values()
+            .any(|(_, at)| now.saturating_duration_since(*at) < crate::tui::PING_FLASH);
         // Group fold / unfold revealing its rows (#35).
         let fold = self
             .fold_anim
@@ -97,6 +102,7 @@ impl App {
             || scroll
             || selection
             || fold
+            || flash
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,10 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // The audit table or a detail panel still fading its new content in (#35).
+        let fade = self
+            .audit_filter_at
+            .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::CONTENT_FADE);
         // An SFTP pane still sliding to its new directory (#35).
         let nav = self
             .sftp_nav
@@ -127,6 +131,7 @@ impl App {
             || progress
             || queue
             || nav
+            || fade
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,11 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // Group fold / unfold revealing its rows (#35).
+        let fold = self
+            .fold_anim
+            .as_ref()
+            .is_some_and(|f| now.saturating_duration_since(f.at) < crate::tui::FOLD_ANIM);
         // Host-list highlight wiping in under a moved cursor (#35).
         let selection = self
             .selection_at
@@ -91,6 +96,7 @@ impl App {
             || notice
             || scroll
             || selection
+            || fold
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,10 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // Host-list highlight wiping in under a moved cursor (#35).
+        let selection = self
+            .selection_at
+            .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SELECT_ANIM);
         // Host list still catching up to its scroll target (#35).
         let scroll = self.host_scroll_moving.get();
         // Zoom toast riding in from the right edge (#35).
@@ -86,6 +90,7 @@ impl App {
             || sftp
             || notice
             || scroll
+            || selection
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,10 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // A staged transfer's row still flying into the queue strip (#35).
+        let queue = self
+            .sftp_queue_at
+            .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SFTP_QUEUE_ANIM);
         // SFTP progress bar still sweeping toward the reported figure (#35).
         let progress = self.sftp_progress_moving.get();
         // A fresh sparkline column still growing in (#35).
@@ -115,6 +119,7 @@ impl App {
             || stats
             || spark
             || progress
+            || queue
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,8 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // Identities grid still catching up to its scroll target (#35).
+        let keys = self.keys_scroll_moving.get();
         // The dashboard still fading up out of the intro animation (#35).
         let splash = self
             .dashboard_at
@@ -137,6 +139,7 @@ impl App {
             || nav
             || fade
             || splash
+            || keys
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,6 +60,10 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // The dashboard still fading up out of the intro animation (#35).
+        let splash = self
+            .dashboard_at
+            .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SPLASH_FADE);
         // The audit table or a detail panel still fading its new content in (#35).
         let fade = self
             .audit_filter_at
@@ -132,6 +136,7 @@ impl App {
             || queue
             || nav
             || fade
+            || splash
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/broadcast.rs
+++ b/src/app/broadcast.rs
@@ -60,11 +60,24 @@ impl App {
             || self
                 .session_exit_at
                 .is_some_and(|at| now.saturating_duration_since(at) < crate::tui::SESSION_ANIM);
+        // Slide between two embedded session tabs (#35).
+        let session_tab = self
+            .session_tab_switch
+            .is_some_and(|sw| now.saturating_duration_since(sw.at) < crate::tui::TAB_ANIM);
         // SFTP tab sub-state slide (#35).
         let sftp = self
             .sftp_anim
             .is_some_and(|(_, at)| now.saturating_duration_since(at) < crate::tui::SFTP_ANIM);
-        panel || toasts || dropping || zoom || tab || popup_open || popup_close || session || sftp
+        panel
+            || toasts
+            || dropping
+            || zoom
+            || tab
+            || popup_open
+            || popup_close
+            || session
+            || session_tab
+            || sftp
     }
 
     /// Open the broadcast wizard from the hosts tab. Refuses while a run is live

--- a/src/app/connect.rs
+++ b/src/app/connect.rs
@@ -156,6 +156,10 @@ impl App {
                     self.sessions.push(session);
                     self.active_session = Some(self.sessions.len() - 1);
                     self.mode = AppMode::Connecting;
+                    // Slide the full-screen session view in from the right (#35).
+                    if self.motion_enabled() {
+                        self.session_enter_at = Some(std::time::Instant::now());
+                    }
                     let _ = self.store.log_auth_event(
                         &host_name,
                         username,

--- a/src/app/hostlist.rs
+++ b/src/app/hostlist.rs
@@ -4,6 +4,10 @@ use super::*;
 /// ~63% of the distance left to its target every `HOST_SCROLL_TAU`.
 const HOST_SCROLL_TAU: f32 = 0.055;
 
+/// Time constant of the header counters' chase (#35), a touch slower than the
+/// list scroll so a jump of a few hosts is legible as it counts.
+const HEADER_STATS_TAU: f32 = 0.09;
+
 impl App {
     /// Map a Y offset (relative to hosts panel content area) to a host index,
     /// accounting for group headers and blank separators.
@@ -300,6 +304,48 @@ impl App {
         {
             self.selected = pos;
         }
+    }
+
+    /// Advance the header counters toward `target` and return what to draw
+    /// (#35). Each counter closes on its real value instead of snapping, so a
+    /// handful of hosts dropping offline reads as the tally moving rather than
+    /// a number blinking. Same chase as the host list's scroll, and likewise
+    /// called once per frame from the render pass.
+    pub(crate) fn header_stats_advance(&self, target: [usize; 4]) -> [usize; 4] {
+        let goal = target.map(|v| v as f32);
+        if !self.motion_enabled() {
+            self.header_stats_pos.set(goal);
+            self.header_stats_moving.set(false);
+            return target;
+        }
+        let now = std::time::Instant::now();
+        let Some(last) = self.header_stats_at.get() else {
+            // First frame: the tally starts where it really is.
+            self.header_stats_pos.set(goal);
+            self.header_stats_at.set(Some(now));
+            self.header_stats_moving.set(false);
+            return target;
+        };
+        self.header_stats_at.set(Some(now));
+        let dt = now.saturating_duration_since(last).as_secs_f32();
+        let k = 1.0 - (-dt / HEADER_STATS_TAU).exp();
+        let mut pos = self.header_stats_pos.get();
+        let mut out = [0usize; 4];
+        let mut moving = false;
+        for i in 0..4 {
+            let dist = goal[i] - pos[i];
+            if dist.abs() < 0.5 {
+                pos[i] = goal[i];
+                out[i] = target[i];
+            } else {
+                pos[i] += dist * k;
+                out[i] = pos[i].round().max(0.0) as usize;
+                moving = true;
+            }
+        }
+        self.header_stats_pos.set(pos);
+        self.header_stats_moving.set(moving);
+        out
     }
 
     /// Notice hosts whose ping class changed since the last tick and stamp

--- a/src/app/hostlist.rs
+++ b/src/app/hostlist.rs
@@ -356,6 +356,18 @@ impl App {
         let now = std::time::Instant::now();
         let settled = now.checked_sub(crate::tui::PING_FLASH).unwrap_or(now);
         for (name, samples) in &self.ping_data {
+            // A new reading grows into the sparkline rather than popping in.
+            if let Some(last) = samples.last().copied() {
+                match self.ping_sample.get(name) {
+                    Some((prev, _)) if *prev == last => {}
+                    Some(_) => {
+                        self.ping_sample.insert(name.clone(), (last, now));
+                    }
+                    None => {
+                        self.ping_sample.insert(name.clone(), (last, settled));
+                    }
+                }
+            }
             let class = crate::ping::classify_ping(Some(samples));
             match self.ping_flash.get(name) {
                 Some((prev, _)) if *prev == class => continue,
@@ -367,6 +379,22 @@ impl App {
                 }
             }
         }
+    }
+
+    /// How far a host's newest sparkline column has grown, `0.0` to `1.0`
+    /// (#35). `1.0` at rest, so a settled graph draws at full height.
+    pub(crate) fn ping_grow(&self, host: &str) -> f32 {
+        if !self.motion_enabled() {
+            return 1.0;
+        }
+        let Some((_, at)) = self.ping_sample.get(host) else {
+            return 1.0;
+        };
+        crate::tui::tween::ease_out(crate::tui::tween::progress(
+            *at,
+            crate::tui::PING_FLASH,
+            std::time::Instant::now(),
+        ))
     }
 
     /// Colour for a host's status dot: its settled class colour, flashed

--- a/src/app/hostlist.rs
+++ b/src/app/hostlist.rs
@@ -146,7 +146,25 @@ impl App {
         let mut rows = Vec::new();
         let mut cur_host_depth = 1usize;
         let mut first = true;
+        // A fold in flight (#35) shows only part of its group's subtree: the
+        // rows past that point are simply left out, so the list below closes up
+        // behind them a row at a time instead of jumping.
+        let reveal = self.fold_reveal();
+        // (rows still allowed through, depth of the folding header)
+        let mut budget: Option<(usize, usize)> = None;
         for (nav_idx, row) in self.nav_rows.iter().enumerate() {
+            // Leaving the folding group's subtree ends the budget.
+            if let (Some((_, depth)), NavRow::Header(si)) = (budget, *row) {
+                if self.group_sections[si].depth <= depth {
+                    budget = None;
+                }
+            }
+            if let Some((left, _)) = budget.as_mut() {
+                if *left == 0 {
+                    continue;
+                }
+                *left -= 1;
+            }
             match *row {
                 NavRow::Header(si) => {
                     let section = &self.group_sections[si];
@@ -160,6 +178,34 @@ impl App {
                         depth: section.depth,
                     });
                     cur_host_depth = section.depth + 1;
+                    if let Some((anim, shown)) = reveal {
+                        if section.key() == anim.key {
+                            if anim.expanding {
+                                // Unfolding: the subtree is live in `nav_rows`,
+                                // so let a growing prefix of it through.
+                                let total = self
+                                    .nav_rows
+                                    .iter()
+                                    .skip(nav_idx + 1)
+                                    .take_while(|r| match r {
+                                        NavRow::Header(s) => {
+                                            self.group_sections[*s].depth > section.depth
+                                        }
+                                        NavRow::Host(_) => true,
+                                    })
+                                    .count();
+                                budget =
+                                    Some(((total as f32 * shown).round() as usize, section.depth));
+                            } else {
+                                // Folding: the subtree is already gone from
+                                // `nav_rows`, so replay a shrinking prefix of
+                                // what it looked like. These rows are display
+                                // only — nothing navigates to them.
+                                let keep = (anim.rows.len() as f32 * shown).round() as usize;
+                                rows.extend(anim.rows.iter().take(keep).cloned());
+                            }
+                        }
+                    }
                 }
                 NavRow::Host(host_idx) => {
                     rows.push(VisualRow::Host {
@@ -217,11 +263,32 @@ impl App {
     }
 
     pub(crate) fn toggle_group_by_section(&mut self, si: usize) {
+        // Any fold still playing is stale the moment the tree changes again.
+        self.fold_anim = None;
         let Some(section) = self.group_sections.get(si) else {
             return;
         };
         let key = section.key();
-        if !self.collapsed_groups.remove(&key) {
+        let expanding = self.collapsed_groups.contains(&key);
+        // Capture the rows about to disappear *before* collapsing, so the fold
+        // has something to swallow. An unfold needs no capture: its rows are in
+        // `nav_rows` the moment the collapse is lifted.
+        let rows = if expanding {
+            Vec::new()
+        } else {
+            self.subtree_visual_rows(key)
+        };
+        if self.motion_enabled() {
+            self.fold_anim = Some(FoldAnim {
+                key,
+                expanding,
+                at: std::time::Instant::now(),
+                rows,
+            });
+        }
+        if expanding {
+            self.collapsed_groups.remove(&key);
+        } else {
             self.collapsed_groups.insert(key);
         }
         self.persist_collapsed_groups();
@@ -235,8 +302,52 @@ impl App {
         }
     }
 
+    /// The visual rows of the group's subtree as it stands right now: what a
+    /// fold is about to swallow, captured so it can be replayed on the way out.
+    fn subtree_visual_rows(&self, key: i64) -> Vec<VisualRow> {
+        let rows = self.host_visual_rows();
+        let Some(head) = rows.iter().position(|r| {
+            matches!(r, VisualRow::Header { section, .. }
+                if self.group_sections[*section].key() == key)
+        }) else {
+            return Vec::new();
+        };
+        let VisualRow::Header { depth, .. } = rows[head] else {
+            return Vec::new();
+        };
+        rows.into_iter()
+            .skip(head + 1)
+            .take_while(|r| match r {
+                VisualRow::Header { depth: d, .. } => *d > depth,
+                VisualRow::Host { .. } => true,
+                VisualRow::Blank => false,
+            })
+            .collect()
+    }
+
+    /// Fraction of the animating group's subtree that is on screen right now
+    /// (#35): it grows as the group opens and shrinks as it shuts. `None` when
+    /// no fold is playing, or once it has run its course.
+    fn fold_reveal(&self) -> Option<(&FoldAnim, f32)> {
+        let anim = self.fold_anim.as_ref()?;
+        if !self.motion_enabled() {
+            return None;
+        }
+        let p =
+            crate::tui::tween::progress(anim.at, crate::tui::FOLD_ANIM, std::time::Instant::now());
+        if p >= 1.0 {
+            return None;
+        }
+        // Symmetric easing: a fold and the unfold that undoes it should feel
+        // like the same motion run backwards, which an ease-out does not.
+        let e = crate::tui::tween::ease_in_out(p);
+        Some((anim, if anim.expanding { e } else { 1.0 - e }))
+    }
+
     /// Collapse (`false`) or expand (`true`) every group at once.
     pub(crate) fn set_all_groups_collapsed(&mut self, collapsed: bool) {
+        // A per-group fold in flight would fight the bulk change; drop it.
+        self.fold_anim = None;
         if collapsed {
             self.collapsed_groups = self.group_sections.iter().map(|s| s.key()).collect();
         } else {

--- a/src/app/hostlist.rs
+++ b/src/app/hostlist.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+/// Time constant of the host list's scroll smoothing (#35): the position covers
+/// ~63% of the distance left to its target every `HOST_SCROLL_TAU`.
+const HOST_SCROLL_TAU: f32 = 0.055;
+
 impl App {
     /// Map a Y offset (relative to hosts panel content area) to a host index,
     /// accounting for group headers and blank separators.
@@ -30,6 +34,62 @@ impl App {
         }
     }
 
+    /// Advance the host list's smoothed scroll position toward the target
+    /// offset and return the row offset to draw at (#35).
+    ///
+    /// The list is drawn on whole rows, so the slide can't be a sub-row shift;
+    /// instead the position chases its target exponentially and each frame
+    /// lands on the nearest row, which reads as the list scrolling rather than
+    /// jumping half a panel whenever the selection leaves the window. Called
+    /// once per frame from the render pass (hence `Cell`, not `&mut self`);
+    /// everything else reads [`App::host_scroll_shown`] so click mapping stays
+    /// on the row the user actually sees.
+    pub(crate) fn host_scroll_advance(&self, body_h: usize) -> usize {
+        let target = self.host_scroll_offset(body_h);
+        if !self.motion_enabled() {
+            self.host_scroll_pos.set(target as f32);
+            self.host_scroll_moving.set(false);
+            return target;
+        }
+        let now = std::time::Instant::now();
+        let Some(last) = self.host_scroll_at.get() else {
+            // First frame: start where the list already is, don't scroll in.
+            self.host_scroll_pos.set(target as f32);
+            self.host_scroll_at.set(Some(now));
+            self.host_scroll_moving.set(false);
+            return target;
+        };
+        self.host_scroll_at.set(Some(now));
+        let pos = self.host_scroll_pos.get();
+        let dist = target as f32 - pos;
+        // Within half a row of the target: settle exactly, so the list can come
+        // to rest and stop asking the loop for 60fps.
+        if dist.abs() < 0.5 {
+            self.host_scroll_pos.set(target as f32);
+            self.host_scroll_moving.set(false);
+            return target;
+        }
+        // Exponential approach: covers ~63% of the remaining distance per
+        // HOST_SCROLL_TAU, so a one-row nudge and a half-panel jump both take
+        // about the same (short) time and neither overshoots.
+        let dt = now.saturating_duration_since(last).as_secs_f32();
+        let k = 1.0 - (-dt / HOST_SCROLL_TAU).exp();
+        let next = pos + dist * k;
+        self.host_scroll_pos.set(next);
+        self.host_scroll_moving.set(true);
+        next.round().max(0.0) as usize
+    }
+
+    /// The row offset the host list is currently drawn at. Mirrors whatever
+    /// [`App::host_scroll_advance`] last settled on, so hit-testing agrees with
+    /// what is on screen mid-scroll.
+    pub(crate) fn host_scroll_shown(&self, body_h: usize) -> usize {
+        if !self.motion_enabled() || self.host_scroll_at.get().is_none() {
+            return self.host_scroll_offset(body_h);
+        }
+        self.host_scroll_pos.get().round().max(0.0) as usize
+    }
+
     /// Scroll offset, in whole card-rows, for the keys tab. Keeps the selected
     /// identity card on screen (roughly centered) when the grid overflows.
     /// `card_row_stride` is the height of one card row (card height + gap).
@@ -51,7 +111,7 @@ impl App {
     /// Map a click at visible row `rel_y` (within a `body_h`-row panel) to the
     /// host index under it, accounting for the current scroll offset.
     pub(crate) fn host_row_to_index(&self, rel_y: u16, body_h: usize) -> Option<usize> {
-        let target = rel_y as usize + self.host_scroll_offset(body_h);
+        let target = rel_y as usize + self.host_scroll_shown(body_h);
         match self.host_visual_rows().get(target) {
             Some(VisualRow::Host { host_idx, .. }) => Some(*host_idx),
             _ => None,
@@ -61,7 +121,7 @@ impl App {
     /// Map a click at visible row `rel_y` to a group-header section index (for
     /// click-to-collapse), accounting for the current scroll offset.
     pub(crate) fn host_row_to_header(&self, rel_y: u16, body_h: usize) -> Option<usize> {
-        let target = rel_y as usize + self.host_scroll_offset(body_h);
+        let target = rel_y as usize + self.host_scroll_shown(body_h);
         match self.host_visual_rows().get(target) {
             Some(VisualRow::Header { section, .. }) => Some(*section),
             _ => None,

--- a/src/app/hostlist.rs
+++ b/src/app/hostlist.rs
@@ -112,6 +112,33 @@ impl App {
         selected_row.saturating_sub(visible_rows / 2).min(max_off)
     }
 
+    /// Advance the identities grid toward `target_lines` and return the line
+    /// offset to draw at (#35). Same chase as the host list, but measured in
+    /// lines rather than card rows, so a card-row jump scrolls through instead
+    /// of teleporting a whole card height.
+    pub(crate) fn keys_scroll_advance(&self, target_lines: usize) -> u16 {
+        let goal = target_lines as f32;
+        if !self.motion_enabled() {
+            self.keys_scroll_pos.set(goal);
+            self.keys_scroll_moving.set(false);
+            return target_lines as u16;
+        }
+        let now = std::time::Instant::now();
+        let last = self.keys_scroll_at.replace(Some(now));
+        let pos = self.keys_scroll_pos.get();
+        let dist = goal - pos;
+        if last.is_none() || dist.abs() < 0.5 {
+            self.keys_scroll_pos.set(goal);
+            self.keys_scroll_moving.set(false);
+            return target_lines as u16;
+        }
+        let dt = now.saturating_duration_since(last.unwrap()).as_secs_f32();
+        let next = pos + dist * (1.0 - (-dt / HOST_SCROLL_TAU).exp());
+        self.keys_scroll_pos.set(next);
+        self.keys_scroll_moving.set(true);
+        next.round().max(0.0) as u16
+    }
+
     /// Map a click at visible row `rel_y` (within a `body_h`-row panel) to the
     /// host index under it, accounting for the current scroll offset.
     pub(crate) fn host_row_to_index(&self, rel_y: u16, body_h: usize) -> Option<usize> {

--- a/src/app/hostlist.rs
+++ b/src/app/hostlist.rs
@@ -302,6 +302,52 @@ impl App {
         }
     }
 
+    /// Notice hosts whose ping class changed since the last tick and stamp
+    /// them, so their status dot can flash on the way to its new colour (#35).
+    /// A host seen for the first time is stamped as already settled: opening
+    /// the app shouldn't set the whole list flashing.
+    pub(crate) fn detect_ping_changes(&mut self) {
+        let now = std::time::Instant::now();
+        let settled = now.checked_sub(crate::tui::PING_FLASH).unwrap_or(now);
+        for (name, samples) in &self.ping_data {
+            let class = crate::ping::classify_ping(Some(samples));
+            match self.ping_flash.get(name) {
+                Some((prev, _)) if *prev == class => continue,
+                Some(_) => {
+                    self.ping_flash.insert(name.clone(), (class, now));
+                }
+                None => {
+                    self.ping_flash.insert(name.clone(), (class, settled));
+                }
+            }
+        }
+    }
+
+    /// Colour for a host's status dot: its settled class colour, flashed
+    /// through white for [`crate::tui::PING_FLASH`] after the class changes
+    /// (#35), so a host dropping offline catches the eye.
+    pub(crate) fn ping_flash_color(
+        &self,
+        host: &str,
+        settled: ratatui::style::Color,
+    ) -> ratatui::style::Color {
+        if !self.motion_enabled() {
+            return settled;
+        }
+        let Some((_, at)) = self.ping_flash.get(host) else {
+            return settled;
+        };
+        let p = crate::tui::tween::progress(*at, crate::tui::PING_FLASH, std::time::Instant::now());
+        if p >= 1.0 {
+            return settled;
+        }
+        crate::tui::tween::color_lerp(
+            crate::tui::theme::BRIGHT,
+            settled,
+            crate::tui::tween::ease_out(p),
+        )
+    }
+
     /// The visual rows of the group's subtree as it stands right now: what a
     /// fold is about to swallow, captured so it can be replayed on the way out.
     fn subtree_visual_rows(&self, key: i64) -> Vec<VisualRow> {

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -275,7 +275,7 @@ impl App {
                         Some(crate::tui::tween::SlideAnim::new_in_out(
                             from,
                             to,
-                            std::time::Duration::from_millis(200),
+                            std::time::Duration::from_millis(320),
                         ))
                     } else {
                         None

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -254,9 +254,32 @@ impl App {
                 self.set_ui_zoom(self.ui_zoom.saturating_sub(1));
             }
             _ if self.is_action(KeyAction::TogglePanelZoom, &key) => {
-                self.panel_zoomed = !self.panel_zoomed;
+                let to_zoomed = !self.panel_zoomed;
+                self.panel_zoomed = to_zoomed;
                 self.panel_scroll.set(0);
                 self.panel_sel = None;
+                // Morph the panel between its grid slot and the full body (#35).
+                // Broadcast is a floating panel with its own animation path.
+                self.zoom_anim =
+                    if self.motion_enabled() && self.focused_panel != PanelId::Broadcast {
+                        let areas = crate::tui::dashboard_layout::dashboard_layout_zoomed(
+                            self.terminal_area,
+                            self.ui_zoom,
+                        );
+                        let slot = crate::tui::panel_zoom_source(&areas, self.focused_panel);
+                        let (from, to) = if to_zoomed {
+                            (slot, areas.body)
+                        } else {
+                            (areas.body, slot)
+                        };
+                        Some(crate::tui::tween::SlideAnim::new_in_out(
+                            from,
+                            to,
+                            std::time::Duration::from_millis(200),
+                        ))
+                    } else {
+                        None
+                    };
             }
             _ if self.is_action(KeyAction::FocusPanelLeft, &key) => {
                 self.focus_panel(FocusDir::Left)

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -73,6 +73,7 @@ impl App {
             AppMode::BroadcastPickTarget => self.handle_key_broadcast_pick(key),
             AppMode::BroadcastCommand => self.handle_key_broadcast_command(key),
             AppMode::BroadcastPreview => self.handle_key_broadcast_preview(key),
+            AppMode::Notice => self.handle_key_notice(key),
             AppMode::Connecting | AppMode::Session => self.handle_key_session(key),
             AppMode::Normal => match self.active_tab {
                 1 => self.handle_key_sftp(key),
@@ -323,6 +324,14 @@ impl App {
             }
             _ => {}
         }
+        Ok(())
+    }
+
+    /// Modal message popup (`AppMode::Notice`): any key dismisses it back to the
+    /// dashboard. Used e.g. for an SFTP connection error.
+    pub(crate) fn handle_key_notice(&mut self, _key: KeyEvent) -> Result<()> {
+        self.notice_popup = None;
+        self.mode = AppMode::Normal;
         Ok(())
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -205,6 +205,10 @@ pub struct App {
     /// Captured cells of the last-rendered popup, thrown upward on close (#35).
     pub popup_snapshot:
         std::cell::RefCell<Option<(ratatui::layout::Rect, ratatui::buffer::Buffer)>>,
+    /// Full-frame dashboard snapshot captured just before a popup draws, so the
+    /// open slide can restore what's behind the popup and let it drop in from off
+    /// the top of the screen (#35).
+    pub popup_backdrop: std::cell::RefCell<Option<ratatui::buffer::Buffer>>,
     /// When a popup started closing, driving the upward exit of its snapshot.
     pub popup_closing_at: Option<std::time::Instant>,
     pub palette_query: String,
@@ -412,10 +416,17 @@ impl App {
             active_tab: 0,
             anim_prev_tab: 0,
             tab_switch: None,
-            mode_entered_at: std::time::Instant::now(),
+            // Start "settled" in the past so the initial mode never counts as
+            // just-entered: popups animate only after a real mode change stamps
+            // `mode_entered_at` (via detect_tab_switch in the poll loop), so
+            // direct-mode-set render tests draw popups at rest, not mid-slide.
+            mode_entered_at: std::time::Instant::now()
+                .checked_sub(std::time::Duration::from_secs(3600))
+                .unwrap_or_else(std::time::Instant::now),
             anim_prev_mode: AppMode::Normal,
             last_popup_rect: std::cell::Cell::new(None),
             popup_snapshot: std::cell::RefCell::new(None),
+            popup_backdrop: std::cell::RefCell::new(None),
             popup_closing_at: None,
             palette_query: String::new(),
             palette_selected: 0,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -236,6 +236,15 @@ pub struct App {
 }
 
 impl App {
+    /// Whether UI motion (slides / morphs / fades) should play. Off when the
+    /// user set `appearance.disable_animation` (the reduced-motion toggle, also
+    /// flipped in Settings). Animation call sites jump straight to the final
+    /// state when this is false; [`App::animating`] also returns false so the
+    /// render loop never bumps to 60fps for nothing.
+    pub(crate) fn motion_enabled(&self) -> bool {
+        !self.config.appearance.disable_animation
+    }
+
     /// Build app with default resolver and on-disk metadata db.
     pub fn new(config: AppConfig) -> Result<Self> {
         let data_dir = config::data_dir()?;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -189,6 +189,11 @@ pub struct App {
     /// Highlighted row in the tunnel reconnect settings overlay.
     pub tunnel_reconnect_selected: usize,
     pub active_tab: usize,
+    /// Tab shown on the previous poll tick, so a change can be detected centrally
+    /// (many code paths set `active_tab`) and turned into a slide animation (#35).
+    pub anim_prev_tab: usize,
+    /// In-flight tab-switch slide, or `None` at rest / under reduced motion.
+    pub tab_switch: Option<TabSwitch>,
     pub palette_query: String,
     pub palette_selected: usize,
     pub palette_results: Vec<usize>,
@@ -247,6 +252,21 @@ impl App {
     /// render loop never bumps to 60fps for nothing.
     pub(crate) fn motion_enabled(&self) -> bool {
         !self.config.appearance.disable_animation
+    }
+
+    /// Notice a tab change (from any of the many code paths that set
+    /// `active_tab`) and arm the body slide (#35). Called once per poll tick.
+    pub(crate) fn detect_tab_switch(&mut self) {
+        if self.active_tab != self.anim_prev_tab {
+            if self.motion_enabled() {
+                self.tab_switch = Some(TabSwitch {
+                    from: self.anim_prev_tab,
+                    to: self.active_tab,
+                    at: std::time::Instant::now(),
+                });
+            }
+            self.anim_prev_tab = self.active_tab;
+        }
     }
 
     /// Build app with default resolver and on-disk metadata db.
@@ -344,6 +364,8 @@ impl App {
             settings_selected: 0,
             tunnel_reconnect_selected: 0,
             active_tab: 0,
+            anim_prev_tab: 0,
+            tab_switch: None,
             palette_query: String::new(),
             palette_selected: 0,
             palette_results: Vec::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -137,6 +137,10 @@ pub struct App {
     pub focused_panel: PanelId,
     /// Whether the focused dashboard panel is zoomed to the full body.
     pub panel_zoomed: bool,
+    /// Active zoom morph (#35): interpolates the focused panel between its grid
+    /// slot and the full body on `z` / `Alt+Enter`. `None` when at rest or under
+    /// reduced motion.
+    pub zoom_anim: Option<crate::tui::tween::SlideAnim>,
     /// Scroll offset within the zoomed panel (issue #18). Reset on zoom/focus
     /// change; each zoomed list panel clamps it to its own content via the
     /// `Cell`'s interior mutability during render.
@@ -316,6 +320,7 @@ impl App {
             ui_zoom: 0,
             focused_panel: PanelId::default(),
             panel_zoomed: false,
+            zoom_anim: None,
             panel_scroll: std::cell::Cell::new(0),
             panel_sel: None,
             panel_sel_text: std::cell::RefCell::new(String::new()),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -194,6 +194,11 @@ pub struct App {
     pub anim_prev_tab: usize,
     /// In-flight tab-switch slide, or `None` at rest / under reduced motion.
     pub tab_switch: Option<TabSwitch>,
+    /// When the current `mode` was entered, so popups can animate their open
+    /// (#35). Updated centrally on any mode change.
+    pub mode_entered_at: std::time::Instant,
+    /// `mode` on the previous poll tick, to detect a change centrally.
+    pub anim_prev_mode: AppMode,
     pub palette_query: String,
     pub palette_selected: usize,
     pub palette_results: Vec<usize>,
@@ -266,6 +271,11 @@ impl App {
                 });
             }
             self.anim_prev_tab = self.active_tab;
+        }
+        // Stamp mode-entry time on any change, so popups animate their open (#35).
+        if self.mode != self.anim_prev_mode {
+            self.mode_entered_at = std::time::Instant::now();
+            self.anim_prev_mode = self.mode;
         }
     }
 
@@ -366,6 +376,8 @@ impl App {
             active_tab: 0,
             anim_prev_tab: 0,
             tab_switch: None,
+            mode_entered_at: std::time::Instant::now(),
+            anim_prev_mode: AppMode::Normal,
             palette_query: String::new(),
             palette_selected: 0,
             palette_results: Vec::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -289,14 +289,18 @@ impl App {
             }
             self.anim_prev_tab = self.active_tab;
         }
-        // Stamp mode-entry time on any change, so popups animate open/close (#35).
+        // Drive popup open/close animations off mode changes (#35). Only a
+        // *fresh* open over the dashboard (non-overlay -> overlay) restarts the
+        // drop-in, and only a full close (overlay -> non-overlay) throws the
+        // snapshot up. Overlay -> overlay (e.g. a form bouncing to its
+        // discard-confirm and back on held Esc) does neither, so it never jumps.
         if self.mode != self.anim_prev_mode {
-            self.mode_entered_at = std::time::Instant::now();
-            if is_overlay_mode(self.mode) {
-                // A fresh open cancels any in-flight close.
+            let now_overlay = is_overlay_mode(self.mode);
+            let prev_overlay = is_overlay_mode(self.anim_prev_mode);
+            if now_overlay && !prev_overlay {
+                self.mode_entered_at = std::time::Instant::now();
                 self.popup_closing_at = None;
-            } else if is_overlay_mode(self.anim_prev_mode) {
-                // A popup just closed: throw its captured snapshot upward.
+            } else if prev_overlay && !now_overlay {
                 self.popup_closing_at = Some(std::time::Instant::now());
             }
             self.anim_prev_mode = self.mode;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -199,6 +199,14 @@ pub struct App {
     pub mode_entered_at: std::time::Instant,
     /// `mode` on the previous poll tick, to detect a change centrally.
     pub anim_prev_mode: AppMode,
+    /// Resting rect of the popup drawn this frame (set by `popup_open_rect`), so
+    /// the render pass can snapshot it for the close animation (#35).
+    pub last_popup_rect: std::cell::Cell<Option<ratatui::layout::Rect>>,
+    /// Captured cells of the last-rendered popup, thrown upward on close (#35).
+    pub popup_snapshot:
+        std::cell::RefCell<Option<(ratatui::layout::Rect, ratatui::buffer::Buffer)>>,
+    /// When a popup started closing, driving the upward exit of its snapshot.
+    pub popup_closing_at: Option<std::time::Instant>,
     pub palette_query: String,
     pub palette_selected: usize,
     pub palette_results: Vec<usize>,
@@ -249,6 +257,15 @@ pub struct App {
     search: HostSearch,
 }
 
+/// Whether `mode` draws a popup overlay over the dashboard (so its open/close
+/// should animate, #35). Excludes the full-screen session modes.
+pub(crate) fn is_overlay_mode(mode: AppMode) -> bool {
+    !matches!(
+        mode,
+        AppMode::Normal | AppMode::Connecting | AppMode::Session | AppMode::SessionHostPicker
+    )
+}
+
 impl App {
     /// Whether UI motion (slides / morphs / fades) should play. Off when the
     /// user set `appearance.disable_animation` (the reduced-motion toggle, also
@@ -272,10 +289,25 @@ impl App {
             }
             self.anim_prev_tab = self.active_tab;
         }
-        // Stamp mode-entry time on any change, so popups animate their open (#35).
+        // Stamp mode-entry time on any change, so popups animate open/close (#35).
         if self.mode != self.anim_prev_mode {
             self.mode_entered_at = std::time::Instant::now();
+            if is_overlay_mode(self.mode) {
+                // A fresh open cancels any in-flight close.
+                self.popup_closing_at = None;
+            } else if is_overlay_mode(self.anim_prev_mode) {
+                // A popup just closed: throw its captured snapshot upward.
+                self.popup_closing_at = Some(std::time::Instant::now());
+            }
             self.anim_prev_mode = self.mode;
+        }
+        // Retire a finished close slide so its snapshot buffer is freed.
+        if self
+            .popup_closing_at
+            .is_some_and(|at| at.elapsed() >= crate::tui::POPUP_ANIM)
+        {
+            self.popup_closing_at = None;
+            *self.popup_snapshot.borrow_mut() = None;
         }
     }
 
@@ -378,6 +410,9 @@ impl App {
             tab_switch: None,
             mode_entered_at: std::time::Instant::now(),
             anim_prev_mode: AppMode::Normal,
+            last_popup_rect: std::cell::Cell::new(None),
+            popup_snapshot: std::cell::RefCell::new(None),
+            popup_closing_at: None,
             palette_query: String::new(),
             palette_selected: 0,
             palette_results: Vec::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -236,6 +236,13 @@ pub struct App {
     pub sftp_host: Option<String>,
     /// True while the SFTP picker's host search input is capturing keys.
     pub sftp_picker_searching: bool,
+    /// In-flight SFTP tab sub-state slide and when it started (#35). `None` at
+    /// rest / under reduced motion.
+    pub sftp_anim: Option<(SftpAnim, std::time::Instant)>,
+    /// Snapshot of the SFTP tab body captured each resting frame while a session
+    /// is live, so leaving it can slide the captured cells away after the state
+    /// itself is gone.
+    pub sftp_snapshot: std::cell::RefCell<Option<ratatui::buffer::Buffer>>,
     pub probe_rx: Option<Receiver<crate::ssh::probe::SshLogEntry>>,
     pub os_detect_tx: Option<std::sync::mpsc::Sender<crate::osinfo::OsDetectCmd>>,
     pub os_detect_rx: Option<Receiver<crate::osinfo::OsDetectEvent>>,
@@ -343,6 +350,18 @@ impl App {
         {
             self.session_exit_at = None;
             *self.session_snapshot.borrow_mut() = None;
+        }
+        // Retire a finished SFTP sub-state slide. Its snapshot is refreshed every
+        // resting frame while a session is live, so only free it once there is
+        // none left to capture.
+        if self
+            .sftp_anim
+            .is_some_and(|(_, at)| at.elapsed() >= crate::tui::SFTP_ANIM)
+        {
+            self.sftp_anim = None;
+            if self.sftp.is_none() {
+                *self.sftp_snapshot.borrow_mut() = None;
+            }
         }
         // Retire a finished close slide so its snapshot buffer is freed.
         if self
@@ -477,6 +496,8 @@ impl App {
             sftp_rx: None,
             sftp_host: None,
             sftp_picker_searching: false,
+            sftp_anim: None,
+            sftp_snapshot: std::cell::RefCell::new(None),
             probe_rx: None,
             os_detect_tx: None,
             os_detect_rx: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -217,6 +217,12 @@ pub struct App {
     /// full-screen session view can slide in from the right (#35). `None` at rest
     /// / under reduced motion.
     pub session_enter_at: Option<std::time::Instant>,
+    /// Full-frame snapshot of the last session view, captured each frame while in
+    /// a session so it can be slid off to the right when the host is left (#35).
+    pub session_snapshot: std::cell::RefCell<Option<ratatui::buffer::Buffer>>,
+    /// When the host view started exiting (session -> dashboard), driving the
+    /// slide-out of `session_snapshot`. `None` at rest / under reduced motion.
+    pub session_exit_at: Option<std::time::Instant>,
     pub palette_query: String,
     pub palette_selected: usize,
     pub palette_results: Vec<usize>,
@@ -276,6 +282,11 @@ pub(crate) fn is_overlay_mode(mode: AppMode) -> bool {
     )
 }
 
+/// Whether `mode` shows the full-screen embedded session (connecting or live).
+pub(crate) fn is_session_mode(mode: AppMode) -> bool {
+    matches!(mode, AppMode::Connecting | AppMode::Session)
+}
+
 impl App {
     /// Whether UI motion (slides / morphs / fades) should play. Off when the
     /// user set `appearance.disable_animation` (the reduced-motion toggle, also
@@ -313,7 +324,25 @@ impl App {
             } else if prev_overlay && !now_overlay {
                 self.popup_closing_at = Some(std::time::Instant::now());
             }
+            // Leaving the full-screen host view back to the dashboard slides the
+            // captured session snapshot off to the right (#35). Only to Normal —
+            // opening the session-host picker over a live session isn't an exit.
+            if is_session_mode(self.anim_prev_mode) && self.mode == AppMode::Normal {
+                if self.motion_enabled() {
+                    self.session_exit_at = Some(std::time::Instant::now());
+                } else {
+                    *self.session_snapshot.borrow_mut() = None;
+                }
+            }
             self.anim_prev_mode = self.mode;
+        }
+        // Retire a finished session-exit slide so its snapshot buffer is freed.
+        if self
+            .session_exit_at
+            .is_some_and(|at| at.elapsed() >= crate::tui::SESSION_ANIM)
+        {
+            self.session_exit_at = None;
+            *self.session_snapshot.borrow_mut() = None;
         }
         // Retire a finished close slide so its snapshot buffer is freed.
         if self
@@ -436,6 +465,8 @@ impl App {
             popup_backdrop: std::cell::RefCell::new(None),
             popup_closing_at: None,
             session_enter_at: None,
+            session_snapshot: std::cell::RefCell::new(None),
+            session_exit_at: None,
             palette_query: String::new(),
             palette_selected: 0,
             palette_results: Vec::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -231,6 +231,13 @@ pub struct App {
     pub header_stats_at: std::cell::Cell<Option<std::time::Instant>>,
     /// Whether a counter is still counting, so the loop keeps the frame rate up.
     pub header_stats_moving: std::cell::Cell<bool>,
+    /// Working directories of the two SFTP panes as of the previous tick, so a
+    /// directory change can be detected centrally whether it came from the
+    /// local filesystem or an async remote listing (#35).
+    pub anim_prev_cwd: [std::path::PathBuf; 2],
+    /// Per-pane directory change: whether it went deeper, and when. Indexed by
+    /// [`crate::sftp::model::Side`] (local, remote).
+    pub sftp_nav: [Option<(bool, std::time::Instant)>; 2],
     /// SFTP queue length as of the previous tick, so a newly staged transfer
     /// can be detected centrally and flown in (#35).
     pub anim_prev_queue: usize,
@@ -409,6 +416,7 @@ impl App {
             self.session_exit_at = None;
             *self.session_snapshot.borrow_mut() = None;
         }
+        self.detect_sftp_navigation();
         // A transfer staged since the last tick flies its row in (#35).
         let queued = self.sftp.as_ref().map(|s| s.queue.len()).unwrap_or(0);
         if queued != self.anim_prev_queue {
@@ -584,6 +592,8 @@ impl App {
             header_stats_pos: std::cell::Cell::new([0.0; 4]),
             header_stats_at: std::cell::Cell::new(None),
             header_stats_moving: std::cell::Cell::new(false),
+            anim_prev_cwd: [std::path::PathBuf::new(), std::path::PathBuf::new()],
+            sftp_nav: [None, None],
             anim_prev_queue: 0,
             sftp_queue_at: None,
             sftp_progress_pos: std::cell::Cell::new(0.0),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -170,6 +170,8 @@ pub struct App {
     pub group_manage_selected: usize,
     pub group_notice: Option<String>,
     pub host_notice: Option<String>,
+    /// Message shown by the modal `AppMode::Notice` popup (e.g. a connect error).
+    pub notice_popup: Option<String>,
     pub sort_mode: SortMode,
     pub pending_delete: Option<PendingDelete>,
     pub pre_help_mode: Option<AppMode>,
@@ -402,6 +404,7 @@ impl App {
             group_manage_selected: 0,
             group_notice: None,
             host_notice: None,
+            notice_popup: None,
             sort_mode: SortMode::default(),
             pending_delete: None,
             pre_help_mode: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -231,6 +231,11 @@ pub struct App {
     pub header_stats_at: std::cell::Cell<Option<std::time::Instant>>,
     /// Whether a counter is still counting, so the loop keeps the frame rate up.
     pub header_stats_moving: std::cell::Cell<bool>,
+    /// Audit filter + range as of the previous tick, so a re-filtered table can
+    /// be faded in centrally rather than swapping between frames (#35).
+    pub anim_prev_audit: (AuditFilter, AuditRange),
+    /// When the audit table was last re-filtered.
+    pub audit_filter_at: Option<std::time::Instant>,
     /// Working directories of the two SFTP panes as of the previous tick, so a
     /// directory change can be detected centrally whether it came from the
     /// local filesystem or an async remote listing (#35).
@@ -416,6 +421,11 @@ impl App {
             self.session_exit_at = None;
             *self.session_snapshot.borrow_mut() = None;
         }
+        // The audit table was re-filtered: fade the new rows in (#35).
+        if (self.audit_filter, self.audit_range) != self.anim_prev_audit {
+            self.anim_prev_audit = (self.audit_filter, self.audit_range);
+            self.audit_filter_at = Some(std::time::Instant::now());
+        }
         self.detect_sftp_navigation();
         // A transfer staged since the last tick flies its row in (#35).
         let queued = self.sftp.as_ref().map(|s| s.queue.len()).unwrap_or(0);
@@ -592,6 +602,8 @@ impl App {
             header_stats_pos: std::cell::Cell::new([0.0; 4]),
             header_stats_at: std::cell::Cell::new(None),
             header_stats_moving: std::cell::Cell::new(false),
+            anim_prev_audit: (AuditFilter::default(), AuditRange::default()),
+            audit_filter_at: None,
             anim_prev_cwd: [std::path::PathBuf::new(), std::path::PathBuf::new()],
             sftp_nav: [None, None],
             anim_prev_queue: 0,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -223,6 +223,9 @@ pub struct App {
     /// When the host view started exiting (session -> dashboard), driving the
     /// slide-out of `session_snapshot`. `None` at rest / under reduced motion.
     pub session_exit_at: Option<std::time::Instant>,
+    /// In-flight slide between two embedded session tabs (#35). While it plays,
+    /// `session_snapshot` is held frozen on the tab being left behind.
+    pub session_tab_switch: Option<SessionTabSwitch>,
     pub palette_query: String,
     pub palette_selected: usize,
     pub palette_results: Vec<usize>,
@@ -335,6 +338,9 @@ impl App {
             // captured session snapshot off to the right (#35). Only to Normal —
             // opening the session-host picker over a live session isn't an exit.
             if is_session_mode(self.anim_prev_mode) && self.mode == AppMode::Normal {
+                // Leaving supersedes any tab slide still in flight, and releases
+                // the snapshot it was holding frozen.
+                self.session_tab_switch = None;
                 if self.motion_enabled() {
                     self.session_exit_at = Some(std::time::Instant::now());
                 } else {
@@ -350,6 +356,14 @@ impl App {
         {
             self.session_exit_at = None;
             *self.session_snapshot.borrow_mut() = None;
+        }
+        // Retire a finished session-tab slide, releasing the frozen snapshot of
+        // the tab that was left behind.
+        if self
+            .session_tab_switch
+            .is_some_and(|sw| sw.at.elapsed() >= crate::tui::TAB_ANIM)
+        {
+            self.session_tab_switch = None;
         }
         // Retire a finished SFTP sub-state slide. Its snapshot is refreshed every
         // resting frame while a session is live, so only free it once there is
@@ -486,6 +500,7 @@ impl App {
             session_enter_at: None,
             session_snapshot: std::cell::RefCell::new(None),
             session_exit_at: None,
+            session_tab_switch: None,
             palette_query: String::new(),
             palette_selected: 0,
             palette_results: Vec::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -310,6 +310,13 @@ pub struct App {
     /// Name of the host the live SFTP session is connected to, so the browser
     /// can open an SSH session back to the same host (completes the round trip).
     pub sftp_host: Option<String>,
+    /// Second SFTP worker, driving the left pane when it browses another server
+    /// instead of the local filesystem. `None` while the left pane is local.
+    pub sftp_tx2: Option<std::sync::mpsc::Sender<crate::sftp::SftpCommand>>,
+    pub sftp_rx2: Option<std::sync::mpsc::Receiver<crate::sftp::SftpEvent>>,
+    /// Server-to-server transfer in flight, relayed leg by leg through a local
+    /// temp file. `None` whenever the queue is a plain local transfer.
+    pub sftp_relay: Option<SftpRelay>,
     /// True while the SFTP picker's host search input is capturing keys.
     pub sftp_picker_searching: bool,
     /// In-flight SFTP tab sub-state slide and when it started (#35). `None` at
@@ -645,6 +652,9 @@ impl App {
             sftp_tx: None,
             sftp_rx: None,
             sftp_host: None,
+            sftp_tx2: None,
+            sftp_rx2: None,
+            sftp_relay: None,
             sftp_picker_searching: false,
             sftp_anim: None,
             sftp_snapshot: std::cell::RefCell::new(None),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -223,6 +223,11 @@ pub struct App {
     /// When the host view started exiting (session -> dashboard), driving the
     /// slide-out of `session_snapshot`. `None` at rest / under reduced motion.
     pub session_exit_at: Option<std::time::Instant>,
+    /// `selected` as of the previous poll tick, so a moved cursor can be
+    /// detected centrally and its highlight wiped in (#35).
+    pub anim_prev_selected: usize,
+    /// When the host-list cursor last moved, driving the highlight wipe.
+    pub selection_at: Option<std::time::Instant>,
     /// Smoothed scroll position of the host list, in visual rows, chasing the
     /// target offset each frame (#35). `Cell` because the render pass advances
     /// it through `&App`.
@@ -374,6 +379,11 @@ impl App {
             self.session_exit_at = None;
             *self.session_snapshot.borrow_mut() = None;
         }
+        // The cursor moved since the last tick: wipe its highlight in (#35).
+        if self.selected != self.anim_prev_selected {
+            self.anim_prev_selected = self.selected;
+            self.selection_at = Some(std::time::Instant::now());
+        }
         // A notice that changed since the last tick is a fresh one: stamp it so
         // the zoom toast can slide in from the right edge (#35).
         if self.host_notice != self.anim_prev_notice {
@@ -524,6 +534,8 @@ impl App {
             session_snapshot: std::cell::RefCell::new(None),
             session_exit_at: None,
             session_tab_switch: None,
+            anim_prev_selected: 0,
+            selection_at: None,
             host_scroll_pos: std::cell::Cell::new(0.0),
             host_scroll_at: std::cell::Cell::new(None),
             host_scroll_moving: std::cell::Cell::new(false),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -231,6 +231,13 @@ pub struct App {
     pub header_stats_at: std::cell::Cell<Option<std::time::Instant>>,
     /// Whether a counter is still counting, so the loop keeps the frame rate up.
     pub header_stats_moving: std::cell::Cell<bool>,
+    /// Fraction of the running SFTP queue drawn on the progress bar, chasing
+    /// the real figure so the bar sweeps between the worker's updates (#35).
+    pub sftp_progress_pos: std::cell::Cell<f32>,
+    /// When the progress bar was last advanced. `None` until first drawn.
+    pub sftp_progress_at: std::cell::Cell<Option<std::time::Instant>>,
+    /// Whether the bar is still catching up to the real figure.
+    pub sftp_progress_moving: std::cell::Cell<bool>,
     /// Latest ping sample per host and when it landed, so a fresh reading can
     /// grow into the sparkline instead of appearing at full height (#35).
     pub ping_sample: std::collections::HashMap<String, (u32, std::time::Instant)>,
@@ -564,6 +571,9 @@ impl App {
             header_stats_pos: std::cell::Cell::new([0.0; 4]),
             header_stats_at: std::cell::Cell::new(None),
             header_stats_moving: std::cell::Cell::new(false),
+            sftp_progress_pos: std::cell::Cell::new(0.0),
+            sftp_progress_at: std::cell::Cell::new(None),
+            sftp_progress_moving: std::cell::Cell::new(false),
             ping_sample: std::collections::HashMap::new(),
             ping_flash: std::collections::HashMap::new(),
             fold_anim: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -231,6 +231,10 @@ pub struct App {
     pub header_stats_at: std::cell::Cell<Option<std::time::Instant>>,
     /// Whether a counter is still counting, so the loop keeps the frame rate up.
     pub header_stats_moving: std::cell::Cell<bool>,
+    /// When the dashboard first took the screen, so it can fade up out of the
+    /// intro animation instead of replacing it between frames (#35). Set by the
+    /// terminal loop once, just before its first draw.
+    pub dashboard_at: Option<std::time::Instant>,
     /// Audit filter + range as of the previous tick, so a re-filtered table can
     /// be faded in centrally rather than swapping between frames (#35).
     pub anim_prev_audit: (AuditFilter, AuditRange),
@@ -602,6 +606,7 @@ impl App {
             header_stats_pos: std::cell::Cell::new([0.0; 4]),
             header_stats_at: std::cell::Cell::new(None),
             header_stats_moving: std::cell::Cell::new(false),
+            dashboard_at: None,
             anim_prev_audit: (AuditFilter::default(), AuditRange::default()),
             audit_filter_at: None,
             anim_prev_cwd: [std::path::PathBuf::new(), std::path::PathBuf::new()],

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -213,6 +213,10 @@ pub struct App {
     pub popup_backdrop: std::cell::RefCell<Option<ratatui::buffer::Buffer>>,
     /// When a popup started closing, driving the upward exit of its snapshot.
     pub popup_closing_at: Option<std::time::Instant>,
+    /// When a fresh SSH session was launched (mode → Connecting), so the
+    /// full-screen session view can slide in from the right (#35). `None` at rest
+    /// / under reduced motion.
+    pub session_enter_at: Option<std::time::Instant>,
     pub palette_query: String,
     pub palette_selected: usize,
     pub palette_results: Vec<usize>,
@@ -431,6 +435,7 @@ impl App {
             popup_snapshot: std::cell::RefCell::new(None),
             popup_backdrop: std::cell::RefCell::new(None),
             popup_closing_at: None,
+            session_enter_at: None,
             palette_query: String::new(),
             palette_selected: 0,
             palette_results: Vec::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -231,6 +231,13 @@ pub struct App {
     pub header_stats_at: std::cell::Cell<Option<std::time::Instant>>,
     /// Whether a counter is still counting, so the loop keeps the frame rate up.
     pub header_stats_moving: std::cell::Cell<bool>,
+    /// Smoothed scroll position of the identities grid, in *lines* (not card
+    /// rows), chasing the target offset each frame (#35).
+    pub keys_scroll_pos: std::cell::Cell<f32>,
+    /// When the identities grid was last advanced. `None` until first drawn.
+    pub keys_scroll_at: std::cell::Cell<Option<std::time::Instant>>,
+    /// Whether the grid is still catching up to its target offset.
+    pub keys_scroll_moving: std::cell::Cell<bool>,
     /// When the dashboard first took the screen, so it can fade up out of the
     /// intro animation instead of replacing it between frames (#35). Set by the
     /// terminal loop once, just before its first draw.
@@ -606,6 +613,9 @@ impl App {
             header_stats_pos: std::cell::Cell::new([0.0; 4]),
             header_stats_at: std::cell::Cell::new(None),
             header_stats_moving: std::cell::Cell::new(false),
+            keys_scroll_pos: std::cell::Cell::new(0.0),
+            keys_scroll_at: std::cell::Cell::new(None),
+            keys_scroll_moving: std::cell::Cell::new(false),
             dashboard_at: None,
             anim_prev_audit: (AuditFilter::default(), AuditRange::default()),
             audit_filter_at: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -317,6 +317,13 @@ pub struct App {
     /// Server-to-server transfer in flight, relayed leg by leg through a local
     /// temp file. `None` whenever the queue is a plain local transfer.
     pub sftp_relay: Option<SftpRelay>,
+    /// `QueueDone` events still to be swallowed: a worker always finishes its
+    /// run with one, even after an error we already acted on, and acting on it
+    /// twice would restart the very transfer that just failed.
+    pub sftp_swallow_done: usize,
+    /// Whether the run in flight has already reported an error, so its leftover
+    /// queue is left for the user to retry rather than restarted automatically.
+    pub sftp_run_failed: bool,
     /// True while the SFTP picker's host search input is capturing keys.
     pub sftp_picker_searching: bool,
     /// In-flight SFTP tab sub-state slide and when it started (#35). `None` at
@@ -655,6 +662,8 @@ impl App {
             sftp_tx2: None,
             sftp_rx2: None,
             sftp_relay: None,
+            sftp_swallow_done: 0,
+            sftp_run_failed: false,
             sftp_picker_searching: false,
             sftp_anim: None,
             sftp_snapshot: std::cell::RefCell::new(None),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -231,6 +231,9 @@ pub struct App {
     pub header_stats_at: std::cell::Cell<Option<std::time::Instant>>,
     /// Whether a counter is still counting, so the loop keeps the frame rate up.
     pub header_stats_moving: std::cell::Cell<bool>,
+    /// Latest ping sample per host and when it landed, so a fresh reading can
+    /// grow into the sparkline instead of appearing at full height (#35).
+    pub ping_sample: std::collections::HashMap<String, (u32, std::time::Instant)>,
     /// Ping class per host as of the previous tick, and when it last changed,
     /// so a host going green or red flashes instead of switching silently (#35).
     pub ping_flash: std::collections::HashMap<String, (crate::ping::PingClass, std::time::Instant)>,
@@ -561,6 +564,7 @@ impl App {
             header_stats_pos: std::cell::Cell::new([0.0; 4]),
             header_stats_at: std::cell::Cell::new(None),
             header_stats_moving: std::cell::Cell::new(false),
+            ping_sample: std::collections::HashMap::new(),
             ping_flash: std::collections::HashMap::new(),
             fold_anim: None,
             anim_prev_selected: 0,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -223,6 +223,9 @@ pub struct App {
     /// When the host view started exiting (session -> dashboard), driving the
     /// slide-out of `session_snapshot`. `None` at rest / under reduced motion.
     pub session_exit_at: Option<std::time::Instant>,
+    /// Ping class per host as of the previous tick, and when it last changed,
+    /// so a host going green or red flashes instead of switching silently (#35).
+    pub ping_flash: std::collections::HashMap<String, (crate::ping::PingClass, std::time::Instant)>,
     /// In-flight group fold / unfold (#35). While a *fold* plays its rows are
     /// still live in `nav_rows`; `collapsed_groups` takes the change when the
     /// animation ends (see [`App::flush_pending_fold`]).
@@ -383,6 +386,7 @@ impl App {
             self.session_exit_at = None;
             *self.session_snapshot.borrow_mut() = None;
         }
+        self.detect_ping_changes();
         // Retire a finished fold, releasing the rows it was replaying.
         if self
             .fold_anim
@@ -546,6 +550,7 @@ impl App {
             session_snapshot: std::cell::RefCell::new(None),
             session_exit_at: None,
             session_tab_switch: None,
+            ping_flash: std::collections::HashMap::new(),
             fold_anim: None,
             anim_prev_selected: 0,
             selection_at: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -223,6 +223,14 @@ pub struct App {
     /// When the host view started exiting (session -> dashboard), driving the
     /// slide-out of `session_snapshot`. `None` at rest / under reduced motion.
     pub session_exit_at: Option<std::time::Instant>,
+    /// Header counters as drawn right now (total / online / slow / down),
+    /// counting toward their real values rather than snapping (#35). `Cell`
+    /// because the render pass owns the frame clock.
+    pub header_stats_pos: std::cell::Cell<[f32; 4]>,
+    /// When the header counters were last advanced. `None` until first drawn.
+    pub header_stats_at: std::cell::Cell<Option<std::time::Instant>>,
+    /// Whether a counter is still counting, so the loop keeps the frame rate up.
+    pub header_stats_moving: std::cell::Cell<bool>,
     /// Ping class per host as of the previous tick, and when it last changed,
     /// so a host going green or red flashes instead of switching silently (#35).
     pub ping_flash: std::collections::HashMap<String, (crate::ping::PingClass, std::time::Instant)>,
@@ -550,6 +558,9 @@ impl App {
             session_snapshot: std::cell::RefCell::new(None),
             session_exit_at: None,
             session_tab_switch: None,
+            header_stats_pos: std::cell::Cell::new([0.0; 4]),
+            header_stats_at: std::cell::Cell::new(None),
+            header_stats_moving: std::cell::Cell::new(false),
             ping_flash: std::collections::HashMap::new(),
             fold_anim: None,
             anim_prev_selected: 0,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -223,6 +223,11 @@ pub struct App {
     /// When the host view started exiting (session -> dashboard), driving the
     /// slide-out of `session_snapshot`. `None` at rest / under reduced motion.
     pub session_exit_at: Option<std::time::Instant>,
+    /// `host_notice` as of the previous poll tick, so a fresh one can be
+    /// detected centrally (34 code paths set it) and slid in (#35).
+    pub anim_prev_notice: Option<String>,
+    /// When the current `host_notice` appeared, driving the toast slide-in.
+    pub host_notice_at: Option<std::time::Instant>,
     /// In-flight slide between two embedded session tabs (#35). While it plays,
     /// `session_snapshot` is held frozen on the tab being left behind.
     pub session_tab_switch: Option<SessionTabSwitch>,
@@ -358,6 +363,12 @@ impl App {
         {
             self.session_exit_at = None;
             *self.session_snapshot.borrow_mut() = None;
+        }
+        // A notice that changed since the last tick is a fresh one: stamp it so
+        // the zoom toast can slide in from the right edge (#35).
+        if self.host_notice != self.anim_prev_notice {
+            self.anim_prev_notice = self.host_notice.clone();
+            self.host_notice_at = self.host_notice.as_ref().map(|_| std::time::Instant::now());
         }
         // Retire a finished session-tab slide, releasing the frozen snapshot of
         // the tab that was left behind.
@@ -503,6 +514,8 @@ impl App {
             session_snapshot: std::cell::RefCell::new(None),
             session_exit_at: None,
             session_tab_switch: None,
+            anim_prev_notice: None,
+            host_notice_at: None,
             palette_query: String::new(),
             palette_selected: 0,
             palette_results: Vec::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -223,6 +223,16 @@ pub struct App {
     /// When the host view started exiting (session -> dashboard), driving the
     /// slide-out of `session_snapshot`. `None` at rest / under reduced motion.
     pub session_exit_at: Option<std::time::Instant>,
+    /// Smoothed scroll position of the host list, in visual rows, chasing the
+    /// target offset each frame (#35). `Cell` because the render pass advances
+    /// it through `&App`.
+    pub host_scroll_pos: std::cell::Cell<f32>,
+    /// When the scroll position was last advanced, for the frame delta. `None`
+    /// until the list has been drawn once.
+    pub host_scroll_at: std::cell::Cell<Option<std::time::Instant>>,
+    /// Whether the list is still catching up to its target offset, so the loop
+    /// knows to keep the frame rate up.
+    pub host_scroll_moving: std::cell::Cell<bool>,
     /// `host_notice` as of the previous poll tick, so a fresh one can be
     /// detected centrally (34 code paths set it) and slid in (#35).
     pub anim_prev_notice: Option<String>,
@@ -514,6 +524,9 @@ impl App {
             session_snapshot: std::cell::RefCell::new(None),
             session_exit_at: None,
             session_tab_switch: None,
+            host_scroll_pos: std::cell::Cell::new(0.0),
+            host_scroll_at: std::cell::Cell::new(None),
+            host_scroll_moving: std::cell::Cell::new(false),
             anim_prev_notice: None,
             host_notice_at: None,
             palette_query: String::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -223,6 +223,10 @@ pub struct App {
     /// When the host view started exiting (session -> dashboard), driving the
     /// slide-out of `session_snapshot`. `None` at rest / under reduced motion.
     pub session_exit_at: Option<std::time::Instant>,
+    /// In-flight group fold / unfold (#35). While a *fold* plays its rows are
+    /// still live in `nav_rows`; `collapsed_groups` takes the change when the
+    /// animation ends (see [`App::flush_pending_fold`]).
+    pub fold_anim: Option<FoldAnim>,
     /// `selected` as of the previous poll tick, so a moved cursor can be
     /// detected centrally and its highlight wiped in (#35).
     pub anim_prev_selected: usize,
@@ -379,6 +383,14 @@ impl App {
             self.session_exit_at = None;
             *self.session_snapshot.borrow_mut() = None;
         }
+        // Retire a finished fold, releasing the rows it was replaying.
+        if self
+            .fold_anim
+            .as_ref()
+            .is_some_and(|f| f.at.elapsed() >= crate::tui::FOLD_ANIM)
+        {
+            self.fold_anim = None;
+        }
         // The cursor moved since the last tick: wipe its highlight in (#35).
         if self.selected != self.anim_prev_selected {
             self.anim_prev_selected = self.selected;
@@ -534,6 +546,7 @@ impl App {
             session_snapshot: std::cell::RefCell::new(None),
             session_exit_at: None,
             session_tab_switch: None,
+            fold_anim: None,
             anim_prev_selected: 0,
             selection_at: None,
             host_scroll_pos: std::cell::Cell::new(0.0),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -231,6 +231,11 @@ pub struct App {
     pub header_stats_at: std::cell::Cell<Option<std::time::Instant>>,
     /// Whether a counter is still counting, so the loop keeps the frame rate up.
     pub header_stats_moving: std::cell::Cell<bool>,
+    /// SFTP queue length as of the previous tick, so a newly staged transfer
+    /// can be detected centrally and flown in (#35).
+    pub anim_prev_queue: usize,
+    /// When the last transfer was staged, driving its row's fly-in.
+    pub sftp_queue_at: Option<std::time::Instant>,
     /// Fraction of the running SFTP queue drawn on the progress bar, chasing
     /// the real figure so the bar sweeps between the worker's updates (#35).
     pub sftp_progress_pos: std::cell::Cell<f32>,
@@ -404,6 +409,14 @@ impl App {
             self.session_exit_at = None;
             *self.session_snapshot.borrow_mut() = None;
         }
+        // A transfer staged since the last tick flies its row in (#35).
+        let queued = self.sftp.as_ref().map(|s| s.queue.len()).unwrap_or(0);
+        if queued != self.anim_prev_queue {
+            // Only a fresh entry animates; removing one is the user's own key
+            // press and reads fine as an immediate change.
+            self.sftp_queue_at = (queued > self.anim_prev_queue).then(std::time::Instant::now);
+            self.anim_prev_queue = queued;
+        }
         self.detect_ping_changes();
         // Retire a finished fold, releasing the rows it was replaying.
         if self
@@ -571,6 +584,8 @@ impl App {
             header_stats_pos: std::cell::Cell::new([0.0; 4]),
             header_stats_at: std::cell::Cell::new(None),
             header_stats_moving: std::cell::Cell::new(false),
+            anim_prev_queue: 0,
+            sftp_queue_at: None,
             sftp_progress_pos: std::cell::Cell::new(0.0),
             sftp_progress_at: std::cell::Cell::new(None),
             sftp_progress_moving: std::cell::Cell::new(false),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -283,12 +283,14 @@ pub struct App {
     search: HostSearch,
 }
 
-/// Whether `mode` draws a popup overlay over the dashboard (so its open/close
-/// should animate, #35). Excludes the full-screen session modes.
+/// Whether `mode` draws a popup overlay (so its open/close should animate,
+/// #35). Excludes the full-screen session modes, which are not popups. The
+/// session-host picker counts: it is a popup like any other, drawn over either
+/// the dashboard or a live session, both of which snapshot a backdrop for it.
 pub(crate) fn is_overlay_mode(mode: AppMode) -> bool {
     !matches!(
         mode,
-        AppMode::Normal | AppMode::Connecting | AppMode::Session | AppMode::SessionHostPicker
+        AppMode::Normal | AppMode::Connecting | AppMode::Session
     )
 }
 

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -176,11 +176,17 @@ impl App {
     }
 
     pub(crate) fn open_session_host_picker(&mut self) {
+        self.open_host_picker(PickerTarget::NewSession);
+    }
+
+    /// Open the shared host picker for whatever `target` wants a host.
+    pub(crate) fn open_host_picker(&mut self, target: PickerTarget) {
         let return_mode = self.mode;
         self.session_host_picker = Some(SessionHostPicker {
             query: String::new(),
             selected: 0,
             return_mode,
+            target,
         });
         self.mode = AppMode::SessionHostPicker;
     }
@@ -213,15 +219,16 @@ impl App {
             }
             KeyCode::Enter => {
                 let matches = self.session_host_matches();
-                let host_idx = self
+                let picked = self
                     .session_host_picker
                     .as_ref()
-                    .and_then(|p| matches.get(p.selected))
-                    .map(|(idx, _)| *idx);
+                    .and_then(|p| matches.get(p.selected).map(|(idx, _)| (*idx, p.target)));
                 self.session_host_picker = None;
                 self.mode = return_mode;
-                if let Some(idx) = host_idx {
-                    self.connect_host_at(idx)?;
+                match picked {
+                    Some((idx, PickerTarget::NewSession)) => self.connect_host_at(idx)?,
+                    Some((idx, PickerTarget::SftpLeftPane)) => self.sftp_connect_left_pane(idx)?,
+                    None => {}
                 }
             }
             KeyCode::Backspace => {

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -322,7 +322,17 @@ impl App {
             self.mode = AppMode::Normal;
         } else {
             // Stay at the same index if possible, else drop back to the new last.
-            self.active_session = Some(idx.min(self.sessions.len() - 1));
+            let next = idx.min(self.sessions.len() - 1);
+            // The tab that takes over sat to the right of the closed one, unless
+            // the closed one was last — then we fall back to its left neighbour
+            // and the slide has to travel the other way (#35).
+            if self.mode != AppMode::Normal && self.motion_enabled() {
+                self.session_tab_switch = Some(SessionTabSwitch {
+                    dir: if next == idx { 1 } else { -1 },
+                    at: std::time::Instant::now(),
+                });
+            }
+            self.active_session = Some(next);
             let phase = &self.sessions[self.active_session.unwrap()].phase;
             self.mode = if self.mode == AppMode::Normal {
                 AppMode::Normal
@@ -349,6 +359,14 @@ impl App {
 
         if self.mode == AppMode::Normal {
             return;
+        }
+        // Carry the tab we're leaving off in the direction of travel (#35). The
+        // strip wraps, so the direction comes from `delta`, not the indices.
+        if next != cur && self.motion_enabled() {
+            self.session_tab_switch = Some(SessionTabSwitch {
+                dir: if delta > 0 { 1 } else { -1 },
+                at: std::time::Instant::now(),
+            });
         }
 
         // Reflect the new active session's phase in app.mode, so render

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -329,6 +329,9 @@ impl App {
             if self.mode != AppMode::Normal && self.motion_enabled() {
                 self.session_tab_switch = Some(SessionTabSwitch {
                     dir: if next == idx { 1 } else { -1 },
+                    // The closed tab is gone from the strip, so the highlight
+                    // travels from where its neighbour now sits.
+                    from: next,
                     at: std::time::Instant::now(),
                 });
             }
@@ -365,6 +368,7 @@ impl App {
         if next != cur && self.motion_enabled() {
             self.session_tab_switch = Some(SessionTabSwitch {
                 dir: if delta > 0 { 1 } else { -1 },
+                from: cur as usize,
                 at: std::time::Instant::now(),
             });
         }

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -6,6 +6,14 @@ use crate::sftp::model::{FileEntry, Phase, SftpState, Side};
 use crate::sftp::SftpCommand;
 
 impl App {
+    /// Arm an SFTP tab sub-state slide (#35). A no-op under reduced motion,
+    /// where each sub-state simply appears at rest.
+    fn stamp_sftp_anim(&mut self, kind: SftpAnim) {
+        if self.motion_enabled() {
+            self.sftp_anim = Some((kind, std::time::Instant::now()));
+        }
+    }
+
     /// Switch to the SFTP tab (index 1). Setter mirror of the other
     /// `switch_to_*_tab` helpers; kept dead-simple because the SFTP tab has no
     /// eager data to refresh (the picker just reuses the host list).
@@ -616,6 +624,8 @@ impl App {
         self.sftp_tx = Some(tx);
         self.sftp_rx = Some(rx);
         self.sftp_host = Some(entry.name().to_string());
+        // Slide the "connecting…" layer in from the right over the picker (#35).
+        self.stamp_sftp_anim(SftpAnim::ConnectIn);
         Ok(())
     }
 
@@ -708,6 +718,19 @@ impl App {
     /// Tear down the live session. Dropping the command `Sender` makes the
     /// worker thread self-terminate.
     fn sftp_disconnect(&mut self) {
+        // Mirror the way in (#35): a handshake that never completed carries the
+        // "connecting…" layer off to the right, a live browser parts its panes
+        // toward both edges. Both reveal the picker underneath.
+        let kind = self.sftp.as_ref().map(|s| {
+            if s.connecting {
+                SftpAnim::ConnectOut
+            } else {
+                SftpAnim::PanesOut
+            }
+        });
+        if let Some(kind) = kind {
+            self.stamp_sftp_anim(kind);
+        }
         self.sftp = None;
         self.sftp_tx = None;
         self.sftp_rx = None;
@@ -722,9 +745,14 @@ impl App {
 
         match ev {
             SftpEvent::Connected => {
+                let was_connecting = self.sftp.as_ref().is_some_and(|s| s.connecting);
                 if let Some(s) = self.sftp.as_mut() {
                     s.notice = None;
                     s.connecting = false;
+                }
+                // Handshake done: bring the two panes in from their edges (#35).
+                if was_connecting {
+                    self.stamp_sftp_anim(SftpAnim::PanesIn);
                 }
             }
             SftpEvent::ConnectFailed(msg) => {

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -245,18 +245,19 @@ impl App {
                 }
             }
             // Panes are left=local, right=remote, so the arrow points at the
-            // destination: ← downloads (remote → local), → uploads (local → remote).
+            // destination pane and the source is the focused one: ← downloads
+            // (remote → local), → uploads (local → remote).
             KeyCode::Left => {
                 if !running {
                     if let Some(s) = self.sftp.as_mut() {
-                        let _ = s.stage_download();
+                        let _ = s.stage_toward(Side::Local);
                     }
                 }
             }
             KeyCode::Right => {
                 if !running {
                     if let Some(s) = self.sftp.as_mut() {
-                        let _ = s.stage_upload();
+                        let _ = s.stage_toward(Side::Remote);
                     }
                 }
             }

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use std::path::{Path, PathBuf};
 
-use crate::sftp::model::{FileEntry, Phase, SftpState, Side};
+use crate::sftp::model::{Direction, FileEntry, Phase, QueuedTransfer, SftpState, Side};
 
 /// Time constant of the SFTP progress bar's chase (#35).
 const SFTP_PROGRESS_TAU: f32 = 0.12;
@@ -286,6 +286,10 @@ impl App {
             KeyCode::Char('r') => self.sftp_refresh_panes(),
             // Open an SSH session to this same host (SFTP stays in the background).
             KeyCode::Char('s') => self.open_ssh_for_sftp_host()?,
+            // Point the left pane at a second server, or send it back to the
+            // local filesystem.
+            KeyCode::Char('o') => self.open_host_picker(PickerTarget::SftpLeftPane),
+            KeyCode::Char('O') => self.sftp_left_pane_to_local(),
             // Confirm: run the whole queue sequentially.
             KeyCode::Char('c') => self.sftp_run_queue(),
             // File ops (frozen while a queue runs).
@@ -434,30 +438,34 @@ impl App {
             return;
         }
 
-        match side {
-            Side::Remote => {
-                let cmd = match kind {
-                    SftpPromptKind::Mkdir => crate::sftp::SftpCommand::Mkdir(target),
-                    SftpPromptKind::Rename => {
-                        crate::sftp::SftpCommand::Rename(old_path.unwrap_or_default(), target)
-                    }
-                    SftpPromptKind::Chmod => unreachable!("chmod handled earlier"),
-                };
-                // A missing channel OR a failed send (worker thread dead) means
-                // the op won't run — keep the prompt open with an error rather
-                // than closing it as if it succeeded.
-                let sent = self
-                    .sftp_tx
-                    .as_ref()
-                    .map(|tx| tx.send(cmd).is_ok())
-                    .unwrap_or(false);
-                if sent {
-                    self.sftp_prompt = None;
-                    self.mode = AppMode::Normal;
-                } else if let Some(p) = self.sftp_prompt.as_mut() {
-                    p.error = Some("not connected".into());
+        // A pane pointed at a server routes through its worker; only a truly
+        // local pane touches the filesystem here.
+        if self.sftp_channel(side).is_some() {
+            let cmd = match kind {
+                SftpPromptKind::Mkdir => crate::sftp::SftpCommand::Mkdir(target),
+                SftpPromptKind::Rename => {
+                    crate::sftp::SftpCommand::Rename(old_path.unwrap_or_default(), target)
                 }
+                SftpPromptKind::Chmod => unreachable!("chmod handled earlier"),
+            };
+            // A missing channel OR a failed send (worker thread dead) means
+            // the op won't run — keep the prompt open with an error rather
+            // than closing it as if it succeeded.
+            let sent = self
+                .sftp_channel(side)
+                .map(|tx| tx.send(cmd).is_ok())
+                .unwrap_or(false);
+            if sent {
+                self.sftp_prompt = None;
+                self.mode = AppMode::Normal;
+            } else if let Some(p) = self.sftp_prompt.as_mut() {
+                p.error = Some("not connected".into());
             }
+            return;
+        }
+
+        match side {
+            Side::Remote => unreachable!("the remote pane always has a channel"),
             Side::Local => {
                 let result: std::io::Result<()> = match kind {
                     SftpPromptKind::Mkdir => std::fs::create_dir(&target),
@@ -513,20 +521,22 @@ impl App {
             return;
         };
 
-        match side {
-            Side::Remote => {
-                let sent = self
-                    .sftp_tx
-                    .as_ref()
-                    .map(|tx| tx.send(crate::sftp::SftpCommand::Chmod(path, mode)).is_ok())
-                    .unwrap_or(false);
-                if sent {
-                    self.sftp_prompt = None;
-                    self.mode = AppMode::Normal;
-                } else if let Some(p) = self.sftp_prompt.as_mut() {
-                    p.error = Some("not connected".into());
-                }
+        if self.sftp_channel(side).is_some() {
+            let sent = self
+                .sftp_channel(side)
+                .map(|tx| tx.send(crate::sftp::SftpCommand::Chmod(path, mode)).is_ok())
+                .unwrap_or(false);
+            if sent {
+                self.sftp_prompt = None;
+                self.mode = AppMode::Normal;
+            } else if let Some(p) = self.sftp_prompt.as_mut() {
+                p.error = Some("not connected".into());
             }
+            return;
+        }
+
+        match side {
+            Side::Remote => unreachable!("the remote pane always has a channel"),
             Side::Local => {
                 use std::os::unix::fs::PermissionsExt;
                 match std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode)) {
@@ -584,6 +594,25 @@ impl App {
                     // SFTP pane is gone, so surface the failure where the user
                     // will actually see it.
                     self.host_notice = Some("SFTP disconnected — delete not sent".into());
+                }
+            }
+            // Left pane on a second server: same worker round trip as the right.
+            Side::Local if self.sftp.as_ref().is_some_and(|s| s.left_is_remote()) => {
+                let name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                let sent = self
+                    .sftp_tx2
+                    .as_ref()
+                    .map(|tx| tx.send(SftpCommand::Remove(path, is_dir)).is_ok())
+                    .unwrap_or(false);
+                if let Some(s) = self.sftp.as_mut() {
+                    if sent {
+                        s.local.remove_named(&name);
+                    } else {
+                        s.notice = Some("not connected — delete not sent".into());
+                    }
                 }
             }
             Side::Local => {
@@ -701,6 +730,79 @@ impl App {
         Ok(())
     }
 
+    /// The worker that owns `side`: the browser's own for the right pane, the
+    /// second one for a left pane pointed at another server, and `None` for a
+    /// left pane showing the local filesystem (which needs no worker).
+    fn sftp_channel(&self, side: Side) -> Option<&std::sync::mpsc::Sender<SftpCommand>> {
+        match side {
+            Side::Remote => self.sftp_tx.as_ref(),
+            Side::Local if self.sftp.as_ref().is_some_and(|s| s.left_is_remote()) => {
+                self.sftp_tx2.as_ref()
+            }
+            Side::Local => None,
+        }
+    }
+
+    /// Point the left pane at a second server, so two remote hosts can be
+    /// browsed side by side (the right pane keeps its own session).
+    ///
+    /// Runs its own worker: libssh2 has no server-to-server copy, so the two
+    /// ends stay independent connections and a transfer between them is
+    /// relayed locally.
+    pub(crate) fn sftp_connect_left_pane(&mut self, host_idx: usize) -> Result<()> {
+        let Some(entry) = self.hosts.get(host_idx).cloned() else {
+            return Ok(());
+        };
+        if self.sftp.is_none() {
+            self.host_notice = Some("connect the SFTP browser first".into());
+            return Ok(());
+        }
+        let ssh_host = match &entry {
+            HostEntry::Managed(m) => managed_to_ssh_host(m),
+            HostEntry::Legacy { host, .. } => host.clone(),
+        };
+        if ssh_host.proxy_jump.is_some() {
+            self.host_notice =
+                Some("SFTP via ProxyJump isn't supported yet — pick a direct host.".into());
+            return Ok(());
+        }
+
+        let (secret, _diag) = resolve_pending_secret(&entry, self.password_store.as_ref());
+        let agent = crate::ssh::agent::detect_agent();
+        let (tx, rx) = crate::sftp::spawn_sftp_worker(ssh_host, secret, agent);
+        let cwd = PathBuf::from(".");
+        // The worker queues the listing until its handshake completes.
+        let _ = tx.send(SftpCommand::ListDir(Side::Remote, cwd.clone()));
+        self.sftp_tx2 = Some(tx);
+        self.sftp_rx2 = Some(rx);
+        if let Some(s) = self.sftp.as_mut() {
+            s.left_host = Some(entry.name().to_string());
+            s.left_connecting = true;
+            s.local.cwd = cwd;
+            s.local.set_entries(Vec::new());
+        }
+        Ok(())
+    }
+
+    /// Send the left pane back to the local filesystem, dropping its server
+    /// connection (the worker self-terminates when its sender goes).
+    pub(crate) fn sftp_left_pane_to_local(&mut self) {
+        // Any relay in flight has one end on the server we're dropping.
+        if self.sftp_relay.is_some() {
+            self.sftp_relay_abort("second host disconnected — transfer stopped");
+        }
+        self.sftp_tx2 = None;
+        self.sftp_rx2 = None;
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let entries = read_local_dir(&cwd);
+        if let Some(s) = self.sftp.as_mut() {
+            s.left_host = None;
+            s.left_connecting = false;
+            s.local.cwd = cwd;
+            s.local.set_entries(entries);
+        }
+    }
+
     /// Open an SSH session to the host the SFTP browser is connected to (the
     /// reverse of `open_sftp_for_active_session` — completes the round trip).
     /// The SFTP session stays live in the background.
@@ -739,6 +841,13 @@ impl App {
                     let _ = tx.send(SftpCommand::ListDir(Side::Remote, path));
                 }
             }
+            Side::Local if self.sftp.as_ref().is_some_and(|s| s.left_is_remote()) => {
+                // Left pane is a second server: same async path as the right
+                // one, just down the other worker's channel.
+                if let Some(tx) = self.sftp_tx2.as_ref() {
+                    let _ = tx.send(SftpCommand::ListDir(Side::Remote, path));
+                }
+            }
             Side::Local => {
                 let entries = read_local_dir(&path);
                 if let Some(s) = self.sftp.as_mut() {
@@ -749,7 +858,7 @@ impl App {
         }
     }
 
-    fn sftp_run_queue(&mut self) {
+    pub(crate) fn sftp_run_queue(&mut self) {
         if self
             .sftp
             .as_ref()
@@ -761,6 +870,31 @@ impl App {
             Some(s) if !s.queue.is_empty() => s.queue.clone(),
             _ => return,
         };
+        // Two servers: neither worker can talk to the other, so each item is
+        // relayed through a local temp file, one leg at a time.
+        if self.sftp.as_ref().is_some_and(|s| s.left_is_remote()) {
+            let tmp_dir = std::env::temp_dir().join(format!("sshub-relay-{}", std::process::id()));
+            if let Err(e) = std::fs::create_dir_all(&tmp_dir) {
+                if let Some(s) = self.sftp.as_mut() {
+                    s.notice = Some(format!("no scratch space for the relay: {e}"));
+                }
+                return;
+            }
+            if let Some(s) = self.sftp.as_mut() {
+                s.phase = Phase::Running;
+                s.progress = None;
+                s.running = queue.clone();
+            }
+            self.sftp_relay = Some(SftpRelay {
+                total: queue.len(),
+                items: queue.into_iter().collect(),
+                tmp_dir,
+                leg: RelayLeg::Fetching,
+            });
+            self.sftp_relay_step();
+            return;
+        }
+
         if let Some(tx) = self.sftp_tx.as_ref() {
             if tx.send(SftpCommand::RunQueue(queue.clone())).is_ok() {
                 if let Some(s) = self.sftp.as_mut() {
@@ -774,6 +908,148 @@ impl App {
         }
     }
 
+    /// Start (or continue) relaying server-to-server transfers, one leg at a
+    /// time: the source worker pulls an item into a temp directory, then the
+    /// destination worker pushes it up from there.
+    fn sftp_relay_step(&mut self) {
+        let Some(relay) = self.sftp_relay.as_ref() else {
+            return;
+        };
+        let Some(item) = relay.items.front().cloned() else {
+            // Nothing left: tidy up and let the queue finish normally.
+            self.sftp_relay_finish();
+            return;
+        };
+        let leg = relay.leg;
+        let tmp = relay.tmp_dir.join(&item.name);
+        // `Download` means right-to-left, so the source is the right pane.
+        let (from, to) = match item.direction {
+            Direction::Download => (Side::Remote, Side::Local),
+            Direction::Upload => (Side::Local, Side::Remote),
+        };
+        let (side, cmd) = match leg {
+            RelayLeg::Fetching => (
+                from,
+                QueuedTransfer {
+                    direction: Direction::Download,
+                    src: item.src.clone(),
+                    dst: tmp,
+                    name: item.name.clone(),
+                    is_dir: item.is_dir,
+                },
+            ),
+            RelayLeg::Pushing => (
+                to,
+                QueuedTransfer {
+                    direction: Direction::Upload,
+                    src: tmp,
+                    dst: item.dst.clone(),
+                    name: item.name.clone(),
+                    is_dir: item.is_dir,
+                },
+            ),
+        };
+        let sent = self
+            .sftp_channel(side)
+            .map(|tx| tx.send(SftpCommand::RunQueue(vec![cmd])).is_ok())
+            .unwrap_or(false);
+        if !sent {
+            self.sftp_relay_abort("not connected — transfer stopped");
+        }
+    }
+
+    /// Fold a worker's `QueueDone` into the relay: finish the leg, move to the
+    /// next one, or take the completed item off the queue. Returns true when
+    /// the event belonged to a relay (so the normal completion path is skipped).
+    fn sftp_relay_queue_done(&mut self) -> bool {
+        let Some(relay) = self.sftp_relay.as_mut() else {
+            return false;
+        };
+        match relay.leg {
+            RelayLeg::Fetching => {
+                relay.leg = RelayLeg::Pushing;
+            }
+            RelayLeg::Pushing => {
+                // The item is across; drop its temp copy and the queue entry.
+                if let Some(done) = relay.items.pop_front() {
+                    let tmp = relay.tmp_dir.join(&done.name);
+                    let _ = if done.is_dir {
+                        std::fs::remove_dir_all(&tmp)
+                    } else {
+                        std::fs::remove_file(&tmp)
+                    };
+                    if let Some(s) = self.sftp.as_mut() {
+                        s.queue.retain(|q| *q != done);
+                        s.running.retain(|q| *q != done);
+                    }
+                }
+                if let Some(relay) = self.sftp_relay.as_mut() {
+                    relay.leg = RelayLeg::Fetching;
+                }
+            }
+        }
+        self.sftp_relay_step();
+        true
+    }
+
+    /// Report a relay leg's progress against the whole item, so the bar counts
+    /// one file rather than restarting for each leg: the fetch fills the first
+    /// half, the push the second.
+    fn sftp_relay_progress(&mut self, transferred: u64, size: u64) {
+        let Some(relay) = self.sftp_relay.as_ref() else {
+            return;
+        };
+        let done = relay.total.saturating_sub(relay.items.len());
+        let half = if relay.leg == RelayLeg::Fetching {
+            0.0
+        } else {
+            0.5
+        };
+        let leg = if size > 0 {
+            (transferred as f64 / size as f64).clamp(0.0, 1.0) * 0.5
+        } else {
+            0.0
+        };
+        let fraction = half + leg;
+        if let Some(s) = self.sftp.as_mut() {
+            s.progress = Some(crate::sftp::model::Progress {
+                index: done,
+                total: relay.total,
+                // Scaled to a notional 1000 units so the bar can show a
+                // fraction of a single relayed item.
+                transferred: (fraction * 1000.0) as u64,
+                size: 1000,
+            });
+        }
+    }
+
+    /// Stop a relay part-way with a notice, leaving whatever hasn't moved in
+    /// the queue so it can be retried.
+    fn sftp_relay_abort(&mut self, msg: &str) {
+        if let Some(relay) = self.sftp_relay.take() {
+            let _ = std::fs::remove_dir_all(&relay.tmp_dir);
+        }
+        if let Some(s) = self.sftp.as_mut() {
+            s.phase = Phase::Browsing;
+            s.progress = None;
+            s.running.clear();
+            s.notice = Some(msg.to_string());
+        }
+    }
+
+    /// Every item is across: clear the temp directory and settle the browser.
+    fn sftp_relay_finish(&mut self) {
+        if let Some(relay) = self.sftp_relay.take() {
+            let _ = std::fs::remove_dir_all(&relay.tmp_dir);
+        }
+        if let Some(s) = self.sftp.as_mut() {
+            s.phase = Phase::Browsing;
+            s.progress = None;
+            s.running.clear();
+        }
+        self.sftp_refresh_panes();
+    }
+
     /// Re-list both panes: remote via the worker (async `DirListing`), local
     /// synchronously. Used by the `r` refresh key and after a queue completes.
     fn sftp_refresh_panes(&mut self) {
@@ -783,6 +1059,12 @@ impl App {
         };
         if let Some(tx) = self.sftp_tx.as_ref() {
             let _ = tx.send(SftpCommand::ListDir(Side::Remote, remote_cwd));
+        }
+        if self.sftp.as_ref().is_some_and(|s| s.left_is_remote()) {
+            if let Some(tx) = self.sftp_tx2.as_ref() {
+                let _ = tx.send(SftpCommand::ListDir(Side::Remote, local_cwd));
+            }
+            return;
         }
         let entries = read_local_dir(&local_cwd);
         if let Some(s) = self.sftp.as_mut() {
@@ -806,10 +1088,68 @@ impl App {
         if let Some(kind) = kind {
             self.stamp_sftp_anim(kind);
         }
+        if let Some(relay) = self.sftp_relay.take() {
+            let _ = std::fs::remove_dir_all(&relay.tmp_dir);
+        }
         self.sftp = None;
         self.sftp_tx = None;
         self.sftp_rx = None;
         self.sftp_host = None;
+        self.sftp_tx2 = None;
+        self.sftp_rx2 = None;
+    }
+
+    /// Apply one [`SftpEvent`] from the *left* pane's worker (the second
+    /// server). The worker speaks in its own terms -- everything it reports is
+    /// `Side::Remote` -- so its listings are folded into the left pane here.
+    pub fn apply_sftp_event_left(&mut self, ev: crate::sftp::SftpEvent) {
+        use crate::sftp::SftpEvent;
+
+        match ev {
+            SftpEvent::Connected => {
+                if let Some(s) = self.sftp.as_mut() {
+                    s.left_connecting = false;
+                    s.notice = None;
+                }
+            }
+            SftpEvent::ConnectFailed(msg) => {
+                let host = self
+                    .sftp
+                    .as_ref()
+                    .and_then(|s| s.left_host.clone())
+                    .unwrap_or_default();
+                // Fall back to the local filesystem rather than leaving the
+                // pane stuck on a server that never answered.
+                self.sftp_left_pane_to_local();
+                self.notice_popup = Some(format!("Could not connect to {host}:\n{msg}"));
+                self.mode = AppMode::Notice;
+            }
+            SftpEvent::DirListing(_, path, entries) => {
+                if let Some(s) = self.sftp.as_mut() {
+                    s.local.cwd = path;
+                    s.local.set_entries(entries);
+                }
+            }
+            SftpEvent::OpDone => self.sftp_refresh_panes(),
+            SftpEvent::Error(msg) if self.sftp_relay.is_some() => {
+                self.sftp_relay_abort(&msg);
+                self.sftp_refresh_panes();
+            }
+            SftpEvent::Error(msg) => {
+                if let Some(s) = self.sftp.as_mut() {
+                    s.notice = Some(msg);
+                }
+                self.sftp_refresh_panes();
+            }
+            // This worker only ever runs one leg of a relay at a time.
+            SftpEvent::QueueDone => {
+                self.sftp_relay_queue_done();
+            }
+            SftpEvent::Progress {
+                transferred, size, ..
+            } => self.sftp_relay_progress(transferred, size),
+            SftpEvent::TransferDone(_) => {}
+        }
     }
 
     /// Apply one [`SftpEvent`] drained from the worker to the live `sftp` state.
@@ -857,6 +1197,9 @@ impl App {
                 }
             }
             SftpEvent::Progress {
+                transferred, size, ..
+            } if self.sftp_relay.is_some() => self.sftp_relay_progress(transferred, size),
+            SftpEvent::Progress {
                 index,
                 total,
                 transferred,
@@ -872,6 +1215,9 @@ impl App {
                 }
             }
             SftpEvent::TransferDone(_) => {}
+            SftpEvent::QueueDone if self.sftp_relay.is_some() => {
+                self.sftp_relay_queue_done();
+            }
             SftpEvent::QueueDone => {
                 let mut more = false;
                 if let Some(s) = self.sftp.as_mut() {
@@ -889,6 +1235,10 @@ impl App {
             }
             SftpEvent::OpDone => {
                 // A remote remove/mkdir/rename landed — re-list so it shows.
+                self.sftp_refresh_panes();
+            }
+            SftpEvent::Error(msg) if self.sftp_relay.is_some() => {
+                self.sftp_relay_abort(&msg);
                 self.sftp_refresh_panes();
             }
             SftpEvent::Error(msg) => {

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -48,6 +48,36 @@ impl App {
         next
     }
 
+    /// Notice either SFTP pane changing directory and stamp which way it went
+    /// (#35), so its listing can slide in from the matching side. Detected
+    /// centrally because a remote change lands asynchronously, on the worker's
+    /// `DirListing`, rather than when the key was pressed.
+    pub(crate) fn detect_sftp_navigation(&mut self) {
+        let cwds = match self.sftp.as_ref() {
+            Some(s) => [s.local.cwd.clone(), s.remote.cwd.clone()],
+            // No session: forget the old paths so reconnecting doesn't read as
+            // a navigation.
+            None => {
+                self.anim_prev_cwd = [PathBuf::new(), PathBuf::new()];
+                self.sftp_nav = [None, None];
+                return;
+            }
+        };
+        for (i, cwd) in cwds.into_iter().enumerate() {
+            if cwd == self.anim_prev_cwd[i] {
+                continue;
+            }
+            // Descending into a child goes one way, anything else (parent, or a
+            // jump elsewhere) the other. The first listing of a fresh session
+            // has no previous path and doesn't animate.
+            let fresh = self.anim_prev_cwd[i].as_os_str().is_empty();
+            let deeper = cwd.starts_with(&self.anim_prev_cwd[i]);
+            self.anim_prev_cwd[i] = cwd;
+            self.sftp_nav[i] =
+                (!fresh && self.motion_enabled()).then(|| (deeper, std::time::Instant::now()));
+        }
+    }
+
     /// Switch to the SFTP tab (index 1). Setter mirror of the other
     /// `switch_to_*_tab` helpers; kept dead-simple because the SFTP tab has no
     /// eager data to refresh (the picker just reuses the host list).

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -870,6 +870,7 @@ impl App {
             Some(s) if !s.queue.is_empty() => s.queue.clone(),
             _ => return,
         };
+        self.sftp_run_failed = false;
         // Two servers: neither worker can talk to the other, so each item is
         // relayed through a local temp file, one leg at a time.
         if self.sftp.as_ref().is_some_and(|s| s.left_is_remote()) {
@@ -895,6 +896,7 @@ impl App {
             return;
         }
 
+        self.sftp_run_failed = false;
         if let Some(tx) = self.sftp_tx.as_ref() {
             if tx.send(SftpCommand::RunQueue(queue.clone())).is_ok() {
                 if let Some(s) = self.sftp.as_mut() {
@@ -1023,11 +1025,30 @@ impl App {
         }
     }
 
+    /// Consume one owed trailing `QueueDone`, if any. Returns whether this
+    /// event was one of them and should be ignored.
+    fn sftp_take_swallowed_done(&mut self) -> bool {
+        if self.sftp_swallow_done == 0 {
+            return false;
+        }
+        self.sftp_swallow_done -= 1;
+        true
+    }
+
     /// Stop a relay part-way with a notice, leaving whatever hasn't moved in
     /// the queue so it can be retried.
     fn sftp_relay_abort(&mut self, msg: &str) {
         if let Some(relay) = self.sftp_relay.take() {
             let _ = std::fs::remove_dir_all(&relay.tmp_dir);
+        }
+        // The leg that failed still owes us a `QueueDone`; swallow it, and tell
+        // both workers to stop in case one is still grinding through a tree.
+        self.sftp_swallow_done += 1;
+        for tx in [self.sftp_tx.as_ref(), self.sftp_tx2.as_ref()]
+            .into_iter()
+            .flatten()
+        {
+            let _ = tx.send(SftpCommand::Cancel);
         }
         if let Some(s) = self.sftp.as_mut() {
             s.phase = Phase::Browsing;
@@ -1132,10 +1153,12 @@ impl App {
             }
             SftpEvent::OpDone => self.sftp_refresh_panes(),
             SftpEvent::Error(msg) if self.sftp_relay.is_some() => {
+                self.sftp_run_failed = true;
                 self.sftp_relay_abort(&msg);
                 self.sftp_refresh_panes();
             }
             SftpEvent::Error(msg) => {
+                self.sftp_run_failed = true;
                 if let Some(s) = self.sftp.as_mut() {
                     s.notice = Some(msg);
                 }
@@ -1143,7 +1166,9 @@ impl App {
             }
             // This worker only ever runs one leg of a relay at a time.
             SftpEvent::QueueDone => {
-                self.sftp_relay_queue_done();
+                if !self.sftp_take_swallowed_done() {
+                    self.sftp_relay_queue_done();
+                }
             }
             SftpEvent::Progress {
                 transferred, size, ..
@@ -1215,6 +1240,7 @@ impl App {
                 }
             }
             SftpEvent::TransferDone(_) => {}
+            SftpEvent::QueueDone if self.sftp_take_swallowed_done() => {}
             SftpEvent::QueueDone if self.sftp_relay.is_some() => {
                 self.sftp_relay_queue_done();
             }
@@ -1228,8 +1254,10 @@ impl App {
                 // Refresh both panes so completed transfers show up.
                 self.sftp_refresh_panes();
                 // Anything staged mid-run rolls straight into the next pass: a
-                // queue you can add to while it works has to keep working.
-                if more {
+                // queue you can add to while it works has to keep working. A
+                // run that reported an error stops there instead -- restarting
+                // it would retry the failing transfer forever.
+                if more && !self.sftp_run_failed {
                     self.sftp_run_queue();
                 }
             }
@@ -1238,10 +1266,12 @@ impl App {
                 self.sftp_refresh_panes();
             }
             SftpEvent::Error(msg) if self.sftp_relay.is_some() => {
+                self.sftp_run_failed = true;
                 self.sftp_relay_abort(&msg);
                 self.sftp_refresh_panes();
             }
             SftpEvent::Error(msg) => {
+                self.sftp_run_failed = true;
                 if let Some(s) = self.sftp.as_mut() {
                     s.notice = Some(msg);
                 }

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -3,6 +3,9 @@ use super::*;
 use std::path::{Path, PathBuf};
 
 use crate::sftp::model::{FileEntry, Phase, SftpState, Side};
+
+/// Time constant of the SFTP progress bar's chase (#35).
+const SFTP_PROGRESS_TAU: f32 = 0.12;
 use crate::sftp::SftpCommand;
 
 impl App {
@@ -12,6 +15,37 @@ impl App {
         if self.motion_enabled() {
             self.sftp_anim = Some((kind, std::time::Instant::now()));
         }
+    }
+
+    /// Advance the SFTP progress bar toward `target` (0.0 to 1.0) and return
+    /// what to draw (#35).
+    ///
+    /// The worker reports progress in chunks, so the raw figure steps; the bar
+    /// closes on it continuously and keeps sweeping between updates. Reset to
+    /// the target outright when it moves backwards, which means the queue has
+    /// moved on to the next (smaller) file rather than made negative progress.
+    /// Called once per frame from the render pass.
+    pub(crate) fn sftp_progress_advance(&self, target: f32) -> f32 {
+        let target = target.clamp(0.0, 1.0);
+        if !self.motion_enabled() {
+            self.sftp_progress_pos.set(target);
+            self.sftp_progress_moving.set(false);
+            return target;
+        }
+        let now = std::time::Instant::now();
+        let last = self.sftp_progress_at.replace(Some(now));
+        let pos = self.sftp_progress_pos.get();
+        let dist = target - pos;
+        if last.is_none() || dist < 0.0 || dist < 0.002 {
+            self.sftp_progress_pos.set(target);
+            self.sftp_progress_moving.set(false);
+            return target;
+        }
+        let dt = now.saturating_duration_since(last.unwrap()).as_secs_f32();
+        let next = pos + dist * (1.0 - (-dt / SFTP_PROGRESS_TAU).exp());
+        self.sftp_progress_pos.set(next);
+        self.sftp_progress_moving.set(true);
+        next
     }
 
     /// Switch to the SFTP tab (index 1). Setter mirror of the other

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -602,6 +602,10 @@ impl App {
         let local_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
         let mut state = SftpState::new(remote_cwd.clone(), local_cwd.clone());
+        // Show a "connecting…" state (not an empty browser) until the worker
+        // reports Connected. An unreachable host never flashes a blank window —
+        // it fails into the Notice popup instead.
+        state.connecting = true;
         state.local.set_entries(read_local_dir(&local_cwd));
 
         // Kick off the first remote listing; the worker queues it until the
@@ -720,11 +724,20 @@ impl App {
             SftpEvent::Connected => {
                 if let Some(s) = self.sftp.as_mut() {
                     s.notice = None;
+                    s.connecting = false;
                 }
             }
             SftpEvent::ConnectFailed(msg) => {
+                let host = self.sftp_host.clone().unwrap_or_default();
                 self.sftp_disconnect();
-                self.host_notice = Some(format!("SFTP connection failed: {msg}"));
+                // Surface the failure as a modal popup instead of silently
+                // reverting to the picker — an unreachable host is loud, not blank.
+                self.notice_popup = Some(if host.is_empty() {
+                    format!("SFTP connection failed:\n{msg}")
+                } else {
+                    format!("Could not connect to {host}:\n{msg}")
+                });
+                self.mode = AppMode::Notice;
             }
             SftpEvent::DirListing(side, path, entries) => {
                 if let Some(s) = self.sftp.as_mut() {

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -296,7 +296,7 @@ impl App {
         let Some(s) = self.sftp.as_ref() else { return };
         let side = s.focused_side();
         let pane = s.focused_pane();
-        let Some(entry) = pane.selected_entry() else {
+        let Some(entry) = pane.selected_entry().filter(|e| !e.is_parent()) else {
             return;
         };
         let path = pane.cwd.join(&entry.name);
@@ -318,13 +318,13 @@ impl App {
         let (value, old_path) = match kind {
             SftpPromptKind::Mkdir => (String::new(), None),
             SftpPromptKind::Rename => {
-                let Some(entry) = pane.selected_entry() else {
+                let Some(entry) = pane.selected_entry().filter(|e| !e.is_parent()) else {
                     return;
                 };
                 (entry.name.clone(), Some(base.join(&entry.name)))
             }
             SftpPromptKind::Chmod => {
-                let Some(entry) = pane.selected_entry() else {
+                let Some(entry) = pane.selected_entry().filter(|e| !e.is_parent()) else {
                     return;
                 };
                 // Seed with the current octal permissions so the user edits from

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -201,13 +201,22 @@ impl App {
             .sftp
             .as_ref()
             .is_some_and(|s| s.phase == crate::sftp::model::Phase::Running);
+        // The local pane stays browsable during a run (its listings are read
+        // straight off the filesystem). The remote one doesn't: the worker
+        // handles commands in order, so a listing queued behind a transfer
+        // would leave the pane looking hung until the transfer finished.
+        let can_navigate = !running
+            || self
+                .sftp
+                .as_ref()
+                .is_some_and(|s| s.focused_side() == Side::Local);
         // Esc / Cancel disconnects the live session back to the picker.
         if self.is_action(KeyAction::Cancel, &key) {
             self.sftp_disconnect();
             return Ok(());
         }
         // Enter descends into the selected directory of the focused pane.
-        if !running && self.is_action(KeyAction::Connect, &key) {
+        if can_navigate && self.is_action(KeyAction::Connect, &key) {
             if let Some((side, path)) = self.sftp.as_ref().and_then(|s| s.enter_dir()) {
                 self.sftp_navigate(side, path);
             }
@@ -238,7 +247,7 @@ impl App {
                 }
             }
             KeyCode::Backspace => {
-                if !running {
+                if can_navigate {
                     if let Some((side, path)) = self.sftp.as_ref().and_then(|s| s.parent_dir()) {
                         self.sftp_navigate(side, path);
                     }
@@ -247,18 +256,16 @@ impl App {
             // Panes are left=local, right=remote, so the arrow points at the
             // destination pane and the source is the focused one: ← downloads
             // (remote → local), → uploads (local → remote).
+            // Staging stays open while a run is in flight: whatever is added
+            // rolls into the next pass when this one finishes.
             KeyCode::Left => {
-                if !running {
-                    if let Some(s) = self.sftp.as_mut() {
-                        let _ = s.stage_toward(Side::Local);
-                    }
+                if let Some(s) = self.sftp.as_mut() {
+                    let _ = s.stage_toward(Side::Local);
                 }
             }
             KeyCode::Right => {
-                if !running {
-                    if let Some(s) = self.sftp.as_mut() {
-                        let _ = s.stage_toward(Side::Remote);
-                    }
+                if let Some(s) = self.sftp.as_mut() {
+                    let _ = s.stage_toward(Side::Remote);
                 }
             }
             // Remove the most recently staged transfer from the queue.
@@ -755,10 +762,13 @@ impl App {
             _ => return,
         };
         if let Some(tx) = self.sftp_tx.as_ref() {
-            if tx.send(SftpCommand::RunQueue(queue)).is_ok() {
+            if tx.send(SftpCommand::RunQueue(queue.clone())).is_ok() {
                 if let Some(s) = self.sftp.as_mut() {
                     s.phase = Phase::Running;
                     s.progress = None;
+                    // Remember exactly what went out: anything staged while
+                    // this runs stays queued for the next pass.
+                    s.running = queue;
                 }
             }
         }
@@ -863,13 +873,19 @@ impl App {
             }
             SftpEvent::TransferDone(_) => {}
             SftpEvent::QueueDone => {
+                let mut more = false;
                 if let Some(s) = self.sftp.as_mut() {
                     s.phase = Phase::Browsing;
                     s.progress = None;
-                    s.queue.clear();
+                    more = s.finish_run();
                 }
                 // Refresh both panes so completed transfers show up.
                 self.sftp_refresh_panes();
+                // Anything staged mid-run rolls straight into the next pass: a
+                // queue you can add to while it works has to keep working.
+                if more {
+                    self.sftp_run_queue();
+                }
             }
             SftpEvent::OpDone => {
                 // A remote remove/mkdir/rename landed — re-list so it shows.

--- a/src/app/tests/misc.rs
+++ b/src/app/tests/misc.rs
@@ -479,3 +479,70 @@ pub(crate) fn help_scroll_stops_at_render_ceiling() {
     app.handle_key(key(KeyCode::End)).unwrap();
     assert_eq!(app.help_scroll, max);
 }
+
+/// The smoothed host-list scroll (#35) must start settled, chase a moved
+/// target across several frames rather than snapping, and eventually land on
+/// it exactly.
+#[test]
+fn host_scroll_chases_its_target_over_several_frames() {
+    let hosts: Vec<(String, SshHost)> = (0..40)
+        .map(|i| (format!("h{i:02}"), host(&format!("h{i:02}"))))
+        .collect();
+    let mut app = test_app(hosts.iter().map(|(n, h)| (n.as_str(), h.clone())).collect());
+    let body_h = 10;
+
+    // First draw adopts the target outright: the list must not scroll in from
+    // row zero when the app opens on a selection halfway down.
+    app.selected = 20;
+    let first = app.host_scroll_advance(body_h);
+    assert_eq!(first, app.host_scroll_offset(body_h));
+    assert!(!app.host_scroll_moving.get());
+
+    // Jump the selection to the end: the next frame moves toward the new
+    // target without reaching it, and reports itself as moving. Frames are
+    // backdated by a 60fps tick, since the chase is driven by wall-clock time
+    // and a test runs its frames back to back.
+    let tick = |app: &App| {
+        app.host_scroll_at.set(Some(
+            std::time::Instant::now() - std::time::Duration::from_millis(16),
+        ));
+    };
+    app.selected = app.nav_rows.len() - 1;
+    let target = app.host_scroll_offset(body_h);
+    tick(&app);
+    let stepped = app.host_scroll_advance(body_h);
+    assert!(app.host_scroll_moving.get(), "should report as moving");
+    assert!(
+        stepped > first && stepped < target,
+        "expected a step between {first} and {target}, got {stepped}"
+    );
+    // Hit-testing agrees with what was drawn, mid-scroll.
+    assert_eq!(app.host_scroll_shown(body_h), stepped);
+
+    // Given enough frames it settles exactly on the target and stops asking
+    // for more of them.
+    for _ in 0..200 {
+        tick(&app);
+        app.host_scroll_advance(body_h);
+    }
+    assert_eq!(app.host_scroll_advance(body_h), target);
+    assert!(!app.host_scroll_moving.get());
+}
+
+/// Reduced motion keeps the list pinned to the target offset, with no chase.
+#[test]
+fn host_scroll_snaps_under_reduced_motion() {
+    let hosts: Vec<(String, SshHost)> = (0..40)
+        .map(|i| (format!("h{i:02}"), host(&format!("h{i:02}"))))
+        .collect();
+    let mut app = test_app(hosts.iter().map(|(n, h)| (n.as_str(), h.clone())).collect());
+    app.config.appearance.disable_animation = true;
+    let body_h = 10;
+
+    app.selected = 0;
+    app.host_scroll_advance(body_h);
+    app.selected = app.nav_rows.len() - 1;
+    let target = app.host_scroll_offset(body_h);
+    assert_eq!(app.host_scroll_advance(body_h), target);
+    assert!(!app.host_scroll_moving.get());
+}

--- a/src/app/tests/misc.rs
+++ b/src/app/tests/misc.rs
@@ -719,3 +719,34 @@ fn header_stats_count_toward_their_target() {
     assert_eq!(app.header_stats_advance([12, 0, 3, 9]), [12, 0, 3, 9]);
     assert!(!app.header_stats_moving.get());
 }
+
+/// A fresh ping reading grows into the sparkline (#35): the newest column
+/// starts flat and reaches full height, and a first reading is already there.
+#[test]
+fn fresh_ping_sample_grows_into_the_sparkline() {
+    let mut app = test_app(vec![("a", host("a"))]);
+    assert_eq!(app.ping_grow("a"), 1.0, "no data: nothing to grow");
+
+    // First reading: the graph appearing is not a new sample landing.
+    app.ping_data.insert("a".into(), vec![12]);
+    app.detect_ping_changes();
+    assert_eq!(app.ping_grow("a"), 1.0);
+
+    // A new reading starts the column at the floor.
+    app.ping_data.insert("a".into(), vec![12, 40]);
+    app.detect_ping_changes();
+    assert!(app.ping_grow("a") < 1.0, "expected the column mid-growth");
+
+    // A repeated value is not a new reading.
+    let at = app.ping_sample.get("a").unwrap().1;
+    app.ping_data.insert("a".into(), vec![12, 40, 40]);
+    app.detect_ping_changes();
+    assert_eq!(app.ping_sample.get("a").unwrap().1, at);
+
+    // Grown out, it draws at full height again.
+    app.ping_sample.insert(
+        "a".into(),
+        (40, std::time::Instant::now() - crate::tui::PING_FLASH),
+    );
+    assert_eq!(app.ping_grow("a"), 1.0);
+}

--- a/src/app/tests/misc.rs
+++ b/src/app/tests/misc.rs
@@ -686,3 +686,36 @@ fn ping_flash_is_off_under_reduced_motion() {
         crate::tui::theme::GREEN
     );
 }
+
+/// The header tally counts toward its real values instead of snapping (#35),
+/// and lands on them exactly.
+#[test]
+fn header_stats_count_toward_their_target() {
+    let app = test_app(vec![("a", host("a"))]);
+    let tick = |app: &App| {
+        app.header_stats_at.set(Some(
+            std::time::Instant::now() - std::time::Duration::from_millis(16),
+        ));
+    };
+
+    // First frame adopts the tally outright: no counting up from zero on open.
+    assert_eq!(app.header_stats_advance([12, 8, 3, 1]), [12, 8, 3, 1]);
+    assert!(!app.header_stats_moving.get());
+
+    // A jump is approached, not taken in one step.
+    tick(&app);
+    let stepped = app.header_stats_advance([12, 0, 3, 9]);
+    assert!(app.header_stats_moving.get());
+    assert_eq!(stepped[0], 12, "an unchanged counter stays put");
+    assert!(
+        (1..8).contains(&stepped[1]) && (1..9).contains(&stepped[3]),
+        "expected both counters mid-flight, got {stepped:?}"
+    );
+
+    for _ in 0..200 {
+        tick(&app);
+        app.header_stats_advance([12, 0, 3, 9]);
+    }
+    assert_eq!(app.header_stats_advance([12, 0, 3, 9]), [12, 0, 3, 9]);
+    assert!(!app.header_stats_moving.get());
+}

--- a/src/app/tests/misc.rs
+++ b/src/app/tests/misc.rs
@@ -618,3 +618,71 @@ fn fold_replays_the_subtree_while_nav_rows_collapse_at_once() {
     app.fold_anim.as_mut().unwrap().at = std::time::Instant::now() - crate::tui::FOLD_ANIM;
     assert_eq!(hosts_shown(&app), 4);
 }
+
+/// A host whose ping class changes flashes on the way to its new colour (#35),
+/// while one seen for the first time is already settled.
+#[test]
+fn ping_class_change_flashes_the_status_dot() {
+    let mut app = test_app(vec![("a", host("a"))]);
+    let settled = crate::tui::theme::GREEN;
+
+    // Nothing known about the host yet: no flash to play.
+    assert_eq!(app.ping_flash_color("a", settled), settled);
+
+    // First samples arrive: the app opening is not a status change.
+    app.ping_data.insert("a".into(), vec![12]);
+    app.detect_ping_changes();
+    assert_eq!(app.ping_flash_color("a", settled), settled);
+
+    // The host goes unreachable: the dot flashes away from its class colour.
+    app.ping_data
+        .insert("a".into(), vec![crate::ping::PING_UNREACHABLE]);
+    app.detect_ping_changes();
+    let flashing = app.ping_flash_color("a", crate::tui::theme::RED);
+    assert_ne!(
+        flashing,
+        crate::tui::theme::RED,
+        "expected the dot mid-flash, not its resting colour"
+    );
+
+    // More samples of the same class don't restart it.
+    let at = app.ping_flash.get("a").unwrap().1;
+    app.ping_data
+        .insert("a".into(), vec![crate::ping::PING_UNREACHABLE; 2]);
+    app.detect_ping_changes();
+    assert_eq!(
+        app.ping_flash.get("a").unwrap().1,
+        at,
+        "flash not restarted"
+    );
+
+    // Once it has run its course the dot is back to its class colour.
+    app.ping_flash.insert(
+        "a".into(),
+        (
+            crate::ping::PingClass::Unreachable,
+            std::time::Instant::now() - crate::tui::PING_FLASH,
+        ),
+    );
+    assert_eq!(
+        app.ping_flash_color("a", crate::tui::theme::RED),
+        crate::tui::theme::RED
+    );
+}
+
+/// Reduced motion never flashes.
+#[test]
+fn ping_flash_is_off_under_reduced_motion() {
+    let mut app = test_app(vec![("a", host("a"))]);
+    app.config.appearance.disable_animation = true;
+    app.ping_data.insert("a".into(), vec![12]);
+    app.detect_ping_changes();
+    app.ping_flash.insert(
+        "a".into(),
+        (crate::ping::PingClass::Online, std::time::Instant::now()),
+    );
+    assert_eq!(
+        app.ping_flash_color("a", crate::tui::theme::GREEN),
+        crate::tui::theme::GREEN
+    );
+}

--- a/src/app/tests/misc.rs
+++ b/src/app/tests/misc.rs
@@ -546,3 +546,75 @@ fn host_scroll_snaps_under_reduced_motion() {
     assert_eq!(app.host_scroll_advance(body_h), target);
     assert!(!app.host_scroll_moving.get());
 }
+
+/// Folding a group (#35) keeps `nav_rows` authoritative -- the collapse
+/// applies at once -- while the visual rows replay a shrinking prefix of the
+/// subtree, so the list closes up a row at a time instead of jumping.
+#[test]
+fn fold_replays_the_subtree_while_nav_rows_collapse_at_once() {
+    let store = test_store();
+    let group = store
+        .create_group(&NewHostGroup {
+            name: "prod".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    for i in 0..4 {
+        store
+            .create_host(&NewHost {
+                name: format!("p{i}"),
+                address: format!("10.0.0.{i}"),
+                port: 22,
+                group_id: Some(group.id),
+                ..Default::default()
+            })
+            .unwrap();
+    }
+    let mut app = App::new_with_deps(
+        AppConfig::default(),
+        AppDeps {
+            resolver: Box::new(MockResolver::new(vec![])),
+            metadata: Arc::new(MetadataDb::default()),
+            store,
+            password_store: Box::new(crate::credentials::NoopPasswordStore),
+        },
+    );
+    app.reload_hosts().unwrap();
+    let hosts_shown = |app: &App| {
+        app.host_visual_rows()
+            .iter()
+            .filter(|r| matches!(r, VisualRow::Host { .. }))
+            .count()
+    };
+    assert_eq!(hosts_shown(&app), 4);
+
+    // Folding collapses the tree immediately...
+    app.toggle_group_by_section(0);
+    assert_eq!(app.nav_rows.len(), 1, "only the header is navigable");
+    // ...but the rows are still on screen, replayed from the captured subtree.
+    assert_eq!(
+        hosts_shown(&app),
+        4,
+        "full subtree at the start of the fold"
+    );
+
+    // Halfway through the (symmetric) reveal, half of them are left.
+    app.fold_anim.as_mut().unwrap().at = std::time::Instant::now() - crate::tui::FOLD_ANIM / 2;
+    let midway = hosts_shown(&app);
+    assert!(
+        (1..4).contains(&midway),
+        "expected a partial subtree, got {midway}"
+    );
+
+    // Once it has run its course nothing is replayed any more.
+    app.fold_anim.as_mut().unwrap().at = std::time::Instant::now() - crate::tui::FOLD_ANIM;
+    assert_eq!(hosts_shown(&app), 0);
+
+    // Unfolding is the mirror: the rows are live again and revealed over time.
+    app.detect_tab_switch();
+    app.toggle_group_by_section(0);
+    assert_eq!(app.nav_rows.len(), 5, "the subtree is navigable again");
+    assert_eq!(hosts_shown(&app), 0, "nothing revealed yet");
+    app.fold_anim.as_mut().unwrap().at = std::time::Instant::now() - crate::tui::FOLD_ANIM;
+    assert_eq!(hosts_shown(&app), 4);
+}

--- a/src/app/tests/sftp.rs
+++ b/src/app/tests/sftp.rs
@@ -192,7 +192,7 @@ fn server_to_server_transfer_relays_in_two_legs() {
 /// it can be retried rather than silently vanishing.
 #[test]
 fn failed_relay_leg_stops_and_keeps_the_item() {
-    use crate::sftp::model::{FileEntry, SftpState, Side};
+    use crate::sftp::model::{Direction, FileEntry, QueuedTransfer, SftpState, Side};
     use crate::sftp::SftpCommand;
 
     let mut app = test_app(vec![]);
@@ -228,4 +228,101 @@ fn failed_relay_leg_stops_and_keeps_the_item() {
         .notice
         .as_deref()
         .is_some_and(|n| n.contains("disk full")));
+}
+
+/// Regression: a worker finishes its run with a `QueueDone` even after an
+/// error. Acting on that used to restart the transfer that had just failed --
+/// which failed again, over and over, with the queue stuck on screen.
+#[test]
+fn failed_relay_is_not_restarted_by_the_trailing_completion() {
+    use crate::sftp::model::{FileEntry, SftpState, Side};
+    use crate::sftp::SftpCommand;
+
+    let mut app = test_app(vec![]);
+    let (tx_right, right) = std::sync::mpsc::channel::<SftpCommand>();
+    let (tx_left, _left) = std::sync::mpsc::channel::<SftpCommand>();
+    app.sftp_tx = Some(tx_right);
+    app.sftp_tx2 = Some(tx_left);
+
+    let mut state = SftpState::new("/srv", "/data");
+    state.left_host = Some("second-host".into());
+    state.remote.set_entries(vec![FileEntry {
+        name: "test2.py".into(),
+        is_dir: false,
+        size: 7,
+        is_symlink: false,
+        perm: None,
+    }]);
+    state.remote.selected = 1; // past the ".." row
+    app.sftp = Some(state);
+    app.sftp
+        .as_mut()
+        .unwrap()
+        .stage_toward(Side::Local)
+        .unwrap();
+    app.sftp_run_queue();
+    while right.try_recv().is_ok() {}
+
+    app.apply_sftp_event(crate::sftp::SftpEvent::Error("write error".into()));
+    app.apply_sftp_event(crate::sftp::SftpEvent::QueueDone);
+
+    assert!(app.sftp_relay.is_none(), "no fresh relay armed");
+    assert_eq!(
+        app.sftp.as_ref().unwrap().phase,
+        crate::sftp::model::Phase::Browsing,
+        "the browser settles instead of looking busy forever"
+    );
+    assert_eq!(
+        app.sftp.as_ref().unwrap().queue.len(),
+        1,
+        "the item stays for a manual retry"
+    );
+}
+
+/// A plain (non-relayed) run that reports an error stops there too, instead of
+/// rolling whatever is left into another pass that fails the same way.
+#[test]
+fn failed_run_does_not_dispatch_another_pass() {
+    use crate::sftp::model::{Direction, FileEntry, QueuedTransfer, SftpState, Side};
+    use crate::sftp::SftpCommand;
+
+    let mut app = test_app(vec![]);
+    let (tx, rx) = std::sync::mpsc::channel::<SftpCommand>();
+    app.sftp_tx = Some(tx);
+
+    let mut state = SftpState::new("/srv", "/data");
+    state.remote.set_entries(vec![FileEntry {
+        name: "a.bin".into(),
+        is_dir: false,
+        size: 1,
+        is_symlink: false,
+        perm: None,
+    }]);
+    state.remote.selected = 1; // past the ".." row
+    app.sftp = Some(state);
+    app.sftp
+        .as_mut()
+        .unwrap()
+        .stage_toward(Side::Local)
+        .unwrap();
+    app.sftp_run_queue();
+    assert!(rx.try_recv().is_ok(), "the run went out");
+
+    // Something is staged mid-run, then the run fails.
+    app.sftp.as_mut().unwrap().queue.push(QueuedTransfer {
+        direction: Direction::Download,
+        src: "/srv/b.bin".into(),
+        dst: "/data/b.bin".into(),
+        name: "b.bin".into(),
+        is_dir: false,
+    });
+    app.apply_sftp_event(crate::sftp::SftpEvent::Error("permission denied".into()));
+    app.apply_sftp_event(crate::sftp::SftpEvent::QueueDone);
+    // Re-listing after the failure is expected; a second RunQueue is not.
+    let dispatched_again =
+        std::iter::from_fn(|| rx.try_recv().ok()).any(|c| matches!(c, SftpCommand::RunQueue(_)));
+    assert!(
+        !dispatched_again,
+        "a failed run waits for the user rather than dispatching another pass"
+    );
 }

--- a/src/app/tests/sftp.rs
+++ b/src/app/tests/sftp.rs
@@ -106,3 +106,126 @@ fn sftp_directory_change_stamps_its_direction() {
     app.detect_sftp_navigation();
     assert!(app.sftp_nav.iter().all(|n| n.is_none()));
 }
+
+/// A transfer between two servers is relayed in two legs through a local temp
+/// file: the source worker pulls it down, the destination worker pushes it up,
+/// and only then does the item leave the queue.
+#[test]
+fn server_to_server_transfer_relays_in_two_legs() {
+    use crate::sftp::model::{Direction, FileEntry, SftpState, Side};
+    use crate::sftp::SftpCommand;
+    use std::path::PathBuf;
+
+    let mut app = test_app(vec![]);
+    let (tx_right, right) = std::sync::mpsc::channel::<SftpCommand>();
+    let (tx_left, left) = std::sync::mpsc::channel::<SftpCommand>();
+    app.sftp_tx = Some(tx_right);
+    app.sftp_tx2 = Some(tx_left);
+
+    let mut state = SftpState::new("/srv", "/data");
+    state.left_host = Some("second-host".into());
+    state.remote.set_entries(vec![FileEntry {
+        name: "dump.sql".into(),
+        is_dir: false,
+        size: 42,
+        is_symlink: false,
+        perm: None,
+    }]);
+    state.remote.selected = state
+        .remote
+        .entries
+        .iter()
+        .position(|e| e.name == "dump.sql")
+        .unwrap();
+    app.sftp = Some(state);
+
+    // Stage right-to-left and run: the first leg goes to the *source* worker
+    // as a download into scratch space.
+    app.sftp
+        .as_mut()
+        .unwrap()
+        .stage_toward(Side::Local)
+        .unwrap();
+    app.sftp_run_queue();
+    let relay = app.sftp_relay.as_ref().expect("relay armed");
+    assert_eq!(relay.leg, RelayLeg::Fetching);
+    let tmp = relay.tmp_dir.join("dump.sql");
+    match right
+        .try_recv()
+        .expect("fetch leg dispatched to the source")
+    {
+        SftpCommand::RunQueue(q) => {
+            assert_eq!(q[0].direction, Direction::Download);
+            assert_eq!(q[0].src, PathBuf::from("/srv/dump.sql"));
+            assert_eq!(q[0].dst, tmp, "fetched into scratch space");
+        }
+        _ => panic!("expected a queue run"),
+    }
+    assert!(left.try_recv().is_err(), "destination waits its turn");
+
+    // The fetch lands: the push goes to the destination worker, out of scratch
+    // space and into the left pane's directory.
+    app.apply_sftp_event(crate::sftp::SftpEvent::QueueDone);
+    assert_eq!(app.sftp_relay.as_ref().unwrap().leg, RelayLeg::Pushing);
+    match left
+        .try_recv()
+        .expect("push leg dispatched to the destination")
+    {
+        SftpCommand::RunQueue(q) => {
+            assert_eq!(q[0].direction, Direction::Upload);
+            assert_eq!(q[0].src, tmp);
+            assert_eq!(q[0].dst, PathBuf::from("/data/dump.sql"));
+        }
+        _ => panic!("expected a queue run"),
+    }
+
+    // The push lands: the item is done, the relay is over and the queue empty.
+    app.apply_sftp_event_left(crate::sftp::SftpEvent::QueueDone);
+    assert!(app.sftp_relay.is_none(), "relay finished");
+    let state = app.sftp.as_ref().unwrap();
+    assert!(state.queue.is_empty(), "the relayed item left the queue");
+    assert_eq!(state.phase, crate::sftp::model::Phase::Browsing);
+    assert!(!tmp.exists(), "scratch copy cleaned up");
+}
+
+/// A failure part-way through a relay stops it and leaves the item queued, so
+/// it can be retried rather than silently vanishing.
+#[test]
+fn failed_relay_leg_stops_and_keeps_the_item() {
+    use crate::sftp::model::{FileEntry, SftpState, Side};
+    use crate::sftp::SftpCommand;
+
+    let mut app = test_app(vec![]);
+    let (tx_right, _right) = std::sync::mpsc::channel::<SftpCommand>();
+    let (tx_left, _left) = std::sync::mpsc::channel::<SftpCommand>();
+    app.sftp_tx = Some(tx_right);
+    app.sftp_tx2 = Some(tx_left);
+
+    let mut state = SftpState::new("/srv", "/data");
+    state.left_host = Some("second-host".into());
+    state.remote.set_entries(vec![FileEntry {
+        name: "dump.sql".into(),
+        is_dir: false,
+        size: 42,
+        is_symlink: false,
+        perm: None,
+    }]);
+    state.remote.selected = 1; // past the ".." row
+    app.sftp = Some(state);
+    app.sftp
+        .as_mut()
+        .unwrap()
+        .stage_toward(Side::Local)
+        .unwrap();
+    app.sftp_run_queue();
+
+    app.apply_sftp_event(crate::sftp::SftpEvent::Error("disk full".into()));
+    assert!(app.sftp_relay.is_none(), "relay stopped");
+    let state = app.sftp.as_ref().unwrap();
+    assert_eq!(state.queue.len(), 1, "the item stays queued for a retry");
+    assert_eq!(state.phase, crate::sftp::model::Phase::Browsing);
+    assert!(state
+        .notice
+        .as_deref()
+        .is_some_and(|n| n.contains("disk full")));
+}

--- a/src/app/tests/sftp.rs
+++ b/src/app/tests/sftp.rs
@@ -30,3 +30,40 @@ pub(crate) fn sftp_picker_search_connects_to_filtered_host() {
 
     assert_eq!(app.sftp_host.as_deref(), Some("charlie"));
 }
+
+/// The SFTP progress bar sweeps toward the worker's chunked figure (#35),
+/// settles on it, and resets outright when the queue moves to the next file.
+#[test]
+fn sftp_progress_bar_chases_the_reported_figure() {
+    let app = test_app(vec![]);
+    let tick = |app: &App| {
+        app.sftp_progress_at.set(Some(
+            std::time::Instant::now() - std::time::Duration::from_millis(16),
+        ));
+    };
+
+    // First frame adopts the figure: the bar doesn't sweep in from empty.
+    assert_eq!(app.sftp_progress_advance(0.4), 0.4);
+    assert!(!app.sftp_progress_moving.get());
+
+    // A chunk lands: the bar closes on it over several frames.
+    tick(&app);
+    let stepped = app.sftp_progress_advance(0.9);
+    assert!(app.sftp_progress_moving.get());
+    assert!(
+        (0.4..0.9).contains(&stepped),
+        "expected a partial sweep, got {stepped}"
+    );
+    for _ in 0..200 {
+        tick(&app);
+        app.sftp_progress_advance(0.9);
+    }
+    assert_eq!(app.sftp_progress_advance(0.9), 0.9);
+    assert!(!app.sftp_progress_moving.get());
+
+    // The next (smaller) file reports less progress: snap back rather than
+    // sweeping backwards.
+    tick(&app);
+    assert_eq!(app.sftp_progress_advance(0.05), 0.05);
+    assert!(!app.sftp_progress_moving.get());
+}

--- a/src/app/tests/sftp.rs
+++ b/src/app/tests/sftp.rs
@@ -67,3 +67,42 @@ fn sftp_progress_bar_chases_the_reported_figure() {
     assert_eq!(app.sftp_progress_advance(0.05), 0.05);
     assert!(!app.sftp_progress_moving.get());
 }
+
+/// A pane changing directory is noticed centrally and stamped with the way it
+/// went (#35), whether the change came from the local filesystem or an async
+/// remote listing.
+#[test]
+fn sftp_directory_change_stamps_its_direction() {
+    use crate::sftp::model::SftpState;
+
+    let mut app = test_app(vec![]);
+    app.sftp = Some(SftpState::new("/srv", "/home/me"));
+
+    // The first listing of a session is not a navigation.
+    app.detect_sftp_navigation();
+    assert!(app.sftp_nav.iter().all(|n| n.is_none()));
+
+    // Descending into a child is stamped as going deeper.
+    app.sftp.as_mut().unwrap().local.cwd = "/home/me/work".into();
+    app.detect_sftp_navigation();
+    assert_eq!(app.sftp_nav[0].map(|(deeper, _)| deeper), Some(true));
+    assert!(app.sftp_nav[1].is_none(), "the other pane stays put");
+
+    // Stepping back out goes the other way.
+    app.sftp.as_mut().unwrap().local.cwd = "/home".into();
+    app.detect_sftp_navigation();
+    assert_eq!(app.sftp_nav[0].map(|(deeper, _)| deeper), Some(false));
+
+    // A remote listing landing later is stamped just the same.
+    app.sftp.as_mut().unwrap().remote.cwd = "/srv/www".into();
+    app.detect_sftp_navigation();
+    assert_eq!(app.sftp_nav[1].map(|(deeper, _)| deeper), Some(true));
+
+    // Disconnecting forgets the paths, so reconnecting isn't a navigation.
+    app.sftp = None;
+    app.detect_sftp_navigation();
+    assert!(app.sftp_nav.iter().all(|n| n.is_none()));
+    app.sftp = Some(SftpState::new("/srv", "/home/me"));
+    app.detect_sftp_navigation();
+    assert!(app.sftp_nav.iter().all(|n| n.is_none()));
+}

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -372,6 +372,16 @@ pub struct BroadcastState {
     pub audit_written: bool, // guard: log_auth_event fires once at completion
 }
 
+/// An in-flight tab-switch slide (#35): the body wipes between the `from` and
+/// `to` tabs. Direction is `to > from` (new slides in from the right) vs
+/// `to < from` (current slides out to the right, revealing the left tab).
+#[derive(Debug, Clone, Copy)]
+pub struct TabSwitch {
+    pub from: usize,
+    pub to: usize,
+    pub at: std::time::Instant,
+}
+
 /// A transient error popup (issue #3): one failed host's error text, slides in
 /// from the right above the broadcast panel and auto-expires. Geometry + slide
 /// progress are derived from `born` at render time (no stored anim state).

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -353,6 +353,9 @@ pub enum AppMode {
     BroadcastCommand,
     /// Broadcast wizard stage 3: target preview + [y]/[e]/[N] barrier.
     BroadcastPreview,
+    /// A modal message popup (e.g. a connection error). Any key dismisses it;
+    /// the text lives in `App::notice_popup`.
+    Notice,
 }
 
 /// Live background-run state; App holds `broadcast: Option<BroadcastState>`.

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -385,6 +385,26 @@ pub struct TabSwitch {
     pub at: std::time::Instant,
 }
 
+/// An in-flight group fold / unfold (#35): the group's subtree is revealed one
+/// row at a time on the way open and swallowed the same way on the way shut,
+/// so the rows below it get pushed rather than teleported.
+///
+/// The collapse itself applies immediately either way, so `nav_rows` stays the
+/// truth about what is visible and navigable. The animation is purely visual:
+/// an unfold reveals a growing prefix of the rows now in `nav_rows`, while a
+/// fold replays a shrinking prefix of `rows`, captured just before they went.
+#[derive(Debug, Clone)]
+pub struct FoldAnim {
+    /// [`HostGroupSection::key`] of the group being folded.
+    pub key: i64,
+    /// `true` while opening, `false` while shutting.
+    pub expanding: bool,
+    pub at: std::time::Instant,
+    /// Subtree rows as they looked before a fold, replayed on the way out.
+    /// Empty for an unfold, whose rows are live in `nav_rows`.
+    pub rows: Vec<VisualRow>,
+}
+
 /// An in-flight session-tab slide (#35): moving between embedded sessions
 /// carries the old tab off one edge while the new one follows it in. `dir` is
 /// `+1` for "next" and `-1` for "prev"; it cannot be derived from the tab

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -385,6 +385,23 @@ pub struct TabSwitch {
     pub at: std::time::Instant,
 }
 
+/// An in-flight SFTP tab sub-state slide (#35). The tab body swaps between the
+/// host picker, the "connecting…" placeholder and the dual-pane browser, and
+/// each swap moves in the direction it "came from": the placeholder rides in
+/// and out on the right edge, the two browser panes meet in the middle and part
+/// again toward their own edges.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SftpAnim {
+    /// Picker -> "connecting…": the placeholder enters from the right.
+    ConnectIn,
+    /// "connecting…" -> picker (failed / aborted handshake): it leaves right.
+    ConnectOut,
+    /// "connecting…" -> browser: the panes slide in from both edges.
+    PanesIn,
+    /// Browser -> picker: the panes part and slide off both edges.
+    PanesOut,
+}
+
 /// A transient error popup (issue #3): one failed host's error text, slides in
 /// from the right above the broadcast panel and auto-expires. Geometry + slide
 /// progress are derived from `born` at render time (no stored anim state).

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -385,6 +385,16 @@ pub struct TabSwitch {
     pub at: std::time::Instant,
 }
 
+/// An in-flight session-tab slide (#35): moving between embedded sessions
+/// carries the old tab off one edge while the new one follows it in. `dir` is
+/// `+1` for "next" and `-1` for "prev"; it cannot be derived from the tab
+/// indices, which wrap around at both ends of the strip.
+#[derive(Debug, Clone, Copy)]
+pub struct SessionTabSwitch {
+    pub dir: i8,
+    pub at: std::time::Instant,
+}
+
 /// An in-flight SFTP tab sub-state slide (#35). The tab body swaps between the
 /// host picker, the "connecting…" placeholder and the dual-pane browser, and
 /// each swap moves in the direction it "came from": the placeholder rides in

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -412,6 +412,9 @@ pub struct FoldAnim {
 #[derive(Debug, Clone, Copy)]
 pub struct SessionTabSwitch {
     pub dir: i8,
+    /// Index of the tab being left, so the header highlight can travel from it
+    /// to the new one instead of jumping.
+    pub from: usize,
     pub at: std::time::Instant,
 }
 

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1096,6 +1096,46 @@ pub struct SessionHostPicker {
     pub selected: usize,
     /// Mode to restore when the picker is dismissed without connecting.
     pub return_mode: AppMode,
+    /// What the picked host is for.
+    pub target: PickerTarget,
+}
+
+/// A server-to-server transfer in flight, relayed through a local temp file.
+///
+/// libssh2 has no server-to-server copy and the two panes are independent
+/// connections, so each item is moved in two legs: the source worker downloads
+/// it into a temp directory, then the destination worker uploads it from there.
+/// The temp copy is deleted as soon as the second leg lands.
+#[derive(Debug)]
+pub struct SftpRelay {
+    /// Items still to move, current one first.
+    pub items: std::collections::VecDeque<crate::sftp::model::QueuedTransfer>,
+    /// How many there were, for "relaying i/n".
+    pub total: usize,
+    /// Temp directory holding the item currently in flight.
+    pub tmp_dir: std::path::PathBuf,
+    /// Which leg is running.
+    pub leg: RelayLeg,
+}
+
+/// Which half of a relayed transfer is currently running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayLeg {
+    /// Source worker is pulling the item down into the temp directory.
+    Fetching,
+    /// Destination worker is pushing it back up from there.
+    Pushing,
+}
+
+/// What a host picked in the shared host picker is wanted for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PickerTarget {
+    /// Open a new embedded SSH session tab (Ctrl+T).
+    #[default]
+    NewSession,
+    /// Point the SFTP browser's left pane at a second server, so two remote
+    /// hosts can be browsed side by side.
+    SftpLeftPane,
 }
 
 /// Single-field path prompt for the Termius CSV import ([`AppMode::ImportPrompt`]).

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,9 @@ pub struct AppearanceConfig {
     pub show_detail_panel: bool,
     #[serde(default = "default_date_format")]
     pub date_format: String,
+    /// Reduced-motion toggle. When true, skip all UI motion (the startup
+    /// splash and every panel/toast slide + morph); surfaces jump straight to
+    /// their final state. Default off. Also flipped in Settings (`Ctrl+H`).
     #[serde(default)]
     pub disable_animation: bool,
     /// Ask for confirmation before quitting (q / Ctrl+C). Default true.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,9 @@ fn poll_keys_and_watcher(app: &mut App) -> Result<()> {
         }
     }
 
+    // Arm a tab-switch slide if the active tab changed this tick (#35).
+    app.detect_tab_switch();
+
     let mut config_changed = false;
     if let Some(rx) = app.watcher_rx.as_ref() {
         while rx.try_recv().is_ok() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,9 @@ fn run_terminal_loop(app: &mut App, auto_quit: Option<&str>) -> Result<()> {
         run_animation(&mut terminal)?;
     }
 
+    // The dashboard fades up from here, over the intro animation it replaces.
+    app.dashboard_at = Some(std::time::Instant::now());
+
     let mut last_size: Option<(u16, u16)> = None;
     loop {
         let sz = terminal.size()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,6 +351,17 @@ fn poll_keys_and_watcher(app: &mut App) -> Result<()> {
         }
     }
 
+    // Drain the left pane's worker, when it is browsing a second server.
+    if app.sftp_rx2.is_some() {
+        let events: Vec<crate::sftp::SftpEvent> = {
+            let rx = app.sftp_rx2.as_ref().unwrap();
+            std::iter::from_fn(|| rx.try_recv().ok()).collect()
+        };
+        for ev in events {
+            app.apply_sftp_event_left(ev);
+        }
+    }
+
     // Drain SSH probe log entries from background worker
     if let Some(rx) = app.probe_rx.as_ref() {
         let entries: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,9 +301,6 @@ fn poll_keys_and_watcher(app: &mut App) -> Result<()> {
         }
     }
 
-    // Arm a tab-switch slide if the active tab changed this tick (#35).
-    app.detect_tab_switch();
-
     let mut config_changed = false;
     if let Some(rx) = app.watcher_rx.as_ref() {
         while rx.try_recv().is_ok() {
@@ -383,6 +380,13 @@ fn poll_keys_and_watcher(app: &mut App) -> Result<()> {
 
     // Refresh auth events cache periodically
     app.refresh_auth_cache();
+
+    // Arm tab-switch / popup slides for ANY mode or tab change this tick (#35).
+    // Must run AFTER the background event drains (SFTP / OS-detect / broadcast),
+    // not just after key handling: a mode change from e.g. an SFTP ConnectFailed
+    // event must stamp `mode_entered_at` in the same tick, or the next frame
+    // renders the popup at rest (a center flash) before the open slide starts.
+    app.detect_tab_switch();
 
     Ok(())
 }

--- a/src/session/render.rs
+++ b/src/session/render.rs
@@ -19,6 +19,19 @@ use crate::config::{KeyAction, KeybindsConfig};
 use crate::session::{Session, SessionMeta, SessionPhase};
 use crate::tui::theme;
 
+/// The PTY body's rect: everything between the one-row header and the one-row
+/// footer. Exposed so the tab-switch slide can move the body alone and leave
+/// the header fixed (#35) -- sliding the whole screen, chrome included, made
+/// switching tabs unpleasant to look at.
+pub fn body_rect(area: Rect) -> Rect {
+    Rect::new(
+        area.x,
+        area.y.saturating_add(1),
+        area.width,
+        area.height.saturating_sub(2),
+    )
+}
+
 pub fn render(frame: &mut Frame, app: &App) {
     let Some(session) = app.active_session() else {
         return;
@@ -77,17 +90,29 @@ fn render_header(frame: &mut Frame, area: Rect, session: &Session, app: &App) {
         Span::raw("  "),
     ];
 
+    // Column each tab's label starts at, filled while the strip is built, so
+    // the highlight can travel between them (#35).
+    let mut tab_spans: Vec<(u16, u16)> = Vec::new();
+    let travel = highlight_travel(app);
     if app.sessions.len() > 1 {
         // Multi-tab header: compact tab strip in place of the verbose
         // connection summary. Active tab is reversed; others are mute.
         let active_idx = app.active_session.unwrap_or(0);
+        // The highlight is painted afterwards, over the interpolated rect, so
+        // every label goes down mute here and the moving bar decides which one
+        // reads as active.
+        let mut col: u16 = area.x + spans.iter().map(span_cols).sum::<u16>();
         for (i, s) in app.sessions.iter().enumerate() {
             let label = format!(" {} {} ", i + 1, s.display_name);
-            if i == active_idx {
-                spans.push(Span::styled(label, theme::inv()));
+            let w = label.chars().count() as u16;
+            tab_spans.push((col, w));
+            col += w + 1;
+            let style = if i == active_idx && travel.is_none() {
+                theme::inv()
             } else {
-                spans.push(Span::styled(label, theme::mute()));
-            }
+                theme::mute()
+            };
+            spans.push(Span::styled(label, style));
             spans.push(Span::raw(" "));
         }
     } else {
@@ -137,6 +162,47 @@ fn render_header(frame: &mut Frame, area: Rect, session: &Session, app: &App) {
     spans.push(Span::styled(hint_text, theme::mute()));
 
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
+
+    // Slide the active-tab highlight from the tab being left to the new one, so
+    // the strip stays put and only the bar under it moves (#35).
+    if let Some(p) = travel {
+        let from = app
+            .session_tab_switch
+            .map(|sw| sw.from.min(tab_spans.len().saturating_sub(1)))
+            .unwrap_or(0);
+        let to = app.active_session.unwrap_or(0);
+        if let (Some(&(fx, fw)), Some(&(tx, tw))) = (tab_spans.get(from), tab_spans.get(to)) {
+            let e = crate::tui::tween::ease_in_out(p);
+            let x = lerp_u16(fx, tx, e);
+            let w = lerp_u16(fw, tw, e);
+            let buf = frame.buffer_mut();
+            for cx in x..x.saturating_add(w).min(area.x + area.width) {
+                if let Some(cell) = buf.cell_mut((cx, area.y)) {
+                    cell.set_style(theme::inv());
+                }
+            }
+        }
+    }
+}
+
+/// Progress of the tab-highlight travel, or `None` when it is at rest (which
+/// is also when the active label paints itself highlighted).
+fn highlight_travel(app: &App) -> Option<f32> {
+    if !app.motion_enabled() {
+        return None;
+    }
+    let sw = app.session_tab_switch?;
+    let p = crate::tui::tween::progress(sw.at, crate::tui::TAB_ANIM, std::time::Instant::now());
+    (p < 1.0).then_some(p)
+}
+
+/// Display columns a span occupies.
+fn span_cols(span: &Span<'static>) -> u16 {
+    span.content.chars().count() as u16
+}
+
+fn lerp_u16(a: u16, b: u16, t: f32) -> u16 {
+    (a as f32 + (b as f32 - a as f32) * t).round().max(0.0) as u16
 }
 
 fn connection_label(meta: &SessionMeta, display_name: &str) -> String {

--- a/src/session/render.rs
+++ b/src/session/render.rs
@@ -332,9 +332,6 @@ fn render_full_debug_log(frame: &mut Frame, area: Rect, session: &Session) {
     frame.render_widget(Paragraph::new(lines).scroll((scroll, 0)), area);
 }
 
-/// Braille spinner frames, advanced by wall-clock so it animates while idle.
-const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-
 fn render_connecting(
     frame: &mut Frame,
     area: Rect,
@@ -354,7 +351,6 @@ fn render_connecting(
         return;
     }
 
-    let frame_idx = (elapsed.as_millis() / 90) as usize % SPINNER_FRAMES.len();
     let host = session
         .meta
         .address
@@ -372,7 +368,10 @@ fn render_connecting(
     }
     let center = vec![
         Line::from(vec![
-            Span::styled(SPINNER_FRAMES[frame_idx], Style::default().fg(theme::GREEN)),
+            Span::styled(
+                crate::tui::tween::spinner_frame(elapsed),
+                Style::default().fg(theme::GREEN),
+            ),
             Span::raw("  "),
             Span::styled("connecting to ", mute),
             Span::styled(host, Style::default().fg(theme::TEXT)),

--- a/src/sftp/model.rs
+++ b/src/sftp/model.rs
@@ -177,6 +177,9 @@ pub struct SftpState {
     pub progress: Option<Progress>,
     pub notice: Option<String>,
     pub searching: bool,
+    /// True from connect until the worker reports `Connected`, so the UI shows a
+    /// "connecting…" state (the picker) instead of an empty browser.
+    pub connecting: bool,
 }
 
 impl SftpState {
@@ -191,6 +194,7 @@ impl SftpState {
             progress: None,
             notice: None,
             searching: false,
+            connecting: false,
         }
     }
 

--- a/src/sftp/model.rs
+++ b/src/sftp/model.rs
@@ -344,6 +344,26 @@ impl SftpState {
         Some((self.focused_side(), parent))
     }
 
+    /// Stage the **focused pane's** selection for transfer toward `target`.
+    ///
+    /// The arrow keys point at the destination pane (left = local, right =
+    /// remote) and the source is always what the cursor is on. Staging used to
+    /// read the remote pane whichever side was focused, so pressing ← while
+    /// browsing locally queued whatever the remote cursor happened to sit on --
+    /// and queued it again after each local `cd`, since the destination path
+    /// had changed and the duplicate guard compares both ends.
+    pub fn stage_toward(&mut self, target: Side) -> Result<(), String> {
+        if self.focused_side() == target {
+            let msg = "that pane is the destination — Tab to pick a source".to_string();
+            self.notice = Some(msg.clone());
+            return Err(msg);
+        }
+        match target {
+            Side::Local => self.stage_download(),
+            Side::Remote => self.stage_upload(),
+        }
+    }
+
     /// Stage the focused-remote selection for download into `local.cwd`.
     /// Directories are staged too and transferred recursively by the worker.
     pub fn stage_download(&mut self) -> Result<(), String> {
@@ -614,6 +634,45 @@ mod tests {
         assert!(s.stage_upload().is_ok());
         assert_eq!(s.queue.len(), 1);
         assert!(s.queue[0].is_dir);
+    }
+
+    #[test]
+    fn stage_toward_takes_the_source_from_the_focused_pane() {
+        let mut s = state_with_entries();
+        // Focused remote, arrow points left: download, as before.
+        s.remote.selected = row(&s.remote, "a.txt");
+        assert!(s.stage_toward(Side::Local).is_ok());
+        assert_eq!(s.queue.len(), 1);
+        assert_eq!(s.queue[0].direction, Direction::Download);
+
+        // Focused remote, arrow points right: that pane is where the cursor
+        // already is, so nothing is staged.
+        assert!(s.stage_toward(Side::Remote).is_err());
+        assert_eq!(s.queue.len(), 1);
+        assert!(s.notice.is_some());
+
+        // Focused local, arrow points right: upload.
+        s.toggle_focus();
+        s.local.selected = row(&s.local, "b.bin");
+        assert!(s.stage_toward(Side::Remote).is_ok());
+        assert_eq!(s.queue[1].direction, Direction::Upload);
+    }
+
+    /// Regression: pressing ← while browsing locally used to queue the remote
+    /// cursor's entry, and re-queue it after every local `cd`, because the
+    /// duplicate guard compares src *and* dst and the dst had moved.
+    #[test]
+    fn browsing_locally_never_queues_the_remote_cursor() {
+        let mut s = state_with_entries();
+        s.toggle_focus(); // Local
+        assert!(s.stage_toward(Side::Local).is_err());
+        assert!(s.queue.is_empty());
+
+        // ...including after walking into another local directory.
+        s.local.cwd = PathBuf::from("/home/me/work");
+        s.local.set_entries(Vec::new());
+        assert!(s.stage_toward(Side::Local).is_err());
+        assert!(s.queue.is_empty());
     }
 
     #[test]

--- a/src/sftp/model.rs
+++ b/src/sftp/model.rs
@@ -7,6 +7,34 @@
 
 use std::path::PathBuf;
 
+/// Name of the synthetic row that walks a pane up to its parent directory.
+pub const PARENT_ROW: &str = "..";
+
+/// The directory one level up from `path`, or `None` at the root.
+///
+/// `Path::parent` alone is wrong for the relative paths the remote pane starts
+/// on: the server resolves the login directory from `"."`, whose `parent()` is
+/// the empty path -- a listing request the server rejects, which is why walking
+/// up from a fresh remote pane did nothing at all. Relative paths therefore
+/// grow a `..` component instead of losing their last one.
+pub fn parent_of(path: &std::path::Path) -> Option<PathBuf> {
+    let last = path.components().next_back();
+    // Already climbing (".", "..", "a/.."): another `..` is the only way up.
+    if matches!(
+        last,
+        Some(std::path::Component::CurDir) | Some(std::path::Component::ParentDir)
+    ) {
+        return Some(path.join(PARENT_ROW));
+    }
+    match path.parent() {
+        // A bare name ("work") sits in the pane's own directory.
+        Some(p) if p.as_os_str().is_empty() => Some(PathBuf::from(".")),
+        Some(p) => Some(p.to_path_buf()),
+        // Filesystem root: nowhere left to go.
+        None => None,
+    }
+}
+
 /// Which of the two panes a path/entry belongs to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Side {
@@ -46,6 +74,26 @@ pub struct QueuedTransfer {
     pub name: String,
     /// Whether `src` is a directory — the worker transfers it recursively.
     pub is_dir: bool,
+}
+
+impl FileEntry {
+    /// The synthetic ".." row. Enterable, but never a transfer or file-op
+    /// target -- see [`FileEntry::is_parent`].
+    pub fn parent_row() -> Self {
+        Self {
+            name: PARENT_ROW.to_string(),
+            is_dir: true,
+            size: 0,
+            is_symlink: false,
+            perm: None,
+        }
+    }
+
+    /// Whether this is the synthetic parent row rather than a real listing
+    /// entry. No real file can be named `..`, so the name is enough.
+    pub fn is_parent(&self) -> bool {
+        self.name == PARENT_ROW
+    }
 }
 
 /// One browsable directory column (remote or local).
@@ -112,8 +160,15 @@ impl Pane {
     }
 
     /// Replace the listing and clamp the cursor to the new bounds.
+    ///
+    /// Prepends the synthetic [`PARENT_ROW`] unless the pane is at the root, so
+    /// walking up is a visible row you can select rather than a keybind you
+    /// have to know about.
     pub fn set_entries(&mut self, entries: Vec<FileEntry>) {
         self.entries = entries;
+        if parent_of(&self.cwd).is_some() {
+            self.entries.insert(0, FileEntry::parent_row());
+        }
         self.filter = String::new();
         self.clamp_selection();
     }
@@ -273,6 +328,9 @@ impl SftpState {
     pub fn enter_dir(&self) -> Option<(Side, PathBuf)> {
         let pane = self.focused_pane();
         let entry = pane.selected_entry()?;
+        if entry.is_parent() {
+            return self.parent_dir();
+        }
         if !entry.is_dir {
             return None;
         }
@@ -282,9 +340,8 @@ impl SftpState {
     /// Compute the parent path of the focused pane's cwd. Returns
     /// `(Side, parent)` or `None` when already at the root. Pure PathBuf math.
     pub fn parent_dir(&self) -> Option<(Side, PathBuf)> {
-        let pane = self.focused_pane();
-        let parent = pane.cwd.parent()?;
-        Some((self.focused_side(), parent.to_path_buf()))
+        let parent = parent_of(&self.focused_pane().cwd)?;
+        Some((self.focused_side(), parent))
     }
 
     /// Stage the focused-remote selection for download into `local.cwd`.
@@ -295,6 +352,9 @@ impl SftpState {
             .selected_entry()
             .cloned()
             .ok_or_else(|| "nothing selected".to_string())?;
+        if entry.is_parent() {
+            return Err("that row just walks up a directory".to_string());
+        }
         let src = self.remote.cwd.join(&entry.name);
         let dst = self.local.cwd.join(&entry.name);
         if self.queue.iter().any(|q| q.src == src && q.dst == dst) {
@@ -320,6 +380,9 @@ impl SftpState {
             .selected_entry()
             .cloned()
             .ok_or_else(|| "nothing selected".to_string())?;
+        if entry.is_parent() {
+            return Err("that row just walks up a directory".to_string());
+        }
         let src = self.local.cwd.join(&entry.name);
         let dst = self.remote.cwd.join(&entry.name);
         if self.queue.iter().any(|q| q.src == src && q.dst == dst) {
@@ -348,6 +411,15 @@ impl SftpState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Index of the row named `name` in `pane`, so tests address rows by name
+    /// and stay honest about the synthetic ".." row sitting at index 0.
+    fn row(pane: &Pane, name: &str) -> usize {
+        pane.entries
+            .iter()
+            .position(|e| e.name == name)
+            .unwrap_or_else(|| panic!("no row named {name}"))
+    }
 
     fn state_with_entries() -> SftpState {
         let mut s = SftpState::new("/srv", "/home/me");
@@ -400,12 +472,13 @@ mod tests {
     #[test]
     fn move_selection_clamps() {
         let mut s = state_with_entries();
+        // "..", "docs", "a.txt"
         s.move_selection(-5);
         assert_eq!(s.remote.selected, 0);
         s.move_selection(1);
         assert_eq!(s.remote.selected, 1);
         s.move_selection(10);
-        assert_eq!(s.remote.selected, 1); // clamped to len-1
+        assert_eq!(s.remote.selected, 2); // clamped to len-1
     }
 
     #[test]
@@ -428,20 +501,62 @@ mod tests {
     #[test]
     fn enter_dir_only_for_directories() {
         let mut s = state_with_entries();
-        // selected 0 = "docs" (dir)
+        s.remote.selected = row(&s.remote, "docs");
         assert_eq!(
             s.enter_dir(),
             Some((Side::Remote, PathBuf::from("/srv/docs")))
         );
-        // selected 1 = "a.txt" (file) → None
-        s.remote.selected = 1;
+        // A file isn't enterable.
+        s.remote.selected = row(&s.remote, "a.txt");
         assert_eq!(s.enter_dir(), None);
+    }
+
+    #[test]
+    fn parent_row_leads_the_listing_and_walks_up() {
+        let mut s = state_with_entries();
+        assert_eq!(s.remote.entries[0].name, PARENT_ROW, "\"..\" comes first");
+        assert!(s.remote.entries[0].is_parent());
+        // Selecting it and entering walks up, rather than into "/srv/..".
+        s.remote.selected = 0;
+        assert_eq!(s.enter_dir(), Some((Side::Remote, PathBuf::from("/"))));
+        // It is never a transfer target.
+        assert!(s.stage_download().is_err());
+        assert!(s.queue.is_empty());
+    }
+
+    #[test]
+    fn parent_row_absent_at_the_root() {
+        let mut s = SftpState::new("/", "/");
+        s.remote.set_entries(vec![FileEntry {
+            name: "etc".into(),
+            is_dir: true,
+            size: 0,
+            is_symlink: false,
+            perm: None,
+        }]);
+        assert_eq!(s.remote.entries[0].name, "etc", "nowhere to walk up to");
+    }
+
+    #[test]
+    fn parent_of_climbs_relative_paths() {
+        use std::path::Path;
+        // The remote pane starts on ".", whose `parent()` is the empty path;
+        // walking up has to grow a "..", not produce an unlistable path.
+        assert_eq!(parent_of(Path::new(".")), Some(PathBuf::from("./..")));
+        assert_eq!(parent_of(Path::new("..")), Some(PathBuf::from("../..")));
+        assert_eq!(parent_of(Path::new("work")), Some(PathBuf::from(".")));
+        assert_eq!(
+            parent_of(Path::new("/srv/www")),
+            Some(PathBuf::from("/srv"))
+        );
+        assert_eq!(parent_of(Path::new("/")), None);
     }
 
     #[test]
     fn enter_dir_respects_focus() {
         let mut s = state_with_entries();
-        s.toggle_focus(); // now Local, selected 0 = "photos"
+        s.toggle_focus(); // now Local
+        s.local.selected = row(&s.local, "photos");
         assert_eq!(
             s.enter_dir(),
             Some((Side::Local, PathBuf::from("/home/me/photos")))
@@ -459,7 +574,7 @@ mod tests {
     #[test]
     fn stage_download_file() {
         let mut s = state_with_entries();
-        s.remote.selected = 1; // a.txt
+        s.remote.selected = row(&s.remote, "a.txt");
         assert!(s.stage_download().is_ok());
         assert_eq!(s.queue.len(), 1);
         let q = &s.queue[0];
@@ -472,7 +587,7 @@ mod tests {
     #[test]
     fn stage_download_directory_is_queued_recursively() {
         let mut s = state_with_entries();
-        s.remote.selected = 0; // docs (dir)
+        s.remote.selected = row(&s.remote, "docs");
         assert!(s.stage_download().is_ok());
         assert_eq!(s.queue.len(), 1);
         let q = &s.queue[0];
@@ -484,7 +599,7 @@ mod tests {
     #[test]
     fn stage_upload_file() {
         let mut s = state_with_entries();
-        s.local.selected = 1; // b.bin
+        s.local.selected = row(&s.local, "b.bin");
         assert!(s.stage_upload().is_ok());
         let q = &s.queue[0];
         assert_eq!(q.direction, Direction::Upload);
@@ -495,7 +610,7 @@ mod tests {
     #[test]
     fn stage_upload_directory_is_queued_recursively() {
         let mut s = state_with_entries();
-        s.local.selected = 0; // photos (dir)
+        s.local.selected = row(&s.local, "photos");
         assert!(s.stage_upload().is_ok());
         assert_eq!(s.queue.len(), 1);
         assert!(s.queue[0].is_dir);
@@ -504,9 +619,9 @@ mod tests {
     #[test]
     fn unstage_removes() {
         let mut s = state_with_entries();
-        s.remote.selected = 1; // a.txt → download
+        s.remote.selected = row(&s.remote, "a.txt"); // download
         s.stage_download().unwrap();
-        s.local.selected = 1; // b.bin → upload
+        s.local.selected = row(&s.local, "b.bin"); // upload
         s.stage_upload().unwrap();
         assert_eq!(s.queue.len(), 2);
         s.unstage(0);
@@ -518,7 +633,7 @@ mod tests {
     #[test]
     fn staging_same_file_twice_is_deduped() {
         let mut s = state_with_entries();
-        s.remote.selected = 1; // a.txt
+        s.remote.selected = row(&s.remote, "a.txt");
         s.stage_download().unwrap();
         // Second identical stage is rejected (no duplicate queue entry).
         assert!(s.stage_download().is_err());
@@ -547,7 +662,7 @@ mod tests {
         // Downloads always land in local.cwd even when focus is on Local.
         let mut s = state_with_entries();
         s.toggle_focus(); // focus Local, but stage_download reads the remote pane
-        s.remote.selected = 1; // a.txt
+        s.remote.selected = row(&s.remote, "a.txt");
         s.stage_download().unwrap();
         assert_eq!(s.queue[0].src, PathBuf::from("/srv/a.txt"));
         assert_eq!(s.queue[0].dst, PathBuf::from("/home/me/a.txt"));
@@ -592,7 +707,8 @@ mod tests {
             perm: None,
         }]);
         assert!(s.remote.filter.is_empty());
-        assert_eq!(s.remote.visible_len(), 1);
+        // The new row, plus the ".." the pane grows below the root.
+        assert_eq!(s.remote.visible_len(), 2);
     }
 
     #[test]
@@ -607,7 +723,7 @@ mod tests {
     #[test]
     fn set_entries_clamps_selection() {
         let mut s = state_with_entries();
-        s.remote.selected = 1;
+        s.remote.selected = 5;
         s.remote.set_entries(vec![FileEntry {
             name: "only".into(),
             is_dir: false,
@@ -615,6 +731,7 @@ mod tests {
             is_symlink: false,
             perm: None,
         }]);
-        assert_eq!(s.remote.selected, 0);
+        // Clamped to the last row of the new listing ("..", "only").
+        assert_eq!(s.remote.selected, 1);
     }
 }

--- a/src/sftp/model.rs
+++ b/src/sftp/model.rs
@@ -36,6 +36,11 @@ pub fn parent_of(path: &std::path::Path) -> Option<PathBuf> {
 }
 
 /// Which of the two panes a path/entry belongs to.
+///
+/// `Remote` is the right-hand pane, always a server. `Local` is the left-hand
+/// one, which is the local filesystem by default but can be pointed at a
+/// second server ([`SftpState::left_host`]) -- the name is kept for its default
+/// and because the worker protocol is written in these terms.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Side {
     Remote,
@@ -235,6 +240,11 @@ pub struct SftpState {
     /// True from connect until the worker reports `Connected`, so the UI shows a
     /// "connecting…" state (the picker) instead of an empty browser.
     pub connecting: bool,
+    /// Name of the second server the left pane is browsing, or `None` when it
+    /// is showing the local filesystem.
+    pub left_host: Option<String>,
+    /// True from connecting the left pane's server until it reports `Connected`.
+    pub left_connecting: bool,
     /// The transfers handed to the worker for the run in flight. The queue can
     /// be added to while it runs, so completion clears exactly this snapshot
     /// rather than everything staged.
@@ -254,6 +264,8 @@ impl SftpState {
             notice: None,
             searching: false,
             connecting: false,
+            left_host: None,
+            left_connecting: false,
             running: Vec::new(),
         }
     }
@@ -423,6 +435,12 @@ impl SftpState {
             is_dir: entry.is_dir,
         });
         Ok(())
+    }
+
+    /// Whether the left pane is browsing a second server rather than the local
+    /// filesystem, which decides where its listings and file ops are sent.
+    pub fn left_is_remote(&self) -> bool {
+        self.left_host.is_some()
     }
 
     /// Take the transfers just finished out of the queue, leaving anything

--- a/src/sftp/model.rs
+++ b/src/sftp/model.rs
@@ -235,6 +235,10 @@ pub struct SftpState {
     /// True from connect until the worker reports `Connected`, so the UI shows a
     /// "connecting…" state (the picker) instead of an empty browser.
     pub connecting: bool,
+    /// The transfers handed to the worker for the run in flight. The queue can
+    /// be added to while it runs, so completion clears exactly this snapshot
+    /// rather than everything staged.
+    pub running: Vec<QueuedTransfer>,
 }
 
 impl SftpState {
@@ -250,6 +254,7 @@ impl SftpState {
             notice: None,
             searching: false,
             connecting: false,
+            running: Vec::new(),
         }
     }
 
@@ -418,6 +423,14 @@ impl SftpState {
             is_dir: entry.is_dir,
         });
         Ok(())
+    }
+
+    /// Take the transfers just finished out of the queue, leaving anything
+    /// staged while the run was in flight. Returns whether work is left.
+    pub fn finish_run(&mut self) -> bool {
+        let done = std::mem::take(&mut self.running);
+        self.queue.retain(|q| !done.contains(q));
+        !self.queue.is_empty()
     }
 
     /// Remove the queued transfer at `idx` (no-op if out of range).
@@ -672,6 +685,33 @@ mod tests {
         s.local.cwd = PathBuf::from("/home/me/work");
         s.local.set_entries(Vec::new());
         assert!(s.stage_toward(Side::Local).is_err());
+        assert!(s.queue.is_empty());
+    }
+
+    #[test]
+    fn finishing_a_run_keeps_what_was_staged_meanwhile() {
+        let mut s = state_with_entries();
+        s.remote.selected = row(&s.remote, "a.txt");
+        s.stage_download().unwrap();
+        // The run goes out with what is queued right now.
+        s.running = s.queue.clone();
+        s.phase = Phase::Running;
+
+        // More work is staged while it runs.
+        s.remote.selected = row(&s.remote, "docs");
+        s.stage_download().unwrap();
+        assert_eq!(s.queue.len(), 2);
+
+        // Completion clears only the snapshot that ran, and reports that there
+        // is more to do.
+        assert!(s.finish_run(), "the mid-run entry is still pending");
+        assert_eq!(s.queue.len(), 1);
+        assert_eq!(s.queue[0].name, "docs");
+        assert!(s.running.is_empty());
+
+        // A run with nothing staged behind it reports itself as the last one.
+        s.running = s.queue.clone();
+        assert!(!s.finish_run());
         assert!(s.queue.is_empty());
     }
 

--- a/src/sftp/transport.rs
+++ b/src/sftp/transport.rs
@@ -7,8 +7,9 @@
 //! unknown key is recorded and accepted, only a *changed* key is refused.
 
 use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::net::{TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use ssh2::{CheckResult, KnownHostFileKind, KnownHostKeyFormat, Session};
@@ -257,7 +258,14 @@ impl SftpTransport for Ssh2Transport {
         }
 
         let (host, port) = self.address();
-        let tcp = TcpStream::connect((host.as_str(), port))
+        // Resolve + connect with a timeout so an unreachable host fails fast: a
+        // bare TcpStream::connect can hang for a minute+ on a firewalled address.
+        let addr = (host.as_str(), port)
+            .to_socket_addrs()
+            .with_context(|| format!("could not resolve {host}:{port}"))?
+            .next()
+            .ok_or_else(|| anyhow!("no address found for {host}:{port}"))?;
+        let tcp = TcpStream::connect_timeout(&addr, Duration::from_secs(8))
             .with_context(|| format!("could not connect to {host}:{port}"))?;
 
         let mut session = Session::new().context("failed to create SSH session")?;

--- a/src/tui/blit.rs
+++ b/src/tui/blit.rs
@@ -1,0 +1,126 @@
+//! Cell-level buffer blitting, the shared primitive behind every slide (#35).
+//!
+//! A slide draws its layer at rest into a standalone [`Buffer`], then copies
+//! those cells into the frame at an eased offset. Going through cells (instead
+//! of shifting the `Rect` a renderer draws into) lets a layer travel past the
+//! edge of the screen, which a `Rect` cannot express, and keeps every renderer
+//! free of animation concerns.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+
+/// Copy the `region` cells of `src` into `dst` offset by (`dx`, `dy`), dropping
+/// whatever lands outside `clip`.
+///
+/// `src` must be a standalone buffer (never `dst` itself), so the copy order
+/// doesn't matter and a cell can't be read after it was overwritten.
+pub fn blit(dst: &mut Buffer, region: Rect, clip: Rect, src: &Buffer, dx: i32, dy: i32) {
+    for y in region.top()..region.bottom() {
+        let ty = y as i32 + dy;
+        if ty < clip.top() as i32 || ty >= clip.bottom() as i32 {
+            continue;
+        }
+        for x in region.left()..region.right() {
+            let tx = x as i32 + dx;
+            if tx < clip.left() as i32 || tx >= clip.right() as i32 {
+                continue;
+            }
+            if let (Some(s), Some(d)) = (src.cell((x, y)), dst.cell_mut((tx as u16, ty as u16))) {
+                *d = s.clone();
+            }
+        }
+    }
+}
+
+/// Clone the `area` cells of `src` into a standalone buffer keeping the same
+/// absolute coordinates, so a later frame can blit them while sliding.
+pub fn snapshot(src: &Buffer, area: Rect) -> Buffer {
+    let mut out = Buffer::empty(area);
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            if let (Some(s), Some(d)) = (src.cell((x, y)), out.cell_mut((x, y))) {
+                *d = s.clone();
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn area() -> Rect {
+        Rect::new(2, 1, 8, 3)
+    }
+
+    /// A source buffer whose every cell carries its own column as a symbol, so
+    /// an offset is readable straight off the destination row.
+    fn ruler(area: Rect) -> Buffer {
+        let mut b = Buffer::empty(area);
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                b.cell_mut((x, y))
+                    .unwrap()
+                    .set_symbol(&format!("{}", x % 10));
+            }
+        }
+        b
+    }
+
+    fn row(buf: &Buffer, area: Rect, y: u16) -> String {
+        (area.left()..area.right())
+            .map(|x| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn blit_moves_cells_horizontally_and_clips_both_edges() {
+        let a = area();
+        let src = ruler(a);
+        let mut dst = Buffer::empty(a);
+        blit(&mut dst, a, a, &src, 3, 0);
+        // The three leftmost columns were vacated (nothing slid in from off
+        // screen) and the three rightmost source columns fell off the clip.
+        assert_eq!(row(&dst, a, 1), "   23456");
+    }
+
+    #[test]
+    fn blit_moves_cells_vertically() {
+        let a = area();
+        let src = ruler(a);
+        let mut dst = Buffer::empty(a);
+        blit(&mut dst, a, a, &src, 0, 1);
+        // Row 1 is vacated, rows 2..4 carry what rows 1..3 held.
+        assert_eq!(row(&dst, a, 1), " ".repeat(a.width as usize));
+        assert_eq!(row(&dst, a, 2), row(&src, a, 1));
+    }
+
+    #[test]
+    fn blit_with_no_offset_is_a_plain_copy() {
+        let a = area();
+        let src = ruler(a);
+        let mut dst = Buffer::empty(a);
+        blit(&mut dst, a, a, &src, 0, 0);
+        assert_eq!(row(&dst, a, 1), row(&src, a, 1));
+    }
+
+    #[test]
+    fn blit_past_the_clip_writes_nothing() {
+        let a = area();
+        let src = ruler(a);
+        let mut dst = Buffer::empty(a);
+        blit(&mut dst, a, a, &src, a.width as i32, 0);
+        assert_eq!(row(&dst, a, 1), " ".repeat(a.width as usize));
+    }
+
+    #[test]
+    fn snapshot_copies_the_area_verbatim() {
+        let a = area();
+        let src = ruler(a);
+        let snap = snapshot(&src, a);
+        for y in a.top()..a.bottom() {
+            assert_eq!(row(&snap, a, y), row(&src, a, y));
+        }
+    }
+}

--- a/src/tui/blit.rs
+++ b/src/tui/blit.rs
@@ -1,4 +1,5 @@
-//! Cell-level buffer blitting, the shared primitive behind every slide (#35).
+//! Cell-level buffer effects: the shared primitives behind the slides and
+//! fades (#35).
 //!
 //! A slide draws its layer at rest into a standalone [`Buffer`], then copies
 //! those cells into the frame at an eased offset. Going through cells (instead
@@ -8,6 +9,10 @@
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
+
+use crate::tui::theme;
+use crate::tui::tween::color_lerp;
 
 /// Copy the `region` cells of `src` into `dst` offset by (`dx`, `dy`), dropping
 /// whatever lands outside `clip`.
@@ -44,6 +49,29 @@ pub fn snapshot(src: &Buffer, area: Rect) -> Buffer {
         }
     }
     out
+}
+
+/// Fade the cells of `area` up out of the background, `k` of the way in
+/// (`k >= 1.0` is fully drawn, `0.0` invisible).
+///
+/// Used where a panel's *content* changes under a fixed frame -- a different
+/// host's detail, a re-filtered table -- and sliding it would be a lie about
+/// where it came from, but swapping it outright reads as a flicker.
+pub fn fade(buf: &mut Buffer, area: Rect, k: f32) {
+    if k >= 1.0 {
+        return;
+    }
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            let Some(c) = buf.cell_mut((x, y)) else {
+                continue;
+            };
+            c.fg = color_lerp(theme::BG, c.fg, k);
+            if c.bg != Color::Reset {
+                c.bg = color_lerp(theme::BG, c.bg, k);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -112,6 +140,28 @@ mod tests {
         let mut dst = Buffer::empty(a);
         blit(&mut dst, a, a, &src, a.width as i32, 0);
         assert_eq!(row(&dst, a, 1), " ".repeat(a.width as usize));
+    }
+
+    #[test]
+    fn fade_at_rest_leaves_the_cells_alone() {
+        let a = area();
+        let mut buf = Buffer::empty(a);
+        buf.cell_mut((2, 1)).unwrap().fg = theme::GREEN;
+        fade(&mut buf, a, 1.0);
+        assert_eq!(buf.cell((2, 1)).unwrap().fg, theme::GREEN);
+    }
+
+    #[test]
+    fn fade_pulls_colours_toward_the_background() {
+        let a = area();
+        let mut buf = Buffer::empty(a);
+        buf.cell_mut((2, 1)).unwrap().fg = theme::GREEN;
+        buf.cell_mut((2, 1)).unwrap().bg = theme::SEL_BG;
+        fade(&mut buf, a, 0.0);
+        assert_eq!(buf.cell((2, 1)).unwrap().fg, theme::BG);
+        assert_eq!(buf.cell((2, 1)).unwrap().bg, theme::BG);
+        // A transparent background stays transparent rather than being painted.
+        assert_eq!(buf.cell((3, 1)).unwrap().bg, Color::Reset);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -44,8 +44,10 @@ pub fn render(frame: &mut Frame, app: &App) {
     // `popup_open_rect`, and we snapshot it afterwards for the close slide (#35).
     app.last_popup_rect.set(None);
     render_inner(frame, app);
-    // Snapshot the popup shown this frame, then throw a just-closed one upward.
+    // Snapshot the popup shown this frame, slide a fresh one in from the top,
+    // and throw a just-closed one upward.
     capture_popup_snapshot(frame, app);
+    render_popup_open(frame, app);
     render_popup_close(frame, app);
     if app.config.appearance.opaque_background {
         let buf = frame.buffer_mut();
@@ -208,6 +210,11 @@ fn render_inner(frame: &mut Frame, app: &App) {
     }
 
     // ── Overlay popups ─────────────────────────────────────────
+    // Snapshot the dashboard (no popup yet) so the open slide can restore what's
+    // behind the popup and let it drop in from off the top of the screen (#35).
+    if app.motion_enabled() && crate::app::is_overlay_mode(app.mode) {
+        *app.popup_backdrop.borrow_mut() = Some(frame.buffer_mut().clone());
+    }
     match app.mode {
         AppMode::Palette => {
             screens::palette::render_palette(
@@ -576,6 +583,47 @@ fn capture_popup_snapshot(frame: &mut Frame, app: &App) {
     *app.popup_snapshot.borrow_mut() = Some((rect, snap));
 }
 
+/// Slide a freshly-opened popup down into place from off the top of the screen
+/// over [`POPUP_ANIM`] (#35). Restores the dashboard backdrop where the popup
+/// rests, then blits its snapshot shifted up by an easing offset (the whole
+/// popup is above the top at the start), so it truly enters from off-screen.
+fn render_popup_open(frame: &mut Frame, app: &App) {
+    if !app.motion_enabled() || !crate::app::is_overlay_mode(app.mode) {
+        return;
+    }
+    let now = std::time::Instant::now();
+    let p = tween::progress(app.mode_entered_at, POPUP_ANIM, now);
+    if p >= 1.0 {
+        return;
+    }
+    let snap = app.popup_snapshot.borrow();
+    let backdrop = app.popup_backdrop.borrow();
+    let (Some((rect, buf)), Some(bd)) = (snap.as_ref(), backdrop.as_ref()) else {
+        return;
+    };
+    // Off starts a full popup-height above the rest (fully off-screen) and eases
+    // to 0. Restore the dashboard where the popup rests, then blit it shifted up.
+    let off = ((1.0 - tween::ease_out(p)) * rect.bottom() as f32).round() as u16;
+    let fb = frame.buffer_mut();
+    for y in rect.top()..rect.bottom() {
+        for x in rect.left()..rect.right() {
+            if let (Some(src), Some(dst)) = (bd.cell((x, y)), fb.cell_mut((x, y))) {
+                *dst = src.clone();
+            }
+        }
+    }
+    for y in rect.top()..rect.bottom() {
+        let Some(ty) = y.checked_sub(off) else {
+            continue;
+        };
+        for x in rect.left()..rect.right() {
+            if let (Some(src), Some(dst)) = (buf.cell((x, y)), fb.cell_mut((x, ty))) {
+                *dst = src.clone();
+            }
+        }
+    }
+}
+
 /// Blit a just-closed popup's captured snapshot, sliding it up off the top over
 /// [`POPUP_ANIM`] (#35). The dashboard beneath is already drawn, so the popup
 /// rises away revealing it.
@@ -617,32 +665,14 @@ pub const TAB_ANIM: std::time::Duration = std::time::Duration::from_millis(220);
 /// Duration of a popup's open / close slide (#35).
 pub const POPUP_ANIM: std::time::Duration = std::time::Duration::from_millis(260);
 
-/// Shared popup-open animation (#35): given a popup's resting `target` rect,
-/// return where to draw it this frame. It rises into place from slightly below
-/// over [`POPUP_ANIM`] after the mode was entered, so every overlay that runs
-/// its rect through this helper animates its open identically. Returns `target`
-/// unchanged once settled or under reduced motion.
+/// Shared popup rect hook (#35): every overlay runs its resting rect through
+/// this so the render pass can snapshot the popup for its open/close slides.
+/// Returns the rest rect unchanged — the popup always *draws* at rest, and the
+/// slide is a separate blit pass ([`render_popup_open`] / [`render_popup_close`])
+/// that can clip the popup above the top of the screen (a `Rect` cannot).
 pub fn popup_open_rect(target: Rect, app: &App) -> Rect {
-    // Record the resting rect so the render pass can snapshot it for the close
-    // animation, even under reduced motion (the snapshot is free either way).
     app.last_popup_rect.set(Some(target));
-    if !app.motion_enabled() {
-        return target;
-    }
-    let now = std::time::Instant::now();
-    let p = tween::progress(app.mode_entered_at, POPUP_ANIM, now);
-    if p >= 1.0 {
-        return target;
-    }
-    // Drop in from the top edge down to the resting spot for a clear, visible
-    // slide (small travel read as instant). Shifting the top UP only (never
-    // below rest, `y` saturates at 0) keeps it fully on-screen and panic-safe on
-    // a tiny terminal.
-    let drop = target.y as f32 * (1.0 - tween::ease_out(p));
-    Rect {
-        y: target.y.saturating_sub(drop.round() as u16),
-        ..target
-    }
+    target
 }
 
 /// Dispatch a tab index to its body renderer, into `areas`.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -615,7 +615,7 @@ fn render_popup_close(frame: &mut Frame, app: &App) {
 pub const TAB_ANIM: std::time::Duration = std::time::Duration::from_millis(220);
 
 /// Duration of a popup's open / close slide (#35).
-pub const POPUP_ANIM: std::time::Duration = std::time::Duration::from_millis(230);
+pub const POPUP_ANIM: std::time::Duration = std::time::Duration::from_millis(260);
 
 /// Shared popup-open animation (#35): given a popup's resting `target` rect,
 /// return where to draw it this frame. It rises into place from slightly below
@@ -634,11 +634,11 @@ pub fn popup_open_rect(target: Rect, app: &App) -> Rect {
     if p >= 1.0 {
         return target;
     }
-    // Drop into place from just above the resting spot. Shifting the top UP
-    // (never down) keeps the popup fully on-screen — its bottom stays at/above
-    // the resting bottom, and `y` saturates at 0 — so a tiny terminal can't push
-    // content off the buffer and panic.
-    let drop = (target.height as f32 * 0.35 + 2.0) * (1.0 - tween::ease_out(p));
+    // Drop in from the top edge down to the resting spot for a clear, visible
+    // slide (small travel read as instant). Shifting the top UP only (never
+    // below rest, `y` saturates at 0) keeps it fully on-screen and panic-safe on
+    // a tiny terminal.
+    let drop = target.y as f32 * (1.0 - tween::ease_out(p));
     Rect {
         y: target.y.saturating_sub(drop.round() as u16),
         ..target

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -590,16 +590,26 @@ pub fn panel_zoom_source(
     panel: crate::app::PanelId,
 ) -> Rect {
     use crate::app::PanelId;
+    use widgets::middle_stack::{AGENT_H, HOST_H, LATENCY_H};
+    use widgets::right_stack::{AUTH_H, PING_H, RECENT_H};
+    let mid = areas.col_mid;
+    let right = areas.col_right;
+    // Each stacked panel's real slot (same heights the stacks lay out), so the
+    // morph grows/shrinks in both dimensions from the actual box.
     match panel {
         PanelId::Hosts => areas.col_left,
-        PanelId::Detail | PanelId::Agent | PanelId::Latency => areas.col_mid,
-        PanelId::Recent | PanelId::Auth | PanelId::Ping => areas.col_right,
-        // SSH log spans the mid+right columns along the bottom of the body.
+        PanelId::Detail => Rect::new(mid.x, mid.y, mid.width, HOST_H),
+        PanelId::Agent => Rect::new(mid.x, mid.y + HOST_H, mid.width, AGENT_H),
+        PanelId::Latency => Rect::new(mid.x, mid.y + HOST_H + AGENT_H, mid.width, LATENCY_H),
+        PanelId::Recent => Rect::new(right.x, right.y, right.width, RECENT_H),
+        PanelId::Auth => Rect::new(right.x, right.y + RECENT_H, right.width, AUTH_H),
+        PanelId::Ping => Rect::new(right.x, right.y + RECENT_H + AUTH_H, right.width, PING_H),
+        // SSH log spans mid+right along the bottom (see render_hosts_body).
         PanelId::SshLog => Rect::new(
-            areas.col_mid.x,
-            areas.col_mid.y,
-            areas.col_mid.width + 1 + areas.col_right.width,
-            areas.body.height,
+            mid.x,
+            mid.y + 19,
+            mid.width + 1 + right.width,
+            areas.body.height.saturating_sub(19),
         ),
         // Broadcast morphs from its own docked rect, handled elsewhere.
         PanelId::Broadcast => screens::broadcast::docked_rect(areas.body),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -542,7 +542,13 @@ fn render_hosts_body(frame: &mut Frame, areas: &dashboard_layout::DashboardAreas
     // Broadcast (#3) is a floating panel drawn from render_inner instead, so a
     // zoomed Broadcast must not be handled here (it has no home in the hosts
     // grid) — let render_inner's broadcast block own it.
-    if app.panel_zoomed && app.focused_panel != crate::app::PanelId::Broadcast {
+    let grid_panel = app.focused_panel != crate::app::PanelId::Broadcast;
+    let now = std::time::Instant::now();
+    // A zoom morph (#35) is playing while the anim exists and hasn't finished.
+    let morphing = grid_panel && app.zoom_anim.is_some_and(|a| !a.is_done(now));
+
+    // Fully zoomed, no morph in flight: the panel owns the whole body.
+    if app.panel_zoomed && !morphing && grid_panel {
         render_zoomed_panel(frame, areas.body, app);
         return;
     }
@@ -561,6 +567,42 @@ fn render_hosts_body(frame: &mut Frame, areas: &dashboard_layout::DashboardAreas
             log_bottom - log_top,
         );
         widgets::middle_stack::render_ssh_log_panel(frame, log_area, app);
+    }
+
+    // Zoom morph (#35): overlay the focused panel at the interpolating rect over
+    // the grid, so zoom-in grows out of the slot and zoom-out shrinks back into
+    // it. When the morph finishes, the branch above takes over (full body) or
+    // the plain grid remains.
+    if morphing {
+        if let Some(anim) = app.zoom_anim {
+            let rect = anim.rect_at(now);
+            frame.render_widget(Clear, rect);
+            render_zoomed_panel(frame, rect, app);
+        }
+    }
+}
+
+/// The grid slot a panel morphs out of / back into for the zoom animation
+/// (#35). Approximated by the panel's column (or the log strip), which reads
+/// well without threading every sub-panel's exact rect out of the stacks.
+pub fn panel_zoom_source(
+    areas: &dashboard_layout::DashboardAreas,
+    panel: crate::app::PanelId,
+) -> Rect {
+    use crate::app::PanelId;
+    match panel {
+        PanelId::Hosts => areas.col_left,
+        PanelId::Detail | PanelId::Agent | PanelId::Latency => areas.col_mid,
+        PanelId::Recent | PanelId::Auth | PanelId::Ping => areas.col_right,
+        // SSH log spans the mid+right columns along the bottom of the body.
+        PanelId::SshLog => Rect::new(
+            areas.col_mid.x,
+            areas.col_mid.y,
+            areas.col_mid.width + 1 + areas.col_right.width,
+            areas.body.height,
+        ),
+        // Broadcast morphs from its own docked rect, handled elsewhere.
+        PanelId::Broadcast => screens::broadcast::docked_rect(areas.body),
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,6 +7,7 @@ pub mod theme;
 pub mod tween;
 pub mod widgets;
 
+use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
@@ -39,7 +40,13 @@ pub fn format_local_time(epoch_secs: i64) -> String {
 /// is on — paints a solid backdrop behind every still-transparent cell so text
 /// stays readable on a transparent terminal.
 pub fn render(frame: &mut Frame, app: &App) {
+    // Reset the per-frame popup rect; each popup that draws sets it via
+    // `popup_open_rect`, and we snapshot it afterwards for the close slide (#35).
+    app.last_popup_rect.set(None);
     render_inner(frame, app);
+    // Snapshot the popup shown this frame, then throw a just-closed one upward.
+    capture_popup_snapshot(frame, app);
+    render_popup_close(frame, app);
     if app.config.appearance.opaque_background {
         let buf = frame.buffer_mut();
         let area = buf.area;
@@ -543,11 +550,70 @@ fn render_zoom_toast(frame: &mut Frame, footer: Rect, notice: &str) {
     frame.buffer_mut().set_string(x, y, &label, style);
 }
 
+/// Snapshot the popup drawn this frame (opaque cells at `last_popup_rect`) into
+/// `app.popup_snapshot`, so it can be thrown upward when the popup later closes
+/// (#35). No-op when the current mode draws no popup.
+fn capture_popup_snapshot(frame: &mut Frame, app: &App) {
+    if !crate::app::is_overlay_mode(app.mode) {
+        return;
+    }
+    let Some(rect) = app.last_popup_rect.get() else {
+        return;
+    };
+    let rect = rect.intersection(frame.area());
+    if rect.width == 0 || rect.height == 0 {
+        return;
+    }
+    let buf = frame.buffer_mut();
+    let mut snap = Buffer::empty(rect);
+    for y in rect.top()..rect.bottom() {
+        for x in rect.left()..rect.right() {
+            if let (Some(src), Some(dst)) = (buf.cell((x, y)), snap.cell_mut((x, y))) {
+                *dst = src.clone();
+            }
+        }
+    }
+    *app.popup_snapshot.borrow_mut() = Some((rect, snap));
+}
+
+/// Blit a just-closed popup's captured snapshot, sliding it up off the top over
+/// [`POPUP_ANIM`] (#35). The dashboard beneath is already drawn, so the popup
+/// rises away revealing it.
+fn render_popup_close(frame: &mut Frame, app: &App) {
+    if !app.motion_enabled() {
+        return;
+    }
+    let Some(at) = app.popup_closing_at else {
+        return;
+    };
+    let now = std::time::Instant::now();
+    let p = tween::progress(at, POPUP_ANIM, now);
+    if p >= 1.0 {
+        return;
+    }
+    let snap = app.popup_snapshot.borrow();
+    let Some((rect, buf)) = snap.as_ref() else {
+        return;
+    };
+    let off = (tween::ease_out(p) * (rect.height as f32 + 2.0)).round() as u16;
+    let fb = frame.buffer_mut();
+    for y in rect.top()..rect.bottom() {
+        let Some(ty) = y.checked_sub(off) else {
+            continue;
+        };
+        for x in rect.left()..rect.right() {
+            if let (Some(src), Some(dst)) = (buf.cell((x, y)), fb.cell_mut((x, ty))) {
+                *dst = src.clone();
+            }
+        }
+    }
+}
+
 /// Duration of the tab-switch body slide (#35).
 pub const TAB_ANIM: std::time::Duration = std::time::Duration::from_millis(220);
 
-/// Duration of a popup's open slide (#35).
-pub const POPUP_ANIM: std::time::Duration = std::time::Duration::from_millis(140);
+/// Duration of a popup's open / close slide (#35).
+pub const POPUP_ANIM: std::time::Duration = std::time::Duration::from_millis(230);
 
 /// Shared popup-open animation (#35): given a popup's resting `target` rect,
 /// return where to draw it this frame. It rises into place from slightly below
@@ -555,6 +621,9 @@ pub const POPUP_ANIM: std::time::Duration = std::time::Duration::from_millis(140
 /// its rect through this helper animates its open identically. Returns `target`
 /// unchanged once settled or under reduced motion.
 pub fn popup_open_rect(target: Rect, app: &App) -> Rect {
+    // Record the resting rect so the render pass can snapshot it for the close
+    // animation, even under reduced motion (the snapshot is free either way).
+    app.last_popup_rect.set(Some(target));
     if !app.motion_enabled() {
         return target;
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -166,10 +166,11 @@ fn render_inner(frame: &mut Frame, app: &App) {
         if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Broadcast {
             screens::broadcast::render_broadcast_zoomed(frame, body, app);
         } else {
-            let rect = bc
-                .anim
-                .map(|a| a.rect_at(std::time::Instant::now()))
-                .unwrap_or_else(|| screens::broadcast::docked_rect(body));
+            let rect = match bc.anim {
+                Some(a) if app.motion_enabled() => a.rect_at(std::time::Instant::now()),
+                // Reduced motion (or no anim): sit at the resting docked rect.
+                _ => screens::broadcast::docked_rect(body),
+            };
             let focused = app.focused_panel == crate::app::PanelId::Broadcast;
             screens::broadcast::render_broadcast_panel(frame, rect, app, focused);
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -205,6 +205,7 @@ fn render_inner(frame: &mut Frame, app: &App) {
         AppMode::Palette => {
             screens::palette::render_palette(
                 frame,
+                app,
                 &app.palette_query,
                 &app.hosts,
                 &app.palette_results,
@@ -248,7 +249,7 @@ fn render_inner(frame: &mut Frame, app: &App) {
             } else if app.tunnel_form.is_some() {
                 screens::tunnels::render_tunnel_form(frame, app);
             }
-            render_confirm_discard_popup(frame);
+            render_confirm_discard_popup(frame, app);
         }
         AppMode::ConfirmDelete => render_confirm_delete_popup(frame, app),
         AppMode::Help => render_help_popup(frame, app),
@@ -306,6 +307,8 @@ fn render_sftp_prompt_popup(frame: &mut Frame, app: &App) {
         theme::dim(),
     )));
 
+    let popup_area = crate::tui::popup_open_rect(popup_area, app);
+
     frame.render_widget(Clear, popup_area);
     frame.render_widget(
         Paragraph::new(lines).wrap(Wrap { trim: false }).block(
@@ -352,6 +355,8 @@ fn render_import_prompt_popup(frame: &mut Frame, app: &App) {
         "Enter: import  \u{2502}  Esc: cancel",
         theme::dim(),
     )));
+
+    let popup_area = crate::tui::popup_open_rect(popup_area, app);
 
     frame.render_widget(Clear, popup_area);
     frame.render_widget(
@@ -540,6 +545,34 @@ fn render_zoom_toast(frame: &mut Frame, footer: Rect, notice: &str) {
 
 /// Duration of the tab-switch body slide (#35).
 pub const TAB_ANIM: std::time::Duration = std::time::Duration::from_millis(220);
+
+/// Duration of a popup's open slide (#35).
+pub const POPUP_ANIM: std::time::Duration = std::time::Duration::from_millis(140);
+
+/// Shared popup-open animation (#35): given a popup's resting `target` rect,
+/// return where to draw it this frame. It rises into place from slightly below
+/// over [`POPUP_ANIM`] after the mode was entered, so every overlay that runs
+/// its rect through this helper animates its open identically. Returns `target`
+/// unchanged once settled or under reduced motion.
+pub fn popup_open_rect(target: Rect, app: &App) -> Rect {
+    if !app.motion_enabled() {
+        return target;
+    }
+    let now = std::time::Instant::now();
+    let p = tween::progress(app.mode_entered_at, POPUP_ANIM, now);
+    if p >= 1.0 {
+        return target;
+    }
+    // Drop into place from just above the resting spot. Shifting the top UP
+    // (never down) keeps the popup fully on-screen — its bottom stays at/above
+    // the resting bottom, and `y` saturates at 0 — so a tiny terminal can't push
+    // content off the buffer and panic.
+    let drop = (target.height as f32 * 0.35 + 2.0) * (1.0 - tween::ease_out(p));
+    Rect {
+        y: target.y.saturating_sub(drop.round() as u16),
+        ..target
+    }
+}
 
 /// Dispatch a tab index to its body renderer, into `areas`.
 fn render_tab_body(
@@ -743,6 +776,8 @@ fn render_form_popup(frame: &mut Frame, app: &App, kind: FormKind) {
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
 
+    let popup_area = crate::tui::popup_open_rect(popup_area, app);
+
     frame.render_widget(Clear, popup_area);
 
     match kind {
@@ -830,6 +865,8 @@ fn render_confirm_quit_popup(frame: &mut Frame, app: &App) {
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
 
+    let popup_area = crate::tui::popup_open_rect(popup_area, app);
+
     frame.render_widget(Clear, popup_area);
     frame.render_widget(
         Paragraph::new(format!("{message}\n{hint}"))
@@ -845,7 +882,7 @@ fn render_confirm_quit_popup(frame: &mut Frame, app: &App) {
     );
 }
 
-fn render_confirm_discard_popup(frame: &mut Frame) {
+fn render_confirm_discard_popup(frame: &mut Frame, app: &App) {
     let message = "Save changes?";
     let hint = "y: save \u{2502} n: discard \u{2502} Esc: back";
 
@@ -855,6 +892,8 @@ fn render_confirm_discard_popup(frame: &mut Frame) {
     let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    let popup_area = crate::tui::popup_open_rect(popup_area, app);
 
     frame.render_widget(Clear, popup_area);
     frame.render_widget(
@@ -902,6 +941,8 @@ fn render_confirm_delete_popup(frame: &mut Frame, app: &App) {
         ratatui::text::Line::from(""),
         ratatui::text::Line::from("y: delete    Esc: cancel"),
     ];
+
+    let popup_area = crate::tui::popup_open_rect(popup_area, app);
 
     frame.render_widget(Clear, popup_area);
     frame.render_widget(
@@ -957,6 +998,8 @@ fn render_help_popup(frame: &mut Frame, app: &App) {
     let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    let popup_area = crate::tui::popup_open_rect(popup_area, app);
 
     frame.render_widget(Clear, popup_area);
     frame.render_widget(

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -595,7 +595,9 @@ fn render_popup_close(frame: &mut Frame, app: &App) {
     let Some((rect, buf)) = snap.as_ref() else {
         return;
     };
-    let off = (tween::ease_out(p) * (rect.height as f32 + 2.0)).round() as u16;
+    // Travel the popup's whole bottom edge to the top, so at p==1 every row has
+    // slid above y==0 and nothing lingers near the top of the screen.
+    let off = (tween::ease_out(p) * rect.bottom() as f32).round() as u16;
     let fb = frame.buffer_mut();
     for y in rect.top()..rect.bottom() {
         let Some(ty) = y.checked_sub(off) else {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -147,14 +147,15 @@ fn render_inner(frame: &mut Frame, app: &App) {
     let rule2 = row_in(area, areas.tab_bar.y + areas.tab_bar.height);
     widgets::footer::render_hrule(frame, rule2, false);
 
-    // ── Tab body dispatch ─────────────────────────────────────
-    match app.active_tab {
-        0 => render_hosts_body(frame, &areas, app),
-        1 => render_sftp_body(frame, &areas, app),
-        2 => render_tunnels_body(frame, &areas, app),
-        3 => render_keys_body(frame, &areas, app),
-        4 => render_audit_body(frame, &areas, app),
-        _ => render_hosts_body(frame, &areas, app),
+    // ── Tab body dispatch (with slide animation, #35) ─────────
+    let now = std::time::Instant::now();
+    let sliding = app
+        .tab_switch
+        .filter(|s| app.motion_enabled() && now.saturating_duration_since(s.at) < TAB_ANIM);
+    if let Some(sw) = sliding {
+        render_tab_slide(frame, &areas, app, sw, now);
+    } else {
+        render_tab_body(frame, app.active_tab, &areas, app);
     }
 
     // ── Broadcast mode (#3): docked live panel floats over the dashboard ──
@@ -535,6 +536,83 @@ fn render_zoom_toast(frame: &mut Frame, footer: Rect, notice: &str) {
     let y = footer.y - 1;
     let style = theme::cyan().add_modifier(Modifier::REVERSED);
     frame.buffer_mut().set_string(x, y, &label, style);
+}
+
+/// Duration of the tab-switch body slide (#35).
+pub const TAB_ANIM: std::time::Duration = std::time::Duration::from_millis(220);
+
+/// Dispatch a tab index to its body renderer, into `areas`.
+fn render_tab_body(
+    frame: &mut Frame,
+    tab: usize,
+    areas: &dashboard_layout::DashboardAreas,
+    app: &App,
+) {
+    match tab {
+        0 => render_hosts_body(frame, areas, app),
+        1 => render_sftp_body(frame, areas, app),
+        2 => render_tunnels_body(frame, areas, app),
+        3 => render_keys_body(frame, areas, app),
+        4 => render_audit_body(frame, areas, app),
+        _ => render_hosts_body(frame, areas, app),
+    }
+}
+
+/// Copy `areas` with the body region (body + the three columns) shifted right by
+/// `dx` columns, for rendering a tab body mid-slide. Header/tab-bar/footer stay.
+fn shift_body_areas(
+    areas: &dashboard_layout::DashboardAreas,
+    dx: u16,
+) -> dashboard_layout::DashboardAreas {
+    let shift = |r: Rect| Rect::new(r.x.saturating_add(dx), r.y, r.width, r.height);
+    let mut a = *areas;
+    a.body = shift(a.body);
+    a.col_left = shift(a.col_left);
+    a.col_mid = shift(a.col_mid);
+    a.col_right = shift(a.col_right);
+    a
+}
+
+/// Render a tab-switch slide: a static backdrop body plus the moving body
+/// translated right by an eased offset, with a hard edge between them (#35).
+/// `to > from` slides the new tab in from the right; `to < from` slides the old
+/// tab out to the right, revealing the new one beneath.
+fn render_tab_slide(
+    frame: &mut Frame,
+    areas: &dashboard_layout::DashboardAreas,
+    app: &App,
+    sw: crate::app::TabSwitch,
+    now: std::time::Instant,
+) {
+    let p = tween::ease_out(tween::progress(sw.at, TAB_ANIM, now));
+    let bw = areas.body.width;
+    let right = sw.to > sw.from;
+    // The moving layer sits on top starting at `body.x + off`; the backdrop shows
+    // in `[body.x, body.x + off]`. Right: new enters from the right (off: bw->0).
+    // Left: old exits to the right (off: 0->bw).
+    let off = if right {
+        ((1.0 - p) * bw as f32).round() as u16
+    } else {
+        (p * bw as f32).round() as u16
+    };
+    let (backdrop, top) = if right {
+        (sw.from, sw.to)
+    } else {
+        (sw.to, sw.from)
+    };
+
+    render_tab_body(frame, backdrop, areas, app);
+    if off < bw {
+        let clear = Rect::new(
+            areas.body.x + off,
+            areas.body.y,
+            bw - off,
+            areas.body.height,
+        );
+        frame.render_widget(Clear, clear);
+        let shifted = shift_body_areas(areas, off);
+        render_tab_body(frame, top, &shifted, app);
+    }
 }
 
 fn render_hosts_body(frame: &mut Frame, areas: &dashboard_layout::DashboardAreas, app: &App) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -852,6 +852,9 @@ fn render_session_tab_slide(frame: &mut Frame, app: &App) {
     );
 }
 
+/// How long a newly staged SFTP transfer takes to fly into the queue (#35).
+pub const SFTP_QUEUE_ANIM: std::time::Duration = std::time::Duration::from_millis(200);
+
 /// How long a host's status dot flashes after its ping class changes (#35).
 pub const PING_FLASH: std::time::Duration = std::time::Duration::from_millis(420);
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -49,7 +49,11 @@ pub fn render(frame: &mut Frame, app: &App) {
     // slide the session off to the right (#35). Once exited, render_inner has
     // drawn the dashboard beneath — blit the snapshot sliding away over it.
     if crate::app::is_session_mode(app.mode) {
-        *app.session_snapshot.borrow_mut() = Some(frame.buffer_mut().clone());
+        // Hold the snapshot still while a tab slide plays: it *is* the tab being
+        // carried off, so refreshing it would feed the slide its own output.
+        if app.session_tab_switch.is_none() {
+            *app.session_snapshot.borrow_mut() = Some(frame.buffer_mut().clone());
+        }
     } else {
         render_session_exit(frame, app);
     }
@@ -137,6 +141,7 @@ fn render_inner(frame: &mut Frame, app: &App) {
         // for the picker-over-session case (no fresh connect happening).
         if !session_behind_picker {
             render_session_enter(frame, app);
+            render_session_tab_slide(frame, app);
         }
         if app.mode == AppMode::SessionHostPicker {
             screens::session_host_picker::render(frame, app);
@@ -787,6 +792,45 @@ fn render_session_exit(frame: &mut Frame, app: &App) {
             }
         }
     }
+}
+
+/// Slide between two embedded session tabs over [`TAB_ANIM`] (#35): the tab
+/// being left is carried off one edge while the new one follows it in from the
+/// other, so `Ctrl`+arrows reads as travel along the strip instead of a swap.
+/// Shares the dashboard tab-switch duration, being the same gesture.
+fn render_session_tab_slide(frame: &mut Frame, app: &App) {
+    if !app.motion_enabled() {
+        return;
+    }
+    let Some(sw) = app.session_tab_switch else {
+        return;
+    };
+    let now = std::time::Instant::now();
+    let p = tween::progress(sw.at, TAB_ANIM, now);
+    if p >= 1.0 {
+        return;
+    }
+    let snap = app.session_snapshot.borrow();
+    let Some(outgoing) = snap.as_ref() else {
+        return;
+    };
+    let area = frame.area();
+    // The new tab is already drawn at rest; lift it so both layers can move.
+    let incoming = blit::snapshot(frame.buffer_mut(), area);
+    frame.render_widget(Clear, area);
+    let e = tween::ease_out(p);
+    let w = area.width as f32;
+    let dir = sw.dir as f32;
+    let fb = frame.buffer_mut();
+    blit::blit(fb, area, area, outgoing, (-dir * e * w).round() as i32, 0);
+    blit::blit(
+        fb,
+        area,
+        area,
+        &incoming,
+        (dir * (1.0 - e) * w).round() as i32,
+        0,
+    );
 }
 
 /// Duration of the tab-switch body slide (#35).

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -852,6 +852,9 @@ fn render_session_tab_slide(frame: &mut Frame, app: &App) {
     );
 }
 
+/// How long a panel's swapped-out content takes to fade in (#35).
+pub const CONTENT_FADE: std::time::Duration = std::time::Duration::from_millis(140);
+
 /// How long an SFTP pane's listing takes to slide to a new directory (#35).
 pub const SFTP_NAV_ANIM: std::time::Duration = std::time::Duration::from_millis(200);
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,5 @@
 pub mod animation;
+pub mod blit;
 pub mod dashboard_layout;
 pub mod layout;
 pub mod screens;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -537,6 +537,7 @@ fn footer_keybinds(app: &App) -> Vec<(String, &'static str)> {
             ("M".into(), "chmod"),
             ("r".into(), "refresh"),
             ("s".into(), "ssh"),
+            ("o".into(), "2nd host"),
             ("/".into(), "search"),
             ("Esc".into(), "back"),
             ("?".into(), "help"),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -44,6 +44,14 @@ pub fn render(frame: &mut Frame, app: &App) {
     // `popup_open_rect`, and we snapshot it afterwards for the close slide (#35).
     app.last_popup_rect.set(None);
     render_inner(frame, app);
+    // While in the full-screen host view, keep a fresh snapshot so leaving it can
+    // slide the session off to the right (#35). Once exited, render_inner has
+    // drawn the dashboard beneath — blit the snapshot sliding away over it.
+    if crate::app::is_session_mode(app.mode) {
+        *app.session_snapshot.borrow_mut() = Some(frame.buffer_mut().clone());
+    } else {
+        render_session_exit(frame, app);
+    }
     // Snapshot the popup shown this frame, slide a fresh one in from the top,
     // and throw a just-closed one upward.
     capture_popup_snapshot(frame, app);
@@ -739,6 +747,42 @@ fn render_session_enter(frame: &mut Frame, app: &App) {
                 }
             } else if let Some(d) = fb.cell_mut((x, y)) {
                 d.reset();
+            }
+        }
+    }
+}
+
+/// Slide a just-left session's captured snapshot off to the right over
+/// [`SESSION_ANIM`] (#35), revealing the dashboard already drawn beneath. The
+/// mirror of [`render_session_enter`].
+fn render_session_exit(frame: &mut Frame, app: &App) {
+    if !app.motion_enabled() {
+        return;
+    }
+    let Some(at) = app.session_exit_at else {
+        return;
+    };
+    let now = std::time::Instant::now();
+    let p = tween::progress(at, SESSION_ANIM, now);
+    if p >= 1.0 {
+        return;
+    }
+    let snap = app.session_snapshot.borrow();
+    let Some(buf) = snap.as_ref() else {
+        return;
+    };
+    let area = frame.area();
+    // Off eases from 0 to a full screen-width, carrying the session off the right.
+    let off = (tween::ease_out(p) * area.width as f32).round() as u16;
+    if off >= area.width {
+        return;
+    }
+    let fb = frame.buffer_mut();
+    for y in area.y..area.y + area.height {
+        // Left-to-right: each destination x reads source x-off (already passed).
+        for x in (area.x + off)..(area.x + area.width) {
+            if let (Some(s), Some(d)) = (buf.cell((x - off, y)), fb.cell_mut((x, y))) {
+                *d = s.clone();
             }
         }
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -852,6 +852,9 @@ fn render_session_tab_slide(frame: &mut Frame, app: &App) {
     );
 }
 
+/// Duration of the host-list highlight wipe under a moved cursor (#35).
+pub const SELECT_ANIM: std::time::Duration = std::time::Duration::from_millis(120);
+
 /// Duration of the tab-switch body slide (#35).
 pub const TAB_ANIM: std::time::Duration = std::time::Duration::from_millis(220);
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -124,6 +124,11 @@ fn render_inner(frame: &mut Frame, app: &App) {
     // Embedded session takes over the whole frame — no dashboard chrome.
     if matches!(app.mode, AppMode::Connecting | AppMode::Session) || session_behind_picker {
         crate::session::render::render(frame, app);
+        // Slide the freshly-connected session in from the right (#35). Skipped
+        // for the picker-over-session case (no fresh connect happening).
+        if !session_behind_picker {
+            render_session_enter(frame, app);
+        }
         if app.mode == AppMode::SessionHostPicker {
             screens::session_host_picker::render(frame, app);
         }
@@ -701,11 +706,52 @@ fn render_popup_close(frame: &mut Frame, app: &App) {
     }
 }
 
+/// Slide the freshly-rendered full-screen session in from the right edge over
+/// [`SESSION_ANIM`] (#35). Snapshots the session buffer, then blits it shifted
+/// right by an easing offset, leaving the vacated left band blank so the view
+/// reads as pushing in from the right.
+fn render_session_enter(frame: &mut Frame, app: &App) {
+    if !app.motion_enabled() {
+        return;
+    }
+    let Some(at) = app.session_enter_at else {
+        return;
+    };
+    let now = std::time::Instant::now();
+    let p = tween::progress(at, SESSION_ANIM, now);
+    if p >= 1.0 {
+        return;
+    }
+    let area = frame.area();
+    // Off starts a full screen-width to the right (fully off) and eases to 0.
+    let off = ((1.0 - tween::ease_out(p)) * area.width as f32).round() as u16;
+    if off == 0 {
+        return;
+    }
+    let src = frame.buffer_mut().clone();
+    let fb = frame.buffer_mut();
+    for y in area.y..area.y + area.height {
+        // Right-to-left so each destination reads a not-yet-overwritten source.
+        for x in (area.x..area.x + area.width).rev() {
+            if let Some(sx) = x.checked_sub(off).filter(|sx| *sx >= area.x) {
+                if let (Some(s), Some(d)) = (src.cell((sx, y)), fb.cell_mut((x, y))) {
+                    *d = s.clone();
+                }
+            } else if let Some(d) = fb.cell_mut((x, y)) {
+                d.reset();
+            }
+        }
+    }
+}
+
 /// Duration of the tab-switch body slide (#35).
 pub const TAB_ANIM: std::time::Duration = std::time::Duration::from_millis(220);
 
 /// Duration of a popup's open / close slide (#35).
 pub const POPUP_ANIM: std::time::Duration = std::time::Duration::from_millis(260);
+
+/// Duration of the full-screen session-enter slide on connect (#35).
+pub const SESSION_ANIM: std::time::Duration = std::time::Duration::from_millis(280);
 
 /// Shared popup rect hook (#35): every overlay runs its resting rect through
 /// this so the render pass can snapshot the popup for its open/close slides.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -842,7 +842,9 @@ fn render_session_tab_slide(frame: &mut Frame, app: &App) {
     let Some(outgoing) = snap.as_ref() else {
         return;
     };
-    let area = frame.area();
+    // Only the PTY body travels: the header stays put so the tab strip is a
+    // fixed reference while its highlight slides between tabs (#35).
+    let area = crate::session::render::body_rect(frame.area());
     // The new tab is already drawn at rest; lift it so both layers can move.
     let incoming = blit::snapshot(frame.buffer_mut(), area);
     frame.render_widget(Clear, area);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -76,6 +76,15 @@ pub fn render(frame: &mut Frame, app: &App) {
         }
     }
     apply_panel_selection(frame, app);
+    // Fade the whole dashboard up on the way out of the intro animation, so the
+    // first frame arrives rather than replacing the splash outright (#35).
+    if let Some(at) = app.dashboard_at.filter(|_| app.motion_enabled()) {
+        let p = tween::progress(at, SPLASH_FADE, std::time::Instant::now());
+        if p < 1.0 {
+            let area = frame.area();
+            blit::fade(frame.buffer_mut(), area, tween::ease_out(p));
+        }
+    }
 }
 
 /// Highlight the zoomed-panel text selection (issue #18) by reversing the
@@ -851,6 +860,9 @@ fn render_session_tab_slide(frame: &mut Frame, app: &App) {
         0,
     );
 }
+
+/// How long the dashboard takes to fade up over the intro animation (#35).
+pub const SPLASH_FADE: std::time::Duration = std::time::Duration::from_millis(360);
 
 /// How long a panel's swapped-out content takes to fade in (#35).
 pub const CONTENT_FADE: std::time::Duration = std::time::Duration::from_millis(140);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -852,6 +852,9 @@ fn render_session_tab_slide(frame: &mut Frame, app: &App) {
     );
 }
 
+/// Duration of a group's fold / unfold reveal in the host list (#35).
+pub const FOLD_ANIM: std::time::Duration = std::time::Duration::from_millis(180);
+
 /// Duration of the host-list highlight wipe under a moved cursor (#35).
 pub const SELECT_ANIM: std::time::Duration = std::time::Duration::from_millis(120);
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -852,6 +852,9 @@ fn render_session_tab_slide(frame: &mut Frame, app: &App) {
     );
 }
 
+/// How long a host's status dot flashes after its ping class changes (#35).
+pub const PING_FLASH: std::time::Duration = std::time::Duration::from_millis(420);
+
 /// Duration of a group's fold / unfold reveal in the host list (#35).
 pub const FOLD_ANIM: std::time::Duration = std::time::Duration::from_millis(180);
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1854,8 +1854,16 @@ mod tests {
         let buffer = render_to_buffer(&app, 120, 38);
         assert!(buffer_contains(&buffer, "key-00"));
 
+        // The grid scrolls to the selection over a few frames now (#35), so
+        // run it out with a backdated frame clock before looking.
         app.identity_selected = 28;
-        let buffer = render_to_buffer(&app, 120, 38);
+        let mut buffer = render_to_buffer(&app, 120, 38);
+        for _ in 0..40 {
+            app.keys_scroll_at.set(Some(
+                std::time::Instant::now() - std::time::Duration::from_millis(16),
+            ));
+            buffer = render_to_buffer(&app, 120, 38);
+        }
         assert!(
             buffer_contains(&buffer, "key-28"),
             "selected key card scrolled off-screen"

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -230,7 +230,7 @@ fn render_inner(frame: &mut Frame, app: &App) {
     // to the right of the footer until the next key press clears it.
     if app.panel_zoomed {
         if let Some(notice) = &app.host_notice {
-            render_zoom_toast(frame, areas.footer, notice);
+            render_zoom_toast(frame, areas.footer, notice, app);
         }
     }
 
@@ -612,13 +612,26 @@ fn footer_keybinds(app: &App) -> Vec<(String, &'static str)> {
 /// row *above* the footer keybinds, used while a panel is zoomed and the normal
 /// status-bar notice surface is hidden. Sits above the hints so it never clips
 /// them.
-fn render_zoom_toast(frame: &mut Frame, footer: Rect, notice: &str) {
+fn render_zoom_toast(frame: &mut Frame, footer: Rect, notice: &str, app: &App) {
     let label = format!(" {notice} ");
     let w = label.chars().count() as u16;
     if footer.width < w || footer.y == 0 {
         return;
     }
-    let x = footer.x + footer.width - w;
+    let rest_x = footer.x + footer.width - w;
+    // Ride in from off the right edge (#35), like the broadcast toasts. Travel
+    // the distance from the resting slot to the screen edge, so the toast is
+    // fully off-screen at p == 0 and `set_string` clips whatever hangs over.
+    let off = app
+        .host_notice_at
+        .filter(|_| app.motion_enabled())
+        .map(|at| {
+            let p = tween::progress(at, crate::broadcast::TOAST_ANIM, std::time::Instant::now());
+            ((1.0 - tween::ease_out(p)) * frame.area().right().saturating_sub(rest_x) as f32)
+                .round() as u16
+        })
+        .unwrap_or(0);
+    let x = rest_x + off;
     let y = footer.y - 1;
     let style = theme::cyan().add_modifier(Modifier::REVERSED);
     frame.buffer_mut().set_string(x, y, &label, style);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -797,6 +797,9 @@ pub const POPUP_ANIM: std::time::Duration = std::time::Duration::from_millis(260
 /// Duration of the full-screen session-enter slide on connect (#35).
 pub const SESSION_ANIM: std::time::Duration = std::time::Duration::from_millis(280);
 
+/// Duration of an SFTP tab sub-state slide: picker <-> connecting <-> browser (#35).
+pub const SFTP_ANIM: std::time::Duration = std::time::Duration::from_millis(260);
+
 /// Shared popup rect hook (#35): every overlay runs its resting rect through
 /// this so the render pass can snapshot the popup for its open/close slides.
 /// Returns the rest rect unchanged — the popup always *draws* at rest, and the

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -144,6 +144,12 @@ fn render_inner(frame: &mut Frame, app: &App) {
             render_session_tab_slide(frame, app);
         }
         if app.mode == AppMode::SessionHostPicker {
+            // Snapshot the session underneath before the picker draws, so its
+            // drop-in can restore what it covers (#35) — the same contract the
+            // dashboard branch honours for every other popup.
+            if app.motion_enabled() {
+                *app.popup_backdrop.borrow_mut() = Some(frame.buffer_mut().clone());
+            }
             screens::session_host_picker::render(frame, app);
         }
         return;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -278,8 +278,50 @@ fn render_inner(frame: &mut Frame, app: &App) {
         AppMode::BroadcastPickTarget => screens::broadcast::render_pick_target(frame, app),
         AppMode::BroadcastCommand => screens::broadcast::render_command_prompt(frame, app),
         AppMode::BroadcastPreview => screens::broadcast::render_preview(frame, app),
+        AppMode::Notice => render_notice_popup(frame, app),
         _ => {}
     }
+}
+
+/// Modal message popup (`AppMode::Notice`) — e.g. an SFTP connection error.
+/// Text comes from `App::notice_popup`; any key dismisses it.
+fn render_notice_popup(frame: &mut Frame, app: &App) {
+    let Some(message) = app.notice_popup.as_ref() else {
+        return;
+    };
+    let hint = "press any key to dismiss";
+
+    let area = frame.area();
+    let popup_width = 60u16.min(area.width).max(20.min(area.width));
+    // Rough wrapped-line count so the box grows with the message.
+    let inner_w = popup_width.saturating_sub(2).max(1) as usize;
+    let msg_lines = message
+        .split('\n')
+        .map(|l| (l.chars().count() / inner_w) + 1)
+        .sum::<usize>()
+        .max(1);
+    let popup_height = ((msg_lines as u16) + 4)
+        .min(area.height)
+        .max(5.min(area.height));
+    let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+    let popup_area = crate::tui::popup_open_rect(popup_area, app);
+
+    frame.render_widget(Clear, popup_area);
+    frame.render_widget(
+        Paragraph::new(format!("{message}\n\n{hint}"))
+            .wrap(Wrap { trim: false })
+            .style(Style::default().fg(Color::Red))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Connection failed ")
+                    .border_style(Style::default().fg(Color::Red)),
+            ),
+        popup_area,
+    );
 }
 
 fn render_sftp_prompt_popup(frame: &mut Frame, app: &App) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -160,7 +160,7 @@ fn render_inner(frame: &mut Frame, app: &App) {
     let areas = dashboard_layout::dashboard_layout_zoomed(area, app.ui_zoom);
 
     // Header stats
-    let (total, online, slow, down) = compute_header_stats(app);
+    let [total, online, slow, down] = app.header_stats_advance(compute_header_stats(app));
     let clock = format_utc_clock();
     widgets::header::render_header(frame, areas.header, total, online, slow, down, &clock);
 
@@ -480,7 +480,7 @@ fn build_session_chips(app: &App) -> Vec<widgets::header::SessionChip> {
         .collect()
 }
 
-fn compute_header_stats(app: &App) -> (usize, usize, usize, usize) {
+fn compute_header_stats(app: &App) -> [usize; 4] {
     use crate::ping::{classify_ping, PingClass};
 
     let total = app.hosts.len();
@@ -495,7 +495,7 @@ fn compute_header_stats(app: &App) -> (usize, usize, usize, usize) {
             PingClass::Unknown => {}
         }
     }
-    (total, online, slow, down)
+    [total, online, slow, down]
 }
 
 fn footer_keybinds(app: &App) -> Vec<(String, &'static str)> {
@@ -1571,7 +1571,7 @@ mod tests {
         app.ping_data
             .insert("host-02".into(), vec![PING_UNREACHABLE]);
 
-        let (total, online, slow, down) = compute_header_stats(&app);
+        let [total, online, slow, down] = compute_header_stats(&app);
         assert_eq!(total, 3);
         assert_eq!(online, 1);
         assert_eq!(slow, 1);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -852,6 +852,9 @@ fn render_session_tab_slide(frame: &mut Frame, app: &App) {
     );
 }
 
+/// How long an SFTP pane's listing takes to slide to a new directory (#35).
+pub const SFTP_NAV_ANIM: std::time::Duration = std::time::Duration::from_millis(200);
+
 /// How long a newly staged SFTP transfer takes to fly into the queue (#35).
 pub const SFTP_QUEUE_ANIM: std::time::Duration = std::time::Duration::from_millis(200);
 

--- a/src/tui/screens/audit.rs
+++ b/src/tui/screens/audit.rs
@@ -77,6 +77,22 @@ pub fn render_audit(frame: &mut Frame, area: Rect, app: &App) {
         let y = data_y + 2.min(max_rows.saturating_sub(1) as u16);
         buf.set_string(x, y, msg, theme::dim());
     }
+
+    // Everything below the filter strip is the query's result, so a changed
+    // filter or range swaps all of it. Fade it up, leaving the strip itself
+    // (which the user just interacted with) solid (#35).
+    let fade =
+        crate::tui::widgets::middle_stack::content_fade(app.audit_filter_at, app.motion_enabled());
+    let rows_top = filter_y + 2;
+    if fade < 1.0 && area.height > rows_top - area.y {
+        let rows = Rect::new(
+            area.x,
+            rows_top,
+            area.width,
+            (area.y + area.height).saturating_sub(rows_top),
+        );
+        crate::tui::blit::fade(buf, rows, fade);
+    }
 }
 
 fn render_filter_strip(

--- a/src/tui/screens/broadcast.rs
+++ b/src/tui/screens/broadcast.rs
@@ -486,6 +486,8 @@ pub fn render_pick_target(frame: &mut Frame, app: &App) {
     let list_rows = setup.options.len().clamp(1, 12) as u16;
     let popup = popup_rect(frame, 60, 40, list_rows + 4);
 
+    let popup = crate::tui::popup_open_rect(popup, app);
+
     frame.render_widget(Clear, popup);
     frame.render_widget(
         Block::default()
@@ -575,6 +577,8 @@ pub fn render_command_prompt(frame: &mut Frame, app: &App) {
         )),
     ];
 
+    let popup = crate::tui::popup_open_rect(popup, app);
+
     frame.render_widget(Clear, popup);
     frame.render_widget(
         Paragraph::new(lines).wrap(Wrap { trim: false }).block(
@@ -597,6 +601,8 @@ pub fn render_preview(frame: &mut Frame, app: &App) {
     let selected_count = setup.candidates.iter().filter(|c| c.selected).count();
     let list_rows = setup.candidates.len().clamp(1, 14) as u16;
     let popup = popup_rect(frame, 74, 50, list_rows + 6);
+
+    let popup = crate::tui::popup_open_rect(popup, app);
 
     frame.render_widget(Clear, popup);
     frame.render_widget(

--- a/src/tui/screens/broadcast.rs
+++ b/src/tui/screens/broadcast.rs
@@ -370,16 +370,17 @@ pub fn render_broadcast_toasts(frame: &mut Frame, body: Rect, app: &App) {
     let target_x = dock.x;
     let off_right = body.x + body.width; // fully off the right edge
     let now = Instant::now();
+    let motion = app.motion_enabled();
 
     // Anchor: stack grows upward from `stack_bottom`. With the panel present that
     // is just above it (dock.y); once it's gone, the toasts fall down into the
     // freed space (dock.y + dock.height). The transition animates over TOAST_ANIM
-    // from the moment the panel was dismissed.
+    // from the moment the panel was dismissed (skipped under reduced motion).
     let top_anchor = dock.y;
     let low_anchor = dock.y + dock.height;
     let anchor = if app.broadcast.is_some() {
         top_anchor
-    } else if let Some(gone) = app.broadcast_panel_gone_at {
+    } else if let (true, Some(gone)) = (motion, app.broadcast_panel_gone_at) {
         let t = now.saturating_duration_since(gone).as_secs_f32() / TOAST_ANIM.as_secs_f32();
         lerp_u16(top_anchor, low_anchor, ease_out(t.clamp(0.0, 1.0)))
     } else {
@@ -398,8 +399,11 @@ pub fn render_broadcast_toasts(frame: &mut Frame, body: Rect, app: &App) {
 
         // Slide progress from `born`: in for the first TOAST_ANIM, hold, then out
         // once past TOAST_TTL. No stored state — all derived from elapsed time.
+        // Under reduced motion the toast just sits at rest and blinks out at TTL.
         let elapsed = now.saturating_duration_since(toast.born);
-        let x = if elapsed >= TOAST_TTL {
+        let x = if !motion {
+            target_x
+        } else if elapsed >= TOAST_TTL {
             let t = (elapsed - TOAST_TTL).as_secs_f32() / TOAST_ANIM.as_secs_f32();
             lerp_u16(target_x, off_right, ease_out(t.clamp(0.0, 1.0)))
         } else {

--- a/src/tui/screens/field_picker.rs
+++ b/src/tui/screens/field_picker.rs
@@ -60,6 +60,8 @@ pub fn render_field_picker(frame: &mut Frame, app: &App) {
     let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
     let popup = Rect::new(x, y, popup_w, popup_h);
 
+    let popup = crate::tui::popup_open_rect(popup, app);
+
     frame.render_widget(Clear, popup);
     frame.render_widget(
         Block::default()

--- a/src/tui/screens/group_form.rs
+++ b/src/tui/screens/group_form.rs
@@ -37,6 +37,8 @@ pub fn render_group_field_picker(frame: &mut Frame, app: &App) {
     let y = area.y + (area.height.saturating_sub(height)) / 2;
     let popup = Rect::new(x, y, width, height);
 
+    let popup = crate::tui::popup_open_rect(popup, app);
+
     frame.render_widget(Clear, popup);
     let block = Block::default()
         .borders(Borders::ALL)

--- a/src/tui/screens/group_manage.rs
+++ b/src/tui/screens/group_manage.rs
@@ -18,6 +18,8 @@ pub fn render_group_manage_popup(frame: &mut Frame, app: &App) {
     let y = area.y + (area.height.saturating_sub(height)) / 2;
     let popup = Rect::new(x, y, width, height);
 
+    let popup = crate::tui::popup_open_rect(popup, app);
+
     frame.render_widget(Clear, popup);
     let block = Block::default()
         .borders(Borders::ALL)

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -153,11 +153,15 @@ fn help_lines() -> Vec<Line<'static>> {
         entry("[sftp]", ""),
         entry("2", "Open the SFTP tab"),
         entry("Enter", "Connect to host · descend into dir · fold group"),
-        entry("Tab", "Switch focus between local and remote pane"),
-        entry("Backspace", "Up one directory"),
+        entry("Tab", "Switch focus between the two panes"),
+        entry("Backspace", "Up one directory (or select the \"..\" row)"),
         entry(
             "\u{2190} / \u{2192}",
-            "Stage download / upload (files or whole folders)",
+            "Stage the focused pane's selection toward the other one",
+        ),
+        entry(
+            "o / O",
+            "Point the left pane at a second server / back to local files",
         ),
         entry("c / u", "Run queue / remove last queued transfer"),
         entry("d", "Delete selected file/folder (recursive)"),

--- a/src/tui/screens/keybind_editor.rs
+++ b/src/tui/screens/keybind_editor.rs
@@ -20,6 +20,8 @@ pub fn render_keybind_editor(frame: &mut Frame, app: &App) {
     let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
     let popup = Rect::new(x, y, popup_w, popup_h);
 
+    let popup = crate::tui::popup_open_rect(popup, app);
+
     frame.render_widget(Clear, popup);
     frame.render_widget(
         Block::default()

--- a/src/tui/screens/keys.rs
+++ b/src/tui/screens/keys.rs
@@ -84,22 +84,34 @@ pub fn render_keys(frame: &mut Frame, area: Rect, app: &App) {
     let row_offset = app.keys_scroll_row_offset(area.height, cpr, row_stride);
     let window_end_row = row_offset + visible_rows;
 
+    // Scroll by lines rather than whole card rows (#35): the grid slides under
+    // the selection instead of jumping a card height at a time. Cards are drawn
+    // into a taller scratch buffer, padded by one row above and below, so a card
+    // half-way off either edge is clipped by the blit rather than spilling over
+    // the panels around it.
+    let pad = row_stride;
+    let scroll = app.keys_scroll_advance(row_offset * row_stride as usize);
+    let ext = Rect::new(area.x, area.y, area.width, area.height + pad * 2);
+    let mut layer = Buffer::empty(ext);
     for (i, identity) in app.identities.iter().enumerate() {
         let row = i / cpr;
-        if row < row_offset {
+        // Draw a card once any part of it is at or below the top of the view,
+        // and stop once one starts past the bottom. With `pad` == one card row
+        // of slack on each side, the first drawn card can be at most `pad`
+        // above the view, which the padded buffer has room for.
+        let top = (row as u16) * row_stride;
+        if top + row_stride < scroll || top >= scroll + area.height {
             continue;
-        }
-        if row >= window_end_row {
-            break;
         }
 
         let col = i % cpr;
         let card_x = inner_x + (col as u16) * (card_w + CARD_GAP);
-        let y = area.y + ((row - row_offset) as u16) * row_stride;
+        let y = area.y + pad + top - scroll;
 
         let is_selected = i == app.identity_selected;
-        render_card(buf, card_x, y, card_w, identity, is_selected, agent);
+        render_card(&mut layer, card_x, y, card_w, identity, is_selected, agent);
     }
+    crate::tui::blit::blit(buf, ext, area, &layer, 0, -(pad as i32));
 
     // Agent info below the visible cards (only when there is room left).
     let drawn_rows = window_end_row.min(total_rows).saturating_sub(row_offset);

--- a/src/tui/screens/palette.rs
+++ b/src/tui/screens/palette.rs
@@ -1,7 +1,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear};
 
-use crate::app::HostEntry;
+use crate::app::{App, HostEntry};
 use crate::tui::theme;
 
 /// Maximum number of result rows visible in the palette list.
@@ -15,6 +15,7 @@ const MAX_VISIBLE_ROWS: usize = 12;
 /// * `selected` – which row inside `filtered` is highlighted (0-based).
 pub fn render_palette(
     frame: &mut Frame,
+    app: &App,
     query: &str,
     hosts: &[HostEntry],
     filtered: &[usize],
@@ -30,6 +31,7 @@ pub fn render_palette(
     let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
+    let popup_area = crate::tui::popup_open_rect(popup_area, app);
 
     frame.render_widget(Clear, popup_area);
 

--- a/src/tui/screens/session_host_picker.rs
+++ b/src/tui/screens/session_host_picker.rs
@@ -21,6 +21,8 @@ pub fn render(frame: &mut Frame, app: &App) {
     let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
     let popup = Rect::new(x, y, popup_w, popup_h);
 
+    let popup = crate::tui::popup_open_rect(popup, app);
+
     frame.render_widget(Clear, popup);
     frame.render_widget(
         ratatui::widgets::Block::default()

--- a/src/tui/screens/settings.rs
+++ b/src/tui/screens/settings.rs
@@ -15,6 +15,8 @@ pub fn render_settings(frame: &mut Frame, app: &App) {
     let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
     let popup = Rect::new(x, y, popup_w, popup_h);
 
+    let popup = crate::tui::popup_open_rect(popup, app);
+
     frame.render_widget(Clear, popup);
     frame.render_widget(
         Block::default()

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -57,7 +57,14 @@ fn render_rest(frame: &mut Frame, area: Rect, app: &App) {
         }
         Some(state) => {
             let fill = app.sftp_progress_advance(progress_fraction(state));
-            render_browser(frame.buffer_mut(), area, state, fill, staged_fly_in(app))
+            render_browser(
+                frame.buffer_mut(),
+                area,
+                state,
+                fill,
+                staged_fly_in(app),
+                nav_offsets(app, area),
+            )
         }
     }
 }
@@ -106,6 +113,7 @@ fn render_slide(frame: &mut Frame, area: Rect, app: &App, kind: SftpAnim, p: f32
                 state,
                 app.sftp_progress_advance(progress_fraction(state)),
                 staged_fly_in(app),
+                nav_offsets(app, area),
             );
             blit_panes(frame.buffer_mut(), area, &layer, 1.0 - e);
             // Same for an Esc landing mid-slide: the panes part from the rest
@@ -183,7 +191,14 @@ fn render_picker(frame: &mut Frame, area: Rect, app: &App) {
 
 // ── Browser sub-state ────────────────────────────────────────
 
-fn render_browser(buf: &mut Buffer, area: Rect, state: &SftpState, fill: f32, staged: f32) {
+fn render_browser(
+    buf: &mut Buffer,
+    area: Rect,
+    state: &SftpState,
+    fill: f32,
+    staged: f32,
+    nav: [i32; 2],
+) {
     let progress_h: u16 = if state.phase == Phase::Running { 1 } else { 0 };
     let queue_h: u16 = if state.queue.is_empty() {
         1
@@ -214,6 +229,11 @@ fn render_browser(buf: &mut Buffer, area: Rect, state: &SftpState, fill: f32, st
         state.focus == Focus::Remote,
         state.searching && state.focus == Focus::Remote,
     );
+
+    // Slide each pane's listing to its new directory, inside its own border so
+    // the box itself stays put (#35).
+    slide_listing(buf, local_rect, nav[0]);
+    slide_listing(buf, remote_rect, nav[1]);
 
     let queue_y = area.y + panes_h;
     render_queue(
@@ -410,6 +430,48 @@ fn render_queue(
             buf.set_string(x + 4, yy, clamped, style);
         }
     }
+}
+
+/// Shift a pane's listing by `dx` columns within its border, leaving whatever
+/// it vacates blank, so a new directory rides in from the side it came from.
+fn slide_listing(buf: &mut Buffer, pane: Rect, dx: i32) {
+    if dx == 0 || pane.width < 3 || pane.height < 3 {
+        return;
+    }
+    let inner = Rect::new(pane.x + 1, pane.y + 1, pane.width - 2, pane.height - 2);
+    let layer = blit::snapshot(buf, inner);
+    for y in inner.top()..inner.bottom() {
+        for x in inner.left()..inner.right() {
+            if let Some(c) = buf.cell_mut((x, y)) {
+                c.reset();
+            }
+        }
+    }
+    blit::blit(buf, inner, inner, &layer, dx, 0);
+}
+
+/// Column offsets for the two panes' directory slides (#35): the listing
+/// starts a pane-width to one side and eases home. Descending into a child
+/// comes in from the right, stepping back out from the left.
+fn nav_offsets(app: &App, area: Rect) -> [i32; 2] {
+    let half = (area.width / 2) as f32;
+    let now = std::time::Instant::now();
+    std::array::from_fn(|i| {
+        let Some((deeper, at)) = app.sftp_nav[i] else {
+            return 0;
+        };
+        let p = tween::progress(at, crate::tui::SFTP_NAV_ANIM, now);
+        if p >= 1.0 {
+            return 0;
+        }
+        let travel = (1.0 - tween::ease_out(p)) * half;
+        let dx = travel.round() as i32;
+        if deeper {
+            dx
+        } else {
+            -dx
+        }
+    })
 }
 
 /// How far the newest queue row has flown in, `0.0` to `1.0` (#35). `1.0` at

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -213,14 +213,20 @@ fn render_browser(
     let local_rect = Rect::new(area.x, area.y, half, panes_h);
     let remote_rect = Rect::new(area.x + half, area.y, area.width - half, panes_h);
 
+    // The left pane is the local filesystem by default, but can be pointed at
+    // a second server -- in which case it carries that host's name.
+    let left_title = state.left_host.as_deref().unwrap_or("local");
     render_pane(
         buf,
         local_rect,
         &state.local,
-        "local",
+        left_title,
         state.focus == Focus::Local,
         state.searching && state.focus == Focus::Local,
     );
+    if state.left_connecting {
+        render_connecting(buf, local_rect, state.left_host.as_deref());
+    }
     render_pane(
         buf,
         remote_rect,
@@ -385,7 +391,8 @@ fn render_queue(
         let (text, style) = match notice {
             Some(n) => (format!("⚠ {n}"), theme::amber()),
             None => (
-                "queue: empty  (← download · → upload · u remove · c run)".to_string(),
+                "queue: empty  (← download · → upload · u remove · c run · o second host)"
+                    .to_string(),
                 theme::dim(),
             ),
         };

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -20,6 +20,7 @@ use ratatui::prelude::*;
 
 use crate::app::{App, SftpAnim};
 use crate::sftp::model::{Direction, Focus, Pane, Phase, SftpState};
+use crate::tui::blit;
 use crate::tui::text::ellipsize;
 use crate::tui::theme;
 use crate::tui::tween;
@@ -41,7 +42,7 @@ pub fn render_sftp(frame: &mut Frame, area: Rect, app: &App) {
     }
     render_rest(frame, area, app);
     if app.sftp.is_some() && app.motion_enabled() {
-        *app.sftp_snapshot.borrow_mut() = Some(snapshot_area(frame.buffer_mut(), area));
+        *app.sftp_snapshot.borrow_mut() = Some(blit::snapshot(frame.buffer_mut(), area));
     }
 }
 
@@ -76,7 +77,7 @@ fn render_slide(frame: &mut Frame, area: Rect, app: &App, kind: SftpAnim, p: f32
             let mut layer = Buffer::empty(area);
             render_connecting(&mut layer, area, app.sftp_host.as_deref());
             let dx = ((1.0 - e) * area.width as f32).round() as i32;
-            blit_shifted(frame.buffer_mut(), area, area, &layer, dx);
+            blit::blit(frame.buffer_mut(), area, area, &layer, dx, 0);
             // Keep the resting layer around: a host that fails before the slide
             // even lands still has cells to carry back out.
             *app.sftp_snapshot.borrow_mut() = Some(layer);
@@ -85,7 +86,7 @@ fn render_slide(frame: &mut Frame, area: Rect, app: &App, kind: SftpAnim, p: f32
             render_picker(frame, area, app);
             if let Some(src) = app.sftp_snapshot.borrow().as_ref() {
                 let dx = (e * area.width as f32).round() as i32;
-                blit_shifted(frame.buffer_mut(), area, area, src, dx);
+                blit::blit(frame.buffer_mut(), area, area, src, dx, 0);
             }
         }
         SftpAnim::PanesIn => {
@@ -119,45 +120,15 @@ fn blit_panes(dst: &mut Buffer, area: Rect, src: &Buffer, k: f32) {
     let half = area.width / 2;
     let left = Rect::new(area.x, area.y, half, area.height);
     let right = Rect::new(area.x + half, area.y, area.width - half, area.height);
-    blit_shifted(dst, left, area, src, -((half as f32 * k).round() as i32));
-    blit_shifted(
+    blit::blit(dst, left, area, src, -((half as f32 * k).round() as i32), 0);
+    blit::blit(
         dst,
         right,
         area,
         src,
         (right.width as f32 * k).round() as i32,
+        0,
     );
-}
-
-/// Copy the `region` cells of `src` into `dst` shifted `dx` columns, clipped to
-/// `clip`. `src` is always a standalone buffer (never `dst` itself), so the copy
-/// order doesn't matter.
-fn blit_shifted(dst: &mut Buffer, region: Rect, clip: Rect, src: &Buffer, dx: i32) {
-    for y in region.top()..region.bottom() {
-        for x in region.left()..region.right() {
-            let tx = x as i32 + dx;
-            if tx < clip.left() as i32 || tx >= clip.right() as i32 {
-                continue;
-            }
-            if let (Some(s), Some(d)) = (src.cell((x, y)), dst.cell_mut((tx as u16, y))) {
-                *d = s.clone();
-            }
-        }
-    }
-}
-
-/// Clone the `area` cells of `src` into a standalone buffer keeping the same
-/// absolute coordinates, so a later frame can blit them while sliding.
-fn snapshot_area(src: &Buffer, area: Rect) -> Buffer {
-    let mut out = Buffer::empty(area);
-    for y in area.top()..area.bottom() {
-        for x in area.left()..area.right() {
-            if let (Some(s), Some(d)) = (src.cell((x, y)), out.cell_mut((x, y))) {
-                *d = s.clone();
-            }
-        }
-    }
-    out
 }
 
 /// Centered "connecting to <host>…" placeholder shown while the SFTP worker is
@@ -479,29 +450,6 @@ mod tests {
     }
 
     #[test]
-    fn blit_shifted_moves_cells_and_clips_at_the_edges() {
-        let a = area();
-        let src = ruler(a);
-        let mut dst = Buffer::empty(a);
-        blit_shifted(&mut dst, a, a, &src, 3);
-        // Columns 2..4 slid in from off the left edge (nothing wrote them);
-        // the rest carry the source columns three to the right.
-        assert_eq!(row(&dst, a, 1), "   23456");
-        // The three source columns pushed past the right edge are dropped, not
-        // wrapped or written out of bounds.
-        assert_eq!(row(&dst, a, 2), "   23456");
-    }
-
-    #[test]
-    fn blit_shifted_zero_offset_is_a_plain_copy() {
-        let a = area();
-        let src = ruler(a);
-        let mut dst = Buffer::empty(a);
-        blit_shifted(&mut dst, a, a, &src, 0);
-        assert_eq!(row(&dst, a, 1), row(&src, a, 1));
-    }
-
-    #[test]
     fn blit_panes_at_rest_reproduces_the_source() {
         let a = area();
         let src = ruler(a);
@@ -531,14 +479,5 @@ mod tests {
         // the body and the gap they open sits in the middle.
         blit_panes(&mut dst, a, &src, 0.5);
         assert_eq!(row(&dst, a, 1), "45    67");
-    }
-
-    #[test]
-    fn snapshot_area_copies_the_body_verbatim() {
-        let a = area();
-        let src = ruler(a);
-        let snap = snapshot_area(&src, a);
-        assert_eq!(row(&snap, a, 1), row(&src, a, 1));
-        assert_eq!(row(&snap, a, 2), row(&src, a, 2));
     }
 }

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -24,8 +24,24 @@ pub fn render_sftp(frame: &mut Frame, area: Rect, app: &App) {
     }
     match app.sftp.as_ref() {
         None => render_picker(frame, area, app),
+        // Still handshaking: show a "connecting…" line, not empty panes. An
+        // unreachable host fails into the Notice popup (never a blank browser).
+        Some(state) if state.connecting => render_connecting(frame, area, app.sftp_host.as_deref()),
         Some(state) => render_browser(frame, area, state),
     }
+}
+
+/// Centered "connecting to <host>…" placeholder shown while the SFTP worker is
+/// still establishing the session.
+fn render_connecting(frame: &mut Frame, area: Rect, host: Option<&str>) {
+    let msg = match host {
+        Some(h) => format!("\u{27F3} Connecting to {h}\u{2026}"),
+        None => "\u{27F3} Connecting\u{2026}".to_string(),
+    };
+    let w = (msg.chars().count() as u16).min(area.width);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + area.height / 2;
+    frame.buffer_mut().set_string(x, y, &msg, theme::amber());
 }
 
 // ── Picker sub-state ─────────────────────────────────────────

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -55,7 +55,10 @@ fn render_rest(frame: &mut Frame, area: Rect, app: &App) {
         Some(state) if state.connecting => {
             render_connecting(frame.buffer_mut(), area, app.sftp_host.as_deref())
         }
-        Some(state) => render_browser(frame.buffer_mut(), area, state),
+        Some(state) => {
+            let fill = app.sftp_progress_advance(progress_fraction(state));
+            render_browser(frame.buffer_mut(), area, state, fill)
+        }
     }
 }
 
@@ -97,7 +100,12 @@ fn render_slide(frame: &mut Frame, area: Rect, app: &App, kind: SftpAnim, p: f32
             // very line that was reporting the handshake.
             render_connecting(frame.buffer_mut(), area, app.sftp_host.as_deref());
             let mut layer = Buffer::empty(area);
-            render_browser(&mut layer, area, state);
+            render_browser(
+                &mut layer,
+                area,
+                state,
+                app.sftp_progress_advance(progress_fraction(state)),
+            );
             blit_panes(frame.buffer_mut(), area, &layer, 1.0 - e);
             // Same for an Esc landing mid-slide: the panes part from the rest
             // position rather than snapping to it first.
@@ -174,7 +182,7 @@ fn render_picker(frame: &mut Frame, area: Rect, app: &App) {
 
 // ── Browser sub-state ────────────────────────────────────────
 
-fn render_browser(buf: &mut Buffer, area: Rect, state: &SftpState) {
+fn render_browser(buf: &mut Buffer, area: Rect, state: &SftpState, fill: f32) {
     let progress_h: u16 = if state.phase == Phase::Running { 1 } else { 0 };
     let queue_h: u16 = if state.queue.is_empty() {
         1
@@ -218,7 +226,7 @@ fn render_browser(buf: &mut Buffer, area: Rect, state: &SftpState) {
 
     if progress_h > 0 {
         let py = area.y + area.height.saturating_sub(1);
-        render_progress(buf, area.x, py, area.width, state);
+        render_progress(buf, area.x, py, area.width, state, fill);
     }
 }
 
@@ -385,7 +393,22 @@ fn render_queue(
     }
 }
 
-fn render_progress(buf: &mut Buffer, x: u16, y: u16, w: u16, state: &SftpState) {
+/// How far the running transfer has got, `0.0` to `1.0`. Zero when nothing is
+/// running or the size is unknown, which the bar draws as empty.
+fn progress_fraction(state: &SftpState) -> f32 {
+    match state.progress {
+        Some(p) if p.size > 0 => (p.transferred as f32 / p.size as f32).clamp(0.0, 1.0),
+        _ => 0.0,
+    }
+}
+
+/// Eighth-width block glyphs, for a bar that can end part-way through a cell.
+const BAR_PARTIALS: [&str; 7] = ["▏", "▎", "▍", "▌", "▋", "▊", "▉"];
+
+/// Progress line for the running queue: a filled bar under the numbers, drawn
+/// at `fill` (the smoothed figure, #35) so it sweeps between the worker's
+/// chunked updates instead of stepping.
+fn render_progress(buf: &mut Buffer, x: u16, y: u16, w: u16, state: &SftpState, fill: f32) {
     let s = if let Some(p) = state.progress {
         let pct = if p.size > 0 {
             (p.transferred as f64 / p.size as f64 * 100.0) as u32
@@ -403,7 +426,29 @@ fn render_progress(buf: &mut Buffer, x: u16, y: u16, w: u16, state: &SftpState) 
         "running…".to_string()
     };
     let clamped = ellipsize(&s, w.saturating_sub(4) as usize);
+    let label_w = clamped.chars().count() as u16;
     buf.set_string(x + 2, y, clamped, theme::amber());
+
+    // Bar in whatever is left of the line, right of the numbers.
+    let bar_x = x + 3 + label_w;
+    let bar_w = (x + w).saturating_sub(bar_x + 2);
+    if bar_w < 4 {
+        return;
+    }
+    let units = (bar_w as f32 * 8.0 * fill.clamp(0.0, 1.0)).round() as u16;
+    let full = units / 8;
+    let rem = (units % 8) as usize;
+    for i in 0..bar_w {
+        let cell_x = bar_x + i;
+        let (glyph, style) = if i < full {
+            ("█", theme::green())
+        } else if i == full && rem > 0 {
+            (BAR_PARTIALS[rem - 1], theme::green())
+        } else {
+            ("░", theme::dim())
+        };
+        buf.set_string(cell_x, y, glyph, style);
+    }
 }
 
 fn human_size(bytes: u64) -> String {

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -163,9 +163,12 @@ fn snapshot_area(src: &Buffer, area: Rect) -> Buffer {
 /// Centered "connecting to <host>…" placeholder shown while the SFTP worker is
 /// still establishing the session.
 fn render_connecting(buf: &mut Buffer, area: Rect, host: Option<&str>) {
+    // Same braille spinner the session connect screen turns, so a handshake
+    // reads as in flight rather than hung.
+    let spin = tween::spinner_frame_now();
     let msg = match host {
-        Some(h) => format!("\u{27F3} Connecting to {h}\u{2026}"),
-        None => "\u{27F3} Connecting\u{2026}".to_string(),
+        Some(h) => format!("{spin} Connecting to {h}\u{2026}"),
+        None => format!("{spin} Connecting\u{2026}"),
     };
     let w = (msg.chars().count() as u16).min(area.width);
     let x = area.x + (area.width.saturating_sub(w)) / 2;

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -1,9 +1,15 @@
 //! SFTP tab body renderer.
 //!
-//! Two sub-states, mirroring `app.sftp`:
+//! Three sub-states, mirroring `app.sftp`:
 //! - `None` → **picker**: reuse the grouped hosts panel + a "connect" hint.
+//! - `Some(state)` with `connecting` → **placeholder**: a centered
+//!   "connecting…" line while the worker handshakes.
 //! - `Some(state)` → **browser**: two bordered columns (left local / right
 //!   remote), a queue strip, and a progress line while a run is in flight.
+//!
+//! Swapping between them slides (#35): the placeholder rides in and out on the
+//! right edge, the two browser panes meet in the middle and part again toward
+//! their own edges. See [`render_slide`].
 //!
 //! Signature matches the other screens (`render_<name>(frame, area, app)`);
 //! `tui/mod.rs` wires it through a local `render_sftp_body` wrapper.
@@ -12,28 +18,151 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::prelude::*;
 
-use crate::app::App;
+use crate::app::{App, SftpAnim};
 use crate::sftp::model::{Direction, Focus, Pane, Phase, SftpState};
 use crate::tui::text::ellipsize;
 use crate::tui::theme;
+use crate::tui::tween;
 use crate::tui::widgets::panel_box::render_panel_box;
+use crate::tui::SFTP_ANIM;
 
 pub fn render_sftp(frame: &mut Frame, area: Rect, app: &App) {
     if area.height < 3 || area.width < 8 {
         return;
     }
+    // A sub-state slide (#35) owns the body for its duration; the resting frames
+    // also leave a snapshot behind so the next slide *out* has cells to carry.
+    if let Some((kind, at)) = app.sftp_anim.filter(|_| app.motion_enabled()) {
+        let p = tween::progress(at, SFTP_ANIM, std::time::Instant::now());
+        if p < 1.0 {
+            render_slide(frame, area, app, kind, p);
+            return;
+        }
+    }
+    render_rest(frame, area, app);
+    if app.sftp.is_some() && app.motion_enabled() {
+        *app.sftp_snapshot.borrow_mut() = Some(snapshot_area(frame.buffer_mut(), area));
+    }
+}
+
+/// The SFTP body at rest: picker, "connecting…" placeholder, or live browser.
+fn render_rest(frame: &mut Frame, area: Rect, app: &App) {
     match app.sftp.as_ref() {
         None => render_picker(frame, area, app),
         // Still handshaking: show a "connecting…" line, not empty panes. An
         // unreachable host fails into the Notice popup (never a blank browser).
-        Some(state) if state.connecting => render_connecting(frame, area, app.sftp_host.as_deref()),
-        Some(state) => render_browser(frame, area, state),
+        Some(state) if state.connecting => {
+            render_connecting(frame.buffer_mut(), area, app.sftp_host.as_deref())
+        }
+        Some(state) => render_browser(frame.buffer_mut(), area, state),
     }
+}
+
+// ── Sub-state slides (#35) ───────────────────────────────────
+
+/// Draw one frame of an SFTP sub-state slide.
+///
+/// The layer that is arriving (or leaving) is rendered into a standalone buffer
+/// — or read back from the snapshot, when its state is already gone — and then
+/// blitted at an eased offset over the layer it replaces. `ConnectIn` /
+/// `ConnectOut` move the whole "connecting…" placeholder along the right edge;
+/// `PanesIn` / `PanesOut` split at the pane boundary so each half travels to its
+/// own edge, and the two panels meet in the middle.
+fn render_slide(frame: &mut Frame, area: Rect, app: &App, kind: SftpAnim, p: f32) {
+    let e = tween::ease_out(p);
+    match kind {
+        SftpAnim::ConnectIn => {
+            render_picker(frame, area, app);
+            let mut layer = Buffer::empty(area);
+            render_connecting(&mut layer, area, app.sftp_host.as_deref());
+            let dx = ((1.0 - e) * area.width as f32).round() as i32;
+            blit_shifted(frame.buffer_mut(), area, area, &layer, dx);
+            // Keep the resting layer around: a host that fails before the slide
+            // even lands still has cells to carry back out.
+            *app.sftp_snapshot.borrow_mut() = Some(layer);
+        }
+        SftpAnim::ConnectOut => {
+            render_picker(frame, area, app);
+            if let Some(src) = app.sftp_snapshot.borrow().as_ref() {
+                let dx = (e * area.width as f32).round() as i32;
+                blit_shifted(frame.buffer_mut(), area, area, src, dx);
+            }
+        }
+        SftpAnim::PanesIn => {
+            let Some(state) = app.sftp.as_ref() else {
+                return;
+            };
+            // The placeholder stays put underneath, so the panes close over the
+            // very line that was reporting the handshake.
+            render_connecting(frame.buffer_mut(), area, app.sftp_host.as_deref());
+            let mut layer = Buffer::empty(area);
+            render_browser(&mut layer, area, state);
+            blit_panes(frame.buffer_mut(), area, &layer, 1.0 - e);
+            // Same for an Esc landing mid-slide: the panes part from the rest
+            // position rather than snapping to it first.
+            *app.sftp_snapshot.borrow_mut() = Some(layer);
+        }
+        SftpAnim::PanesOut => {
+            render_picker(frame, area, app);
+            if let Some(src) = app.sftp_snapshot.borrow().as_ref() {
+                blit_panes(frame.buffer_mut(), area, src, e);
+            }
+        }
+    }
+}
+
+/// Blit the two browser halves of `src` pushed `k` of the way toward their own
+/// edge: `k == 0` is at rest (panes met in the middle), `k == 1` fully off both
+/// sides.
+fn blit_panes(dst: &mut Buffer, area: Rect, src: &Buffer, k: f32) {
+    // Same split as `render_browser`, so each half carries exactly its pane.
+    let half = area.width / 2;
+    let left = Rect::new(area.x, area.y, half, area.height);
+    let right = Rect::new(area.x + half, area.y, area.width - half, area.height);
+    blit_shifted(dst, left, area, src, -((half as f32 * k).round() as i32));
+    blit_shifted(
+        dst,
+        right,
+        area,
+        src,
+        (right.width as f32 * k).round() as i32,
+    );
+}
+
+/// Copy the `region` cells of `src` into `dst` shifted `dx` columns, clipped to
+/// `clip`. `src` is always a standalone buffer (never `dst` itself), so the copy
+/// order doesn't matter.
+fn blit_shifted(dst: &mut Buffer, region: Rect, clip: Rect, src: &Buffer, dx: i32) {
+    for y in region.top()..region.bottom() {
+        for x in region.left()..region.right() {
+            let tx = x as i32 + dx;
+            if tx < clip.left() as i32 || tx >= clip.right() as i32 {
+                continue;
+            }
+            if let (Some(s), Some(d)) = (src.cell((x, y)), dst.cell_mut((tx as u16, y))) {
+                *d = s.clone();
+            }
+        }
+    }
+}
+
+/// Clone the `area` cells of `src` into a standalone buffer keeping the same
+/// absolute coordinates, so a later frame can blit them while sliding.
+fn snapshot_area(src: &Buffer, area: Rect) -> Buffer {
+    let mut out = Buffer::empty(area);
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            if let (Some(s), Some(d)) = (src.cell((x, y)), out.cell_mut((x, y))) {
+                *d = s.clone();
+            }
+        }
+    }
+    out
 }
 
 /// Centered "connecting to <host>…" placeholder shown while the SFTP worker is
 /// still establishing the session.
-fn render_connecting(frame: &mut Frame, area: Rect, host: Option<&str>) {
+fn render_connecting(buf: &mut Buffer, area: Rect, host: Option<&str>) {
     let msg = match host {
         Some(h) => format!("\u{27F3} Connecting to {h}\u{2026}"),
         None => "\u{27F3} Connecting\u{2026}".to_string(),
@@ -41,7 +170,7 @@ fn render_connecting(frame: &mut Frame, area: Rect, host: Option<&str>) {
     let w = (msg.chars().count() as u16).min(area.width);
     let x = area.x + (area.width.saturating_sub(w)) / 2;
     let y = area.y + area.height / 2;
-    frame.buffer_mut().set_string(x, y, &msg, theme::amber());
+    buf.set_string(x, y, &msg, theme::amber());
 }
 
 // ── Picker sub-state ─────────────────────────────────────────
@@ -71,7 +200,7 @@ fn render_picker(frame: &mut Frame, area: Rect, app: &App) {
 
 // ── Browser sub-state ────────────────────────────────────────
 
-fn render_browser(frame: &mut Frame, area: Rect, state: &SftpState) {
+fn render_browser(buf: &mut Buffer, area: Rect, state: &SftpState) {
     let progress_h: u16 = if state.phase == Phase::Running { 1 } else { 0 };
     let queue_h: u16 = if state.queue.is_empty() {
         1
@@ -86,7 +215,6 @@ fn render_browser(frame: &mut Frame, area: Rect, state: &SftpState) {
     let local_rect = Rect::new(area.x, area.y, half, panes_h);
     let remote_rect = Rect::new(area.x + half, area.y, area.width - half, panes_h);
 
-    let buf = frame.buffer_mut();
     render_pane(
         buf,
         local_rect,
@@ -316,5 +444,98 @@ fn human_size(bytes: u64) -> String {
         format!("{bytes}{}", UNITS[0])
     } else {
         format!("{v:.1}{}", UNITS[i])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn area() -> Rect {
+        Rect::new(2, 1, 8, 2)
+    }
+
+    /// A source buffer whose every cell carries its own column as a symbol, so a
+    /// blit's offset is readable straight off the destination row.
+    fn ruler(area: Rect) -> Buffer {
+        let mut b = Buffer::empty(area);
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                b.cell_mut((x, y))
+                    .unwrap()
+                    .set_symbol(&format!("{}", x % 10));
+            }
+        }
+        b
+    }
+
+    fn row(buf: &Buffer, area: Rect, y: u16) -> String {
+        (area.left()..area.right())
+            .map(|x| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn blit_shifted_moves_cells_and_clips_at_the_edges() {
+        let a = area();
+        let src = ruler(a);
+        let mut dst = Buffer::empty(a);
+        blit_shifted(&mut dst, a, a, &src, 3);
+        // Columns 2..4 slid in from off the left edge (nothing wrote them);
+        // the rest carry the source columns three to the right.
+        assert_eq!(row(&dst, a, 1), "   23456");
+        // The three source columns pushed past the right edge are dropped, not
+        // wrapped or written out of bounds.
+        assert_eq!(row(&dst, a, 2), "   23456");
+    }
+
+    #[test]
+    fn blit_shifted_zero_offset_is_a_plain_copy() {
+        let a = area();
+        let src = ruler(a);
+        let mut dst = Buffer::empty(a);
+        blit_shifted(&mut dst, a, a, &src, 0);
+        assert_eq!(row(&dst, a, 1), row(&src, a, 1));
+    }
+
+    #[test]
+    fn blit_panes_at_rest_reproduces_the_source() {
+        let a = area();
+        let src = ruler(a);
+        let mut dst = Buffer::empty(a);
+        blit_panes(&mut dst, a, &src, 0.0);
+        assert_eq!(row(&dst, a, 1), row(&src, a, 1));
+    }
+
+    #[test]
+    fn blit_panes_fully_pushed_leaves_nothing_behind() {
+        let a = area();
+        let src = ruler(a);
+        let mut dst = Buffer::empty(a);
+        blit_panes(&mut dst, a, &src, 1.0);
+        // Both halves have travelled their own width to opposite edges, so every
+        // cell inside the body is still the untouched (blank) destination.
+        assert_eq!(row(&dst, a, 1), " ".repeat(a.width as usize));
+    }
+
+    #[test]
+    fn blit_panes_halves_move_in_opposite_directions() {
+        let a = area();
+        let src = ruler(a);
+        let mut dst = Buffer::empty(a);
+        // Half of the way out: the left pane (4 wide) is 2 columns left of rest
+        // and the right pane 2 columns right, so half of each has already left
+        // the body and the gap they open sits in the middle.
+        blit_panes(&mut dst, a, &src, 0.5);
+        assert_eq!(row(&dst, a, 1), "45    67");
+    }
+
+    #[test]
+    fn snapshot_area_copies_the_body_verbatim() {
+        let a = area();
+        let src = ruler(a);
+        let snap = snapshot_area(&src, a);
+        assert_eq!(row(&snap, a, 1), row(&src, a, 1));
+        assert_eq!(row(&snap, a, 2), row(&src, a, 2));
     }
 }

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -338,7 +338,10 @@ fn render_pane(
         }
 
         let marker = if active { "▸ " } else { "  " };
-        let size_str = if entry.is_dir {
+        // The ".." row is a way out, not a listing entry: no size badge.
+        let size_str = if entry.is_parent() {
+            String::new()
+        } else if entry.is_dir {
             "<dir>".to_string()
         } else {
             human_size(entry.size)

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -57,7 +57,7 @@ fn render_rest(frame: &mut Frame, area: Rect, app: &App) {
         }
         Some(state) => {
             let fill = app.sftp_progress_advance(progress_fraction(state));
-            render_browser(frame.buffer_mut(), area, state, fill)
+            render_browser(frame.buffer_mut(), area, state, fill, staged_fly_in(app))
         }
     }
 }
@@ -105,6 +105,7 @@ fn render_slide(frame: &mut Frame, area: Rect, app: &App, kind: SftpAnim, p: f32
                 area,
                 state,
                 app.sftp_progress_advance(progress_fraction(state)),
+                staged_fly_in(app),
             );
             blit_panes(frame.buffer_mut(), area, &layer, 1.0 - e);
             // Same for an Esc landing mid-slide: the panes part from the rest
@@ -182,7 +183,7 @@ fn render_picker(frame: &mut Frame, area: Rect, app: &App) {
 
 // ── Browser sub-state ────────────────────────────────────────
 
-fn render_browser(buf: &mut Buffer, area: Rect, state: &SftpState, fill: f32) {
+fn render_browser(buf: &mut Buffer, area: Rect, state: &SftpState, fill: f32, staged: f32) {
     let progress_h: u16 = if state.phase == Phase::Running { 1 } else { 0 };
     let queue_h: u16 = if state.queue.is_empty() {
         1
@@ -222,6 +223,7 @@ fn render_browser(buf: &mut Buffer, area: Rect, state: &SftpState, fill: f32) {
         area.width,
         &state.queue,
         state.notice.as_deref(),
+        staged,
     );
 
     if progress_h > 0 {
@@ -354,6 +356,7 @@ fn render_queue(
     w: u16,
     queue: &[crate::sftp::model::QueuedTransfer],
     notice: Option<&str>,
+    staged: f32,
 ) {
     if queue.is_empty() {
         let (text, style) = match notice {
@@ -381,6 +384,7 @@ fn render_queue(
         ellipsize(&header, w.saturating_sub(4) as usize),
         theme::heading(),
     );
+    let last = queue.len().saturating_sub(1);
     for (i, t) in queue.iter().take(4).enumerate() {
         let yy = y + 1 + i as u16;
         let (arrow, label, style) = match t.direction {
@@ -389,7 +393,38 @@ fn render_queue(
         };
         let s = format!("{arrow} {label}  {}", t.name);
         let clamped = ellipsize(&s, w.saturating_sub(6) as usize);
-        buf.set_string(x + 4, yy, clamped, style);
+        // A just-staged row flies in from the side the file is coming from:
+        // a download off the remote pane on the right, an upload off the local
+        // pane on the left (#35).
+        if i == last && staged < 1.0 {
+            let travel = (w as f32 * (1.0 - staged)).round() as i32;
+            let dx = match t.direction {
+                Direction::Download => travel,
+                Direction::Upload => -travel,
+            };
+            let strip = Rect::new(x, yy, w, 1);
+            let mut layer = Buffer::empty(strip);
+            layer.set_string(x + 4, yy, clamped, style);
+            blit::blit(buf, strip, strip, &layer, dx, 0);
+        } else {
+            buf.set_string(x + 4, yy, clamped, style);
+        }
+    }
+}
+
+/// How far the newest queue row has flown in, `0.0` to `1.0` (#35). `1.0` at
+/// rest, so a settled queue draws in place.
+fn staged_fly_in(app: &App) -> f32 {
+    if !app.motion_enabled() {
+        return 1.0;
+    }
+    match app.sftp_queue_at {
+        Some(at) => tween::ease_out(tween::progress(
+            at,
+            crate::tui::SFTP_QUEUE_ANIM,
+            std::time::Instant::now(),
+        )),
+        None => 1.0,
     }
 }
 

--- a/src/tui/screens/tag_filter.rs
+++ b/src/tui/screens/tag_filter.rs
@@ -45,6 +45,8 @@ pub fn render(frame: &mut Frame, app: &App) {
     let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
     let popup = Rect::new(x, y, popup_w, popup_h);
 
+    let popup = crate::tui::popup_open_rect(popup, app);
+
     frame.render_widget(Clear, popup);
     frame.render_widget(
         Block::default()

--- a/src/tui/screens/tunnel_reconnect.rs
+++ b/src/tui/screens/tunnel_reconnect.rs
@@ -15,6 +15,8 @@ pub fn render_tunnel_reconnect_settings(frame: &mut Frame, app: &App) {
     let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
     let popup = Rect::new(x, y, popup_w, popup_h);
 
+    let popup = crate::tui::popup_open_rect(popup, app);
+
     frame.render_widget(Clear, popup);
     frame.render_widget(
         Block::default()

--- a/src/tui/screens/tunnels.rs
+++ b/src/tui/screens/tunnels.rs
@@ -330,6 +330,8 @@ pub fn render_tunnel_form(frame: &mut Frame, app: &App) {
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
 
+    let popup_area = crate::tui::popup_open_rect(popup_area, app);
+
     frame.render_widget(Clear, popup_area);
 
     // Border
@@ -508,6 +510,8 @@ pub fn render_tunnel_host_picker(frame: &mut Frame, app: &App) {
     let x = area.x + (area.width.saturating_sub(popup_w)) / 2;
     let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
     let popup = Rect::new(x, y, popup_w, popup_h);
+
+    let popup = crate::tui::popup_open_rect(popup, app);
 
     frame.render_widget(Clear, popup);
     frame.render_widget(

--- a/src/tui/screens/tunnels.rs
+++ b/src/tui/screens/tunnels.rs
@@ -6,6 +6,9 @@ use crate::app::App;
 use crate::store::TunnelType;
 use crate::tui::theme;
 
+/// One breath of a reconnecting tunnel's status dot (#35).
+const TUNNEL_PULSE: std::time::Duration = std::time::Duration::from_millis(1100);
+
 pub fn render_tunnels(frame: &mut Frame, area: Rect, app: &App) {
     if area.height < 4 || area.width < 20 {
         return;
@@ -115,6 +118,7 @@ pub fn render_tunnels(frame: &mut Frame, area: Rect, app: &App) {
             app.tunnel_manager.reconnect_attempt(tunnel.id),
             app.tunnel_manager.reconnect_countdown_secs(tunnel.id),
             app.config.tunnel_reconnect.max_attempts,
+            app.motion_enabled(),
         );
     }
 
@@ -150,6 +154,7 @@ fn render_tunnel_row(
     reconnect_attempt: Option<u32>,
     reconnect_countdown: Option<u64>,
     max_attempts: u32,
+    motion: bool,
 ) {
     let running = status == "up";
     let base_style = if selected {
@@ -174,7 +179,20 @@ fn render_tunnel_row(
     let status_w = cols[0].1;
     let (dot, dot_color) = match status {
         "up" => ("●", theme::GREEN),
+        // Retrying: the dot breathes, so a tunnel working its way back reads
+        // as busy rather than parked on amber (#35).
+        "reconnecting" if motion => (
+            "●",
+            crate::tui::tween::color_lerp(
+                theme::AMBER,
+                theme::DIM,
+                crate::tui::tween::pulse_now(TUNNEL_PULSE),
+            ),
+        ),
         "reconnecting" => ("●", theme::AMBER),
+        // Coming up: the same spinner every other in-flight handshake turns.
+        "starting" if motion => (crate::tui::tween::spinner_frame_now(), theme::AMBER),
+        "starting" => ("○", theme::AMBER),
         "gave_up" | "error" => ("●", theme::RED),
         _ => ("○", theme::DIM),
     };

--- a/src/tui/tween.rs
+++ b/src/tui/tween.rs
@@ -7,6 +7,15 @@ use std::time::{Duration, Instant};
 
 use ratatui::layout::Rect;
 
+/// Easing curve applied by a [`SlideAnim`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Easing {
+    /// Front-loaded: fast then settling. Good for things flying in.
+    Out,
+    /// Symmetric: eases in and out. Good for A<->B morphs (zoom, tab swap).
+    InOut,
+}
+
 /// A rect slide from `from` to `to`, eased over `dur` starting at `start`.
 #[derive(Debug, Clone, Copy)]
 pub struct SlideAnim {
@@ -14,16 +23,28 @@ pub struct SlideAnim {
     pub to: Rect,
     pub start: Instant,
     pub dur: Duration,
+    pub easing: Easing,
 }
 
 impl SlideAnim {
-    /// Construct a slide whose clock starts now.
+    /// Construct an ease-out slide whose clock starts now.
     pub fn new(from: Rect, to: Rect, dur: Duration) -> Self {
+        Self::with_easing(from, to, dur, Easing::Out)
+    }
+
+    /// Construct an ease-in-out slide (symmetric morph) whose clock starts now.
+    pub fn new_in_out(from: Rect, to: Rect, dur: Duration) -> Self {
+        Self::with_easing(from, to, dur, Easing::InOut)
+    }
+
+    /// Construct a slide with an explicit easing curve, clock starting now.
+    pub fn with_easing(from: Rect, to: Rect, dur: Duration, easing: Easing) -> Self {
         Self {
             from,
             to,
             start: Instant::now(),
             dur,
+            easing,
         }
     }
 
@@ -38,7 +59,11 @@ impl SlideAnim {
             return self.to;
         }
         let t = elapsed.as_secs_f32() / self.dur.as_secs_f32();
-        rect_lerp(self.from, self.to, ease_out(t))
+        let eased = match self.easing {
+            Easing::Out => ease_out(t),
+            Easing::InOut => ease_in_out(t),
+        };
+        rect_lerp(self.from, self.to, eased)
     }
 
     /// True once `dur` has elapsed since `start`.
@@ -47,11 +72,33 @@ impl SlideAnim {
     }
 }
 
+/// Raw (un-eased) progress of a timed animation: `elapsed / dur` clamped to
+/// `[0, 1]`. The shared clock helper for time-driven animations that don't use
+/// a [`SlideAnim`] (e.g. a directional slide computed from an anchor).
+pub fn progress(start: Instant, dur: Duration, now: Instant) -> f32 {
+    if dur.is_zero() {
+        return 1.0;
+    }
+    (now.saturating_duration_since(start).as_secs_f32() / dur.as_secs_f32()).clamp(0.0, 1.0)
+}
+
 /// Cubic ease-out on `t` clamped to `[0, 1]` -> `[0, 1]`: `1 - (1 - t)^3`.
 pub fn ease_out(t: f32) -> f32 {
     let t = t.clamp(0.0, 1.0);
     let inv = 1.0 - t;
     1.0 - inv * inv * inv
+}
+
+/// Cubic ease-in-out on `t` clamped to `[0, 1]` -> `[0, 1]`: slow at both ends,
+/// fastest in the middle. Symmetric, for A<->B morphs.
+pub fn ease_in_out(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    if t < 0.5 {
+        4.0 * t * t * t
+    } else {
+        let f = -2.0 * t + 2.0;
+        1.0 - f * f * f / 2.0
+    }
 }
 
 /// Per-field linear interpolation of a `Rect` at (already-eased) `t`, rounded.
@@ -116,6 +163,39 @@ mod tests {
     fn ease_out_is_ahead_of_linear() {
         // Ease-out front-loads progress: it should exceed linear in the middle.
         assert!(ease_out(0.5) > 0.5);
+    }
+
+    #[test]
+    fn ease_in_out_endpoints_and_symmetry() {
+        assert_eq!(ease_in_out(0.0), 0.0);
+        assert_eq!(ease_in_out(1.0), 1.0);
+        assert!((ease_in_out(0.5) - 0.5).abs() < 1e-6, "midpoint is 0.5");
+        // Symmetric about (0.5, 0.5).
+        assert!((ease_in_out(0.25) + ease_in_out(0.75) - 1.0).abs() < 1e-6);
+        // Clamps.
+        assert_eq!(ease_in_out(-1.0), 0.0);
+        assert_eq!(ease_in_out(2.0), 1.0);
+    }
+
+    #[test]
+    fn progress_clamps_and_endpoints() {
+        let start = Instant::now();
+        let dur = Duration::from_millis(200);
+        assert_eq!(progress(start, dur, start), 0.0);
+        assert!((progress(start, dur, start + Duration::from_millis(100)) - 0.5).abs() < 1e-3);
+        assert_eq!(progress(start, dur, start + dur), 1.0);
+        assert_eq!(progress(start, dur, start + Duration::from_secs(9)), 1.0);
+        assert_eq!(progress(start, Duration::ZERO, start), 1.0);
+    }
+
+    #[test]
+    fn in_out_slide_reaches_endpoints() {
+        let from = rect(0, 0, 40, 12);
+        let to = rect(60, 20, 20, 6);
+        let dur = Duration::from_millis(200);
+        let anim = SlideAnim::new_in_out(from, to, dur);
+        assert_eq!(anim.rect_at(anim.start), from);
+        assert_eq!(anim.rect_at(anim.start + dur), to);
     }
 
     #[test]

--- a/src/tui/tween.rs
+++ b/src/tui/tween.rs
@@ -106,6 +106,20 @@ fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
         .clamp(0.0, 255.0) as u8
 }
 
+/// Smooth 0 -> 1 -> 0 wave driven by the wall clock, one full swing per
+/// `period`. For indicators that breathe in place rather than travel; every
+/// such indicator breathes in step.
+pub fn pulse_now(period: Duration) -> f32 {
+    let period_ms = period.as_millis().max(1);
+    let ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let t = (ms % period_ms) as f32 / period_ms as f32;
+    // Triangle, then eased so the turning points aren't a visible corner.
+    ease_in_out(if t < 0.5 { t * 2.0 } else { 2.0 - t * 2.0 })
+}
+
 /// Braille spinner frames for "work in flight" indicators, advanced by a clock
 /// so they animate while the app is otherwise idle.
 pub const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -242,6 +256,14 @@ mod tests {
         let anim = SlideAnim::new_in_out(from, to, dur);
         assert_eq!(anim.rect_at(anim.start), from);
         assert_eq!(anim.rect_at(anim.start + dur), to);
+    }
+
+    #[test]
+    fn pulse_stays_in_range() {
+        for _ in 0..16 {
+            let v = pulse_now(Duration::from_millis(900));
+            assert!((0.0..=1.0).contains(&v), "pulse out of range: {v}");
+        }
     }
 
     #[test]

--- a/src/tui/tween.rs
+++ b/src/tui/tween.rs
@@ -6,6 +6,7 @@
 use std::time::{Duration, Instant};
 
 use ratatui::layout::Rect;
+use ratatui::style::Color;
 
 /// Easing curve applied by a [`SlideAnim`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -80,6 +81,29 @@ pub fn progress(start: Instant, dur: Duration, now: Instant) -> f32 {
         return 1.0;
     }
     (now.saturating_duration_since(start).as_secs_f32() / dur.as_secs_f32()).clamp(0.0, 1.0)
+}
+
+/// Blend `from` into `to`, `t` of the way (`t` clamped to `[0, 1]`).
+///
+/// The theme is pure RGB, so a status change can fade instead of snapping.
+/// Non-RGB colours (indexed, named, `Reset`) have no meaningful midpoint, so
+/// they switch at the halfway mark rather than pretending to blend.
+pub fn color_lerp(from: Color, to: Color, t: f32) -> Color {
+    let t = t.clamp(0.0, 1.0);
+    match (from, to) {
+        (Color::Rgb(r1, g1, b1), Color::Rgb(r2, g2, b2)) => {
+            Color::Rgb(lerp_u8(r1, r2, t), lerp_u8(g1, g2, t), lerp_u8(b1, b2, t))
+        }
+        _ if t < 0.5 => from,
+        _ => to,
+    }
+}
+
+/// Linearly interpolate one colour channel and round to nearest.
+fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
+    (a as f32 + (b as f32 - a as f32) * t)
+        .round()
+        .clamp(0.0, 255.0) as u8
 }
 
 /// Braille spinner frames for "work in flight" indicators, advanced by a clock
@@ -218,6 +242,26 @@ mod tests {
         let anim = SlideAnim::new_in_out(from, to, dur);
         assert_eq!(anim.rect_at(anim.start), from);
         assert_eq!(anim.rect_at(anim.start + dur), to);
+    }
+
+    #[test]
+    fn color_lerp_blends_rgb_channels() {
+        let a = Color::Rgb(0, 0, 0);
+        let b = Color::Rgb(255, 100, 50);
+        assert_eq!(color_lerp(a, b, 0.0), a);
+        assert_eq!(color_lerp(a, b, 1.0), b);
+        assert_eq!(color_lerp(a, b, 0.5), Color::Rgb(128, 50, 25));
+        // Clamped, not extrapolated.
+        assert_eq!(color_lerp(a, b, -1.0), a);
+        assert_eq!(color_lerp(a, b, 2.0), b);
+    }
+
+    #[test]
+    fn color_lerp_switches_non_rgb_at_the_midpoint() {
+        let a = Color::Red;
+        let b = Color::Rgb(0, 0, 0);
+        assert_eq!(color_lerp(a, b, 0.4), a);
+        assert_eq!(color_lerp(a, b, 0.6), b);
     }
 
     #[test]

--- a/src/tui/tween.rs
+++ b/src/tui/tween.rs
@@ -82,6 +82,28 @@ pub fn progress(start: Instant, dur: Duration, now: Instant) -> f32 {
     (now.saturating_duration_since(start).as_secs_f32() / dur.as_secs_f32()).clamp(0.0, 1.0)
 }
 
+/// Braille spinner frames for "work in flight" indicators, advanced by a clock
+/// so they animate while the app is otherwise idle.
+pub const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Milliseconds one spinner frame is held for.
+const SPINNER_STEP_MS: u128 = 90;
+
+/// Spinner frame for a task that has been running for `elapsed`.
+pub fn spinner_frame(elapsed: Duration) -> &'static str {
+    SPINNER_FRAMES[(elapsed.as_millis() / SPINNER_STEP_MS) as usize % SPINNER_FRAMES.len()]
+}
+
+/// Spinner frame driven by the wall clock, for indicators that don't track a
+/// start time of their own. Every such spinner turns in step.
+pub fn spinner_frame_now() -> &'static str {
+    let ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    SPINNER_FRAMES[(ms / SPINNER_STEP_MS) as usize % SPINNER_FRAMES.len()]
+}
+
 /// Cubic ease-out on `t` clamped to `[0, 1]` -> `[0, 1]`: `1 - (1 - t)^3`.
 pub fn ease_out(t: f32) -> f32 {
     let t = t.clamp(0.0, 1.0);
@@ -196,6 +218,21 @@ mod tests {
         let anim = SlideAnim::new_in_out(from, to, dur);
         assert_eq!(anim.rect_at(anim.start), from);
         assert_eq!(anim.rect_at(anim.start + dur), to);
+    }
+
+    #[test]
+    fn spinner_frame_advances_and_wraps() {
+        assert_eq!(spinner_frame(Duration::ZERO), SPINNER_FRAMES[0]);
+        assert_eq!(spinner_frame(Duration::from_millis(89)), SPINNER_FRAMES[0]);
+        assert_eq!(spinner_frame(Duration::from_millis(90)), SPINNER_FRAMES[1]);
+        // A full cycle is back to the first frame, not out of bounds.
+        assert_eq!(spinner_frame(Duration::from_millis(900)), SPINNER_FRAMES[0]);
+        assert_eq!(spinner_frame(Duration::from_secs(9999)), SPINNER_FRAMES[0]);
+    }
+
+    #[test]
+    fn spinner_frame_now_is_one_of_the_frames() {
+        assert!(SPINNER_FRAMES.contains(&spinner_frame_now()));
     }
 
     #[test]

--- a/src/tui/widgets/hosts_panel.rs
+++ b/src/tui/widgets/hosts_panel.rs
@@ -5,7 +5,40 @@ use ratatui::Frame;
 
 use crate::app::{App, HostEntry};
 use crate::tui::theme;
+use crate::tui::tween;
 use crate::tui::widgets::panel_box;
+
+/// Fraction of the selected row the highlight has filled, left to right (#35).
+/// `1.0` at rest, so a settled cursor draws its full bar. The wipe runs on the
+/// background only: the text under it is already styled for the selection, so a
+/// moved cursor lands on the right row instantly and the bar catches up.
+fn highlight_fill(app: &App) -> f32 {
+    if !app.motion_enabled() {
+        return 1.0;
+    }
+    match app.selection_at {
+        Some(at) => tween::ease_out(tween::progress(
+            at,
+            crate::tui::SELECT_ANIM,
+            std::time::Instant::now(),
+        )),
+        None => 1.0,
+    }
+}
+
+/// Clear the background of the selected row past the point the wipe has
+/// reached, leaving the bar filling in from the left edge of the row.
+fn clip_highlight(buf: &mut ratatui::buffer::Buffer, x: u16, y: u16, w: usize, fill: f32) {
+    if fill >= 1.0 {
+        return;
+    }
+    let filled = (w as f32 * fill).round() as u16;
+    for cx in (x + filled)..(x + w as u16) {
+        if let Some(c) = buf.cell_mut((cx, y)) {
+            c.bg = ratatui::style::Color::Reset;
+        }
+    }
+}
 
 /// Render the hosts panel into the left column of the dashboard bento grid.
 ///
@@ -80,12 +113,17 @@ pub fn render_hosts_panel(frame: &mut Frame, area: Rect, app: &App) {
 
     use crate::app::VisualRow;
     let visual = app.host_visual_rows();
+    let fill = highlight_fill(app);
 
     for (vrow, row) in visual.iter().enumerate() {
         if vrow < offset || vrow >= window_end {
             continue;
         }
         let y = cy + (vrow - offset) as u16;
+        let selected_row = matches!(
+            *row,
+            VisualRow::Header { selected: true, .. } | VisualRow::Host { selected: true, .. }
+        );
 
         match *row {
             VisualRow::Blank => {}
@@ -284,6 +322,12 @@ pub fn render_hosts_panel(frame: &mut Frame, area: Rect, app: &App) {
                 }
             }
         }
+
+        // The highlight bar fills in from the left under a moved cursor; done
+        // after the row is drawn so it clips the row's own styling too.
+        if selected_row {
+            clip_highlight(buf, cx, y, cw, fill);
+        }
     }
 
     // ── Footer ───────────────────────────────────────────
@@ -314,5 +358,45 @@ fn host_address(entry: &HostEntry) -> String {
         HostEntry::Legacy { host, .. } => {
             host.hostname.clone().unwrap_or_else(|| host.name.clone())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::style::Color;
+
+    fn filled_row(fill: f32) -> Vec<Color> {
+        let area = Rect::new(0, 0, 8, 1);
+        let mut buf = Buffer::empty(area);
+        for x in 0..8 {
+            buf.cell_mut((x, 0)).unwrap().bg = theme::SEL_BG;
+        }
+        clip_highlight(&mut buf, 0, 0, 8, fill);
+        (0..8).map(|x| buf.cell((x, 0)).unwrap().bg).collect()
+    }
+
+    #[test]
+    fn highlight_at_rest_keeps_the_whole_bar() {
+        assert!(filled_row(1.0).iter().all(|c| *c == theme::SEL_BG));
+    }
+
+    #[test]
+    fn highlight_fills_from_the_left() {
+        let bgs = filled_row(0.5);
+        assert!(
+            bgs[..4].iter().all(|c| *c == theme::SEL_BG),
+            "left half stays filled: {bgs:?}"
+        );
+        assert!(
+            bgs[4..].iter().all(|c| *c == Color::Reset),
+            "right half is cleared: {bgs:?}"
+        );
+    }
+
+    #[test]
+    fn highlight_at_zero_clears_the_row() {
+        assert!(filled_row(0.0).iter().all(|c| *c == Color::Reset));
     }
 }

--- a/src/tui/widgets/hosts_panel.rs
+++ b/src/tui/widgets/hosts_panel.rs
@@ -75,7 +75,7 @@ pub fn render_hosts_panel(frame: &mut Frame, area: Rect, app: &App) {
         return;
     }
 
-    let offset = app.host_scroll_offset(body_h);
+    let offset = app.host_scroll_advance(body_h);
     let window_end = offset + body_h;
 
     use crate::app::VisualRow;

--- a/src/tui/widgets/hosts_panel.rs
+++ b/src/tui/widgets/hosts_panel.rs
@@ -216,6 +216,8 @@ pub fn render_hosts_panel(frame: &mut Frame, area: Rect, app: &App) {
                     crate::ping::PingClass::Unreachable => ("\u{25cf}", theme::RED),
                     crate::ping::PingClass::Unknown => ("\u{25cb}", theme::DIM),
                 };
+                // Flash the dot through white when the class just changed (#35).
+                let dot_color = app.ping_flash_color(host_name_for_dot, dot_color);
                 let dot_style = if is_selected {
                     ratatui::style::Style::default()
                         .fg(dot_color)

--- a/src/tui/widgets/middle_stack.rs
+++ b/src/tui/widgets/middle_stack.rs
@@ -81,7 +81,7 @@ pub(crate) fn render_host_panel(buf: &mut Buffer, area: Rect, app: &App) {
 
     // Left: OS logo (when enabled in Settings and the os_icon resolves to a
     // vendored distro logo). The OS name still shows in the fact sheet either way.
-    let zoomed = app.panel_zoomed && app.focused_panel == crate::app::PanelId::Detail;
+    let zoomed = area.height >= crate::tui::widgets::panel_box::ZOOM_CONTENT_MIN;
     let os_id = entry.managed().and_then(|m| m.os_icon.as_deref());
     // When zoomed, prefer the large full-colour logo (fastfetch art); fall back
     // to the small Braille one otherwise.
@@ -390,7 +390,7 @@ pub(crate) fn render_agent_panel(buf: &mut Buffer, area: Rect, app: &App) {
 
     // Zoomed: keep the socket/forward/config header, then list every loaded key
     // (type, bits, full fingerprint, comment) filling the panel height.
-    if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Agent {
+    if area.height >= crate::tui::widgets::panel_box::ZOOM_CONTENT_MIN {
         let bottom_guard = area.y + area.height - 1;
         let label_style = theme::dim();
         let mut y = area.y + 1;
@@ -655,7 +655,7 @@ pub(crate) fn render_latency_panel(buf: &mut Buffer, area: Rect, app: &App) {
 
     // Zoomed: a numeric stat row plus a tall, full-height bar graph of the
     // samples (one bottom-anchored column per sample, coloured by latency).
-    if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Latency {
+    if area.height >= crate::tui::widgets::panel_box::ZOOM_CONTENT_MIN {
         let min = sorted[0];
         let bottom_guard = area.y + area.height - 1;
 

--- a/src/tui/widgets/middle_stack.rs
+++ b/src/tui/widgets/middle_stack.rs
@@ -11,9 +11,9 @@ use crate::tui::theme;
 use crate::tui::widgets::panel_box::{put_clamped, render_panel_box};
 
 // ── Panel heights (sum = 19 to align with the right column) ─
-const HOST_H: u16 = 9;
-const AGENT_H: u16 = 6;
-const LATENCY_H: u16 = 4;
+pub const HOST_H: u16 = 9;
+pub const AGENT_H: u16 = 6;
+pub const LATENCY_H: u16 = 4;
 
 /// Render the three middle-column panels stacked vertically.
 pub fn render_middle_stack(frame: &mut Frame, area: Rect, app: &App) {
@@ -81,7 +81,7 @@ pub(crate) fn render_host_panel(buf: &mut Buffer, area: Rect, app: &App) {
 
     // Left: OS logo (when enabled in Settings and the os_icon resolves to a
     // vendored distro logo). The OS name still shows in the fact sheet either way.
-    let zoomed = app.panel_zoomed;
+    let zoomed = app.panel_zoomed && app.focused_panel == crate::app::PanelId::Detail;
     let os_id = entry.managed().and_then(|m| m.os_icon.as_deref());
     // When zoomed, prefer the large full-colour logo (fastfetch art); fall back
     // to the small Braille one otherwise.
@@ -390,7 +390,7 @@ pub(crate) fn render_agent_panel(buf: &mut Buffer, area: Rect, app: &App) {
 
     // Zoomed: keep the socket/forward/config header, then list every loaded key
     // (type, bits, full fingerprint, comment) filling the panel height.
-    if app.panel_zoomed {
+    if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Agent {
         let bottom_guard = area.y + area.height - 1;
         let label_style = theme::dim();
         let mut y = area.y + 1;
@@ -655,7 +655,7 @@ pub(crate) fn render_latency_panel(buf: &mut Buffer, area: Rect, app: &App) {
 
     // Zoomed: a numeric stat row plus a tall, full-height bar graph of the
     // samples (one bottom-anchored column per sample, coloured by latency).
-    if app.panel_zoomed {
+    if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Latency {
         let min = sorted[0];
         let bottom_guard = area.y + area.height - 1;
 

--- a/src/tui/widgets/middle_stack.rs
+++ b/src/tui/widgets/middle_stack.rs
@@ -54,6 +54,9 @@ pub fn render_middle_stack(frame: &mut Frame, area: Rect, app: &App) {
 /// host's `os_icon` resolves to a known distro (auto-detected on first connect
 /// or set manually in the form); otherwise the card shows just the text.
 pub(crate) fn render_host_panel(buf: &mut Buffer, area: Rect, app: &App) {
+    // Everything below the title belongs to whichever host is selected, so a
+    // moved cursor swaps the lot. Fade it up instead of flicking it over (#35).
+    let fade = content_fade(app.selection_at, app.motion_enabled());
     let entry = app.selected_entry();
     let title = match entry.as_ref() {
         Some(e) => format!("host · {}", e.name()),
@@ -227,6 +230,13 @@ pub(crate) fn render_host_panel(buf: &mut Buffer, area: Rect, app: &App) {
         }
         put_clamped(buf, text_x, y, s, *style, text_w);
     }
+
+    // Fade the body only: the box and its title frame the panel and shouldn't
+    // blink along with what they hold.
+    if area.width > 2 && area.height > 2 {
+        let body = Rect::new(area.x + 1, area.y + 1, area.width - 2, area.height - 2);
+        crate::tui::blit::fade(buf, body, fade);
+    }
 }
 
 /// Render the SSH log panel (meant to span both middle + right columns).
@@ -373,6 +383,22 @@ fn wrap_line(s: &str, width: usize) -> Vec<String> {
 }
 
 // ── Agent panel ─────────────────────────────────────────
+
+/// How far swapped-out panel content has faded in, `0.0` to `1.0` (#35).
+/// `1.0` at rest and under reduced motion, where content simply appears.
+pub(crate) fn content_fade(at: Option<std::time::Instant>, motion: bool) -> f32 {
+    if !motion {
+        return 1.0;
+    }
+    match at {
+        Some(at) => crate::tui::tween::ease_out(crate::tui::tween::progress(
+            at,
+            crate::tui::CONTENT_FADE,
+            std::time::Instant::now(),
+        )),
+        None => 1.0,
+    }
+}
 
 pub(crate) fn render_agent_panel(buf: &mut Buffer, area: Rect, app: &App) {
     render_panel_box(

--- a/src/tui/widgets/middle_stack.rs
+++ b/src/tui/widgets/middle_stack.rs
@@ -668,6 +668,7 @@ pub(crate) fn render_latency_panel(buf: &mut Buffer, area: Rect, app: &App) {
 
         // Bar graph fills the rest of the body below the stat row.
         let graph_top = area.y + 2;
+        let grow = selected.as_deref().map(|n| app.ping_grow(n)).unwrap_or(1.0);
         let graph_h = area.height.saturating_sub(3);
         if graph_h >= 1 && inner_w >= 1 {
             let cols = samples.len().min(inner_w);
@@ -689,7 +690,11 @@ pub(crate) fn render_latency_panel(buf: &mut Buffer, area: Rect, app: &App) {
                 } else {
                     theme::red()
                 };
-                let level = (((v as u64) * units) / max_val).clamp(1, units);
+                let mut level = (((v as u64) * units) / max_val).clamp(1, units);
+                // The newest column grows in rather than appearing full height.
+                if i + 1 == window.len() {
+                    level = ((level as f32 * grow).round() as u64).clamp(1, units);
+                }
                 let full = (level / 8) as u16;
                 let rem = (level % 8) as usize;
                 // Full block cells from the bottom up.
@@ -719,10 +724,16 @@ pub(crate) fn render_latency_panel(buf: &mut Buffer, area: Rect, app: &App) {
         let start = samples.len().saturating_sub(spark_len);
         let window = &samples[start..];
         let max_val = (*window.iter().max().unwrap_or(&1)).max(1);
+        let grow = selected.as_deref().map(|n| app.ping_grow(n)).unwrap_or(1.0);
+        let last = window.len().saturating_sub(1);
         let sparkline: String = window
             .iter()
-            .map(|&v| {
-                let idx = ((v as u64 * 7) / max_val as u64).min(7) as usize;
+            .enumerate()
+            .map(|(i, &v)| {
+                let mut idx = ((v as u64 * 7) / max_val as u64).min(7) as usize;
+                if i == last {
+                    idx = (idx as f32 * grow).round() as usize;
+                }
                 SPARK_CHARS[idx]
             })
             .collect();

--- a/src/tui/widgets/panel_box.rs
+++ b/src/tui/widgets/panel_box.rs
@@ -10,6 +10,14 @@ use ratatui::style::Style;
 use crate::tui::text::ellipsize;
 use crate::tui::theme;
 
+/// A dashboard panel switches from its compact grid layout to the richer zoomed
+/// layout once it is drawn at least this tall (#35). Deciding by the panel's
+/// actual box height (not the global zoom flag) means the content only swaps
+/// once the zoom morph has grown the box enough to hold it, instead of popping
+/// the instant `z` is pressed. Above every compact panel height (max 9), below
+/// a full-body zoom, so a grid slot always reads as compact.
+pub const ZOOM_CONTENT_MIN: u16 = 13;
+
 /// Write `s` at (`x`,`y`), truncated with `…` so it never exceeds `max_w`
 /// display columns — keeps dashboard text inside its panel border even when
 /// the column is narrow (e.g. after a zoom). Returns the columns written.

--- a/src/tui/widgets/right_stack.rs
+++ b/src/tui/widgets/right_stack.rs
@@ -98,7 +98,7 @@ pub(crate) fn render_recent_panel(buf: &mut Buffer, area: Rect, app: &App) {
     // Zoomed (issue #18): `panel_scroll` holds the selected row index; the view
     // follows it and Enter connects the highlighted host. Compact stack: no
     // selection, no offset, and `zoomed_host_idx` is left untouched.
-    let (off, sel) = if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Recent {
+    let (off, sel) = if area.height >= crate::tui::widgets::panel_box::ZOOM_CONTENT_MIN {
         let (first, sel) =
             crate::tui::widgets::panel_box::zoom_window(app, recents.len(), max_display);
         *app.zoomed_host_idx.borrow_mut() = recents.iter().map(|(i, _, _)| *i).collect();
@@ -219,7 +219,7 @@ pub(crate) fn render_auth_panel(buf: &mut Buffer, area: Rect, app: &App) {
     // panel height this still yields ~3 rows.
     let max_events = (area.height.saturating_sub(3)) as usize;
     let name_max = (area.width.saturating_sub(18)) as usize;
-    let (off, sel) = if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Auth {
+    let (off, sel) = if area.height >= crate::tui::widgets::panel_box::ZOOM_CONTENT_MIN {
         let (first, s) = crate::tui::widgets::panel_box::zoom_window(
             app,
             app.auth_events_cache.len(),
@@ -300,7 +300,7 @@ pub(crate) fn render_ping_panel(buf: &mut Buffer, area: Rect, app: &App) {
     // Zoomed (issue #18): take over the whole dashboard body with a per-host
     // table instead of the single aggregate sparkline. The non-zoomed path
     // below is left byte-for-byte unchanged.
-    if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Ping {
+    if area.height >= crate::tui::widgets::panel_box::ZOOM_CONTENT_MIN {
         render_ping_zoomed(buf, area, app, inner_x, inner_w);
         return;
     }

--- a/src/tui/widgets/right_stack.rs
+++ b/src/tui/widgets/right_stack.rs
@@ -11,9 +11,9 @@ use crate::tui::theme;
 use crate::tui::widgets::panel_box::{put_clamped, render_panel_box};
 
 // ── Panel heights ───────────────────────────────────────
-const RECENT_H: u16 = 8;
-const AUTH_H: u16 = 6;
-const PING_H: u16 = 5;
+pub const RECENT_H: u16 = 8;
+pub const AUTH_H: u16 = 6;
+pub const PING_H: u16 = 5;
 
 /// Render the three right-column panels stacked vertically.
 pub fn render_right_stack(frame: &mut Frame, area: Rect, app: &App) {
@@ -98,7 +98,7 @@ pub(crate) fn render_recent_panel(buf: &mut Buffer, area: Rect, app: &App) {
     // Zoomed (issue #18): `panel_scroll` holds the selected row index; the view
     // follows it and Enter connects the highlighted host. Compact stack: no
     // selection, no offset, and `zoomed_host_idx` is left untouched.
-    let (off, sel) = if app.panel_zoomed {
+    let (off, sel) = if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Recent {
         let (first, sel) =
             crate::tui::widgets::panel_box::zoom_window(app, recents.len(), max_display);
         *app.zoomed_host_idx.borrow_mut() = recents.iter().map(|(i, _, _)| *i).collect();
@@ -219,7 +219,7 @@ pub(crate) fn render_auth_panel(buf: &mut Buffer, area: Rect, app: &App) {
     // panel height this still yields ~3 rows.
     let max_events = (area.height.saturating_sub(3)) as usize;
     let name_max = (area.width.saturating_sub(18)) as usize;
-    let (off, sel) = if app.panel_zoomed {
+    let (off, sel) = if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Auth {
         let (first, s) = crate::tui::widgets::panel_box::zoom_window(
             app,
             app.auth_events_cache.len(),
@@ -300,7 +300,7 @@ pub(crate) fn render_ping_panel(buf: &mut Buffer, area: Rect, app: &App) {
     // Zoomed (issue #18): take over the whole dashboard body with a per-host
     // table instead of the single aggregate sparkline. The non-zoomed path
     // below is left byte-for-byte unchanged.
-    if app.panel_zoomed {
+    if app.panel_zoomed && app.focused_panel == crate::app::PanelId::Ping {
         render_ping_zoomed(buf, area, app, inner_x, inner_w);
         return;
     }

--- a/src/tui/widgets/status_bar.rs
+++ b/src/tui/widgets/status_bar.rs
@@ -34,6 +34,7 @@ fn mode_label(mode: AppMode) -> &'static str {
         AppMode::BroadcastPickTarget => "Broadcast",
         AppMode::BroadcastCommand => "Broadcast",
         AppMode::BroadcastPreview => "Broadcast",
+        AppMode::Notice => "Notice",
     }
 }
 


### PR DESCRIPTION
Extends motion across the whole TUI, then fixes what using the animated SFTP tab exposed.

Closes #35

## Motion (#35)

Every idea in the issue landed, on the foundation it asked for: elapsed-time
maths only, no stored animation state that a resize could desync, and the
`App::animating` gate so the frame rate only rises while something is playing.

- **Popups** drop in from off the top and are thrown back up on close, across
  every overlay including the new-session picker (which was the one exception,
  because it can sit over a full-screen session that never captured a backdrop).
- **Tab bodies** slide on switch; a **zoomed panel** morphs out of its grid slot
  and swaps its content by box height rather than instantly.
- **Sessions** slide in on connect and off on the way out. Switching session
  tabs moves the PTY body only — the header stays put and its active-tab
  highlight travels along it instead.
- **SFTP** slides between picker, "connecting…" and browser, with the two panes
  meeting in the middle and parting again; panes slide to a new directory in the
  direction you moved; the connect spinner turns; a staged transfer flies into
  the queue from the side its file came from; the running queue has a progress
  bar that sweeps between the worker's chunked updates.
- **Host list** scrolls under the cursor instead of jumping half a panel, its
  highlight wipes in, and a group's rows are revealed one at a time as it folds.
  Click mapping follows the drawn offset, so hit-testing stays honest mid-scroll.
- **Status** is legible in motion: a host's dot flashes when its ping class
  changes, a reconnecting tunnel's dot breathes, the header tally counts to its
  new values, and a fresh reading grows into the latency graph.
- **Content that swaps under a fixed frame** (host detail, audit table) fades up
  rather than flickering, and the dashboard fades out of the intro animation.

Two shared primitives came out of it: `tui::blit` (cell blitting with clipping,
plus `fade`) and additions to `tui::tween` (`color_lerp`, `pulse_now`,
`spinner_frame`). Reduced motion reuses the existing
`appearance.disable_animation` toggle rather than adding a second one.

## SFTP fixes and features

Found by actually using the tab while animating it:

- **No way out of a directory.** Both panes now list `..`, and `Backspace`
  works: it used to do nothing on a fresh remote pane, because the parent of
  the server-resolved `"."` is the empty path, which the server rejects.
- **Staging read the wrong pane.** `←` queued whatever the *remote* cursor sat
  on whichever pane had focus, so browsing locally and reaching for `←` queued
  an entry you weren't looking at — and queued it again after each local `cd`,
  since the duplicate guard compares both ends and the destination had moved.
- **A failed transfer retried itself forever.** A worker follows an error with
  its usual completion event, which the queue's auto-continue read as "start the
  next pass". Failed runs now stop for a manual retry, and both workers are told
  to cancel.
- **The queue stays open during a run**: files can be staged mid-transfer and
  roll into the next pass; the local pane stays browsable.
- **Two servers.** The left pane can be pointed at a second host with `o` (`O`
  returns it to local files): its own worker, handshake and file operations.
  Transfers between the two are relayed through a local temp file, one leg at a
  time, since SSH has no server-to-server copy; an item only leaves the queue
  once it lands, so a failure keeps it for a retry.

## Testing

`just test` green: 487 unit, 59 e2e, 42 smoke, plus config_load. `cargo fmt
--check` and `cargo clippy --all-targets` clean (only the pre-existing
test-support warnings). New coverage for the parts worth pinning: blit and fade
maths, the scroll and counter chases, the fold reveal, ping flash and sparkline
growth, the relay's two legs, and regressions for the staging and retry-loop
bugs.

Not automatable and checked by hand in a real terminal: how the motion actually
reads, and the two-server relay against live hosts.

## Security notes

No new credential paths: the second SFTP pane resolves its secret through the
same `resolve_pending_secret` the first one uses. The relay writes to a
per-process directory under the system temp dir and removes it on completion,
failure and disconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Written by Claude Opus 5 (Claude Code) on behalf of the maintainer._
