### PR TITLE
build: set a release profile (strip + LTO) for smaller shipped binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,15 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
+      # Nothing else in this job ever runs the binary it ships, and `strip` is
+      # the kind of setting that can produce one that doesn't start at all (on
+      # Apple targets it rewrites the Mach-O, which can invalidate the linker's
+      # ad-hoc signature). `--dry-run` exits without opening the TUI, so it is a
+      # safe liveness check. Skipped for the Intel Mac binary, which an arm64
+      # runner cannot execute without Rosetta.
+      - name: Smoke-test the built binary
+        if: matrix.target != 'x86_64-apple-darwin'
+        run: ./target/${{ matrix.target }}/release/sshub --dry-run
       - name: Package
         run: |
           cd target/${{ matrix.target }}/release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Smoke-test the built binary
         if: matrix.target != 'x86_64-apple-darwin'
         run: ./target/${{ matrix.target }}/release/sshub --dry-run
+      # The Intel Mac binary can't be executed on an arm64 runner, so check it
+      # structurally instead: a truncated/mangled Mach-O and a signature broken
+      # by `strip` are exactly what this leg would otherwise ship unnoticed.
+      - name: Verify the Intel Mac binary
+        if: matrix.target == 'x86_64-apple-darwin'
+        run: |
+          bin=target/${{ matrix.target }}/release/sshub
+          file "$bin" | grep -q 'Mach-O 64-bit executable x86_64'
+          codesign --verify --strict --verbose=2 "$bin"
       - name: Package
         run: |
           cd target/${{ matrix.target }}/release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ All notable changes to SSHub are documented in this file.
 - **SFTP `..` row** - both panes list their parent directory as a selectable
   row, so walking up no longer depends on knowing about `Backspace`.
 
+### Changed
+
+- **Smaller release binaries** - release builds had no profile at all, so they
+  shipped with the symbol table and without cross-crate optimisation. Adding
+  `lto = "thin"`, `codegen-units = 1` and `strip = "symbols"` takes the Linux
+  x86-64 binary from 14.8 MB to 11.6 MB (-21.8%), which every distribution
+  channel carries: the release tarballs, `cargo install`, and anything that
+  repackages them. Release builds take correspondingly longer; `cargo test` and
+  day-to-day `cargo build` are untouched.
+
 ### Fixed
 
 - **SFTP could not leave the login directory** - `Backspace` did nothing on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,9 @@ All notable changes to SSHub are documented in this file.
   `cargo build` are untouched, but every release build now takes noticeably
   longer -- including `just build` and `just install`, which build in release
   mode, and including every dependency, since `codegen-units = 1` applies across
-  the whole graph.
+  the whole graph. One trade to be aware of when reporting a crash: stripping
+  the symbol table leaves `RUST_BACKTRACE` output empty in a released binary,
+  so a backtrace worth sending has to come from a debug build.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,16 @@ All notable changes to SSHub are documented in this file.
 
 ### Changed
 
-- **Smaller release binaries** - release builds had no profile at all, so they
-  shipped with the symbol table and without cross-crate optimisation. Adding
-  `lto = "thin"`, `codegen-units = 1` and `strip = "symbols"` takes the Linux
-  x86-64 binary from 14.8 MB to 11.6 MB (-21.8%), which every distribution
-  channel carries: the release tarballs, `cargo install`, and anything that
-  repackages them. Release builds take correspondingly longer; `cargo test` and
-  day-to-day `cargo build` are untouched.
+- **Smaller release binaries** (issue #42) - release builds had no profile at
+  all, so they shipped with the symbol table and without cross-crate
+  optimisation. Adding `lto = "thin"`, `codegen-units = 1` and
+  `strip = "symbols"` takes the Linux x86-64 binary from 14.8 MB to 11.6 MB
+  (-21.8%), which every distribution channel carries: the release tarballs,
+  `cargo install`, and anything that repackages them. `cargo test` and a plain
+  `cargo build` are untouched, but every release build now takes noticeably
+  longer -- including `just build` and `just install`, which build in release
+  mode, and including every dependency, since `codegen-units = 1` applies across
+  the whole graph.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,11 +66,13 @@ tempfile = "3"
 tui-term = "0.3"
 vt100 = "0.16"
 
-# Shipped binaries carry no debug symbols and are optimised across crate
+# Shipped binaries carry no symbol table and are optimised across crate
 # boundaries: the tarballs from the release workflow, `cargo install sshub`, and
-# anything that repackages them are what users actually download. `panic` is
-# deliberately left alone -- unwinding is what lets the terminal guard restore
-# the tty and the panic hook print somewhere visible.
+# anything that repackages them are what users actually download. (Debug info
+# was never in them -- release defaults to `debug = false` -- so what `strip`
+# removes here is the symbol/string table backtraces read function names from.)
+# `panic` is deliberately left alone: unwinding is what lets the terminal guard
+# restore the tty and the panic hook print somewhere visible.
 [profile.release]
 lto = "thin"
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,16 @@ tempfile = "3"
 tui-term = "0.3"
 vt100 = "0.16"
 
+# Shipped binaries carry no debug symbols and are optimised across crate
+# boundaries: the tarballs from the release workflow, `cargo install sshub`, and
+# anything that repackages them are what users actually download. `panic` is
+# deliberately left alone -- unwinding is what lets the terminal guard restore
+# the tty and the panic hook print somewhere visible.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,6 @@ tempfile = "3"
 tui-term = "0.3"
 vt100 = "0.16"
 
-# Shipped binaries carry no symbol table and are optimised across crate
-# boundaries: the tarballs from the release workflow, `cargo install sshub`, and
-# anything that repackages them are what users actually download. (Debug info
-# was never in them -- release defaults to `debug = false` -- so what `strip`
-# removes here is the symbol/string table backtraces read function names from.)
-# `panic` is deliberately left alone: unwinding is what lets the terminal guard
-# restore the tty and the panic hook print somewhere visible.
-[profile.release]
-lto = "thin"
-codegen-units = 1
-strip = "symbols"
-
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
@@ -94,3 +82,21 @@ path = "tests/e2e/mod.rs"
 [[test]]
 name = "config_load"
 path = "tests/smoke/config_load.rs"
+
+# Shipped binaries carry no symbol table and are optimised across crate
+# boundaries: the tarballs from the release workflow, `cargo install sshub`, and
+# anything that repackages them are what users actually download. (Debug info
+# was never in them -- release defaults to `debug = false` -- so what `strip`
+# removes is the symbol table, which leaves `RUST_BACKTRACE` output empty in a
+# shipped build.)
+#
+# `panic` stays on unwind, and not for the reason you might assume: the panic
+# hook runs under `abort` too, so the tty would be restored either way. What
+# abort would cost is (a) every worker thread -- watcher, ping, broadcast, sftp,
+# os-detect -- whose panic currently kills only itself and leaves the TUI alive,
+# and (b) every cleanup `Drop`, including `AskpassSecret`, which removes the
+# file holding a host's password.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"

--- a/docs/implementation-flow.md
+++ b/docs/implementation-flow.md
@@ -125,7 +125,7 @@ This catches doc drift, wrong API names, regressions, and scope creep that unit 
 | Field | Rule |
 |-------|------|
 | **Target** | `development` only |
-| **Title** | Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:` |
+| **Title** | Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `build:`, `ci:`, `chore:` |
 | **Body** | What changed and why; how you tested; `Closes #N`; security notes if relevant |
 | **Scope** | One logical change set |
 


### PR DESCRIPTION
Closes #42

`Cargo.toml` had no `[profile.release]` at all, so releases went out with cargo's
defaults: symbol table kept, no cross-crate optimisation, 16 codegen units.

```toml
[profile.release]
lto = "thin"
codegen-units = 1
strip = "symbols"
```

## Measured (x86_64-unknown-linux-gnu)

| | bytes |
|---|---|
| baseline, no profile | 14 779 968 |
| + `lto` / `codegen-units` | 13 216 752 |
| + `strip` (this profile) | 11 558 712 |

−21.8% overall, split about evenly: 1.56 MB from LTO and the single codegen
unit, 1.66 MB from the symbol table.

`strip = "debuginfo"` was measured and rejected — release already builds with
`debug = false`, so it saves 92 KB against `symbols`' 1.66 MB. `panic` stays on
unwind; the manifest comment explains why, and it is not the reason you might
guess (see below).

Build-time numbers are deliberately absent: this machine was loaded during the
runs and the figures weren't trustworthy. What is stated is directional —
release builds take longer, across the whole dependency graph, and that includes
`just build` and `just install`.

## What the adversarial review changed

Two independent critics; every finding re-verified against the repo before
acting, and the ones that stuck were real:

- **The published size was from the wrong measurement.** 11 563 248 came from
  `strip --strip-all` on an unstripped build, used as a proxy to avoid another
  15-minute compile. Cargo's own strip yields 11 558 712. Same percentage,
  correct number now.
- **The `panic` rationale was wrong on both halves.** The comment claimed
  unwinding is what lets the terminal guard restore the tty and the hook print.
  In fact the panic hook runs under `abort` too, and it is the hook — not the
  guard — that restores the tty. The real arguments were missing: five worker
  threads that currently survive each other's panics, and cleanup `Drop`s,
  including `AskpassSecret`, which deletes the file holding a host's password.
- **The release job never ran the binary it shipped**, and `strip` is precisely
  the setting that can produce one that won't start — on Apple targets it
  rewrites the Mach-O and can invalidate the ad-hoc signature, which arm64 kills
  at exec. Added a `--dry-run` liveness check before packaging; the Intel Mac
  leg, which an arm64 runner can't execute, is verified structurally instead
  (Mach-O header + `codesign --verify`).
- **"day-to-day `cargo build` untouched"** was misleading here: `just build` is
  a release build and `just install` depends on it.
- **Stripping empties `RUST_BACKTRACE`** rather than merely un-naming frames, so
  the changelog says what a useful bug report now needs.

## Testing

`just test` green (487 unit, 59 e2e, 42 smoke), `cargo fmt --check` and
`cargo clippy --all-targets` clean. Verified locally that a fully stripped
binary still answers `--dry-run` with exit 0. macOS behaviour is what the new
CI steps exist to catch — it cannot be tested from Linux.

## Security notes

None of the code paths changed. Worth recording that the review surfaced
`AskpassSecret`'s `Drop` as a reason not to switch to `panic = "abort"` later:
doing so would leave a host password on disk after a panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Written by Claude Opus 5 (Claude Code) on behalf of the maintainer._