### PR TITLE
feat(sftp): hide dotfiles by default, with a `.` toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ All notable changes to SSHub are documented in this file.
   local pane stays browsable meanwhile.
 - **SFTP `..` row** - both panes list their parent directory as a selectable
   row, so walking up no longer depends on knowing about `Backspace`.
+- **SFTP hides dotfiles** (issue #44), with `.` to show them - in a home
+  directory they were most of the listing, pushing what you came for below the
+  fold. The toggle covers both panes and is remembered across restarts. The
+  `..` row is exempt (it is a way out, not an entry), except while searching,
+  where it steps aside so the cursor lands on a result.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,17 @@ All notable changes to SSHub are documented in this file.
   local pane stays browsable meanwhile.
 - **SFTP `..` row** - both panes list their parent directory as a selectable
   row, so walking up no longer depends on knowing about `Backspace`.
-- **SFTP hides dotfiles** (issue #44), with `.` to show them - in a home
-  directory they were most of the listing, pushing what you came for below the
-  fold. The toggle covers both panes and is remembered across restarts. The
-  `..` row is exempt (it is a way out, not an entry), except while searching,
-  where it steps aside so the cursor lands on a result.
 
 ### Changed
 
+- **SFTP hides dotfiles** (issue #44), with `.` to show them - in a home
+  directory they were most of the listing, pushing what you came for below the
+  fold. This changes what an existing install shows on first run, so the pane
+  says how many entries it is holding back, and a search beginning with a dot
+  (`.ssh`) lifts the hiding rather than reporting no matches. The toggle covers
+  both panes and is remembered across restarts. The `..` row is exempt from the
+  hiding, being a way out rather than an entry, but steps aside while searching
+  so the cursor lands on a result.
 - **Smaller release binaries** (issue #42) - release builds had no profile at
   all, so they shipped with the symbol table and without cross-crate
   optimisation. Adding `lto = "thin"`, `codegen-units = 1` and

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Defaults below. Rebind any action with **Ctrl+K** (saved to `config.toml`). Pres
 | `←` / `→`          | Stage the focused pane's selection toward the other  |
 | `c` / `u`          | Run the queue / unstage the last transfer            |
 | `o` / `O`          | Left pane to a second server / back to local files   |
+| `.`                | Show / hide dotfiles in both panes (remembered)      |
 | `d`                | Delete (recursive)                                   |
 | `n` / `R` / `M`    | New folder / rename / chmod                          |
 | `r`                | Refresh both panes                                   |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -326,6 +326,9 @@ pub struct App {
     pub sftp_run_failed: bool,
     /// True while the SFTP picker's host search input is capturing keys.
     pub sftp_picker_searching: bool,
+    /// Remembered dotfile visibility for the SFTP panes, restored from
+    /// `ui_state` at startup and applied to each new browser.
+    pub sftp_show_hidden: bool,
     /// In-flight SFTP tab sub-state slide and when it started (#35). `None` at
     /// rest / under reduced motion.
     pub sftp_anim: Option<(SftpAnim, std::time::Instant)>,
@@ -665,6 +668,7 @@ impl App {
             sftp_swallow_done: 0,
             sftp_run_failed: false,
             sftp_picker_searching: false,
+            sftp_show_hidden: false,
             sftp_anim: None,
             sftp_snapshot: std::cell::RefCell::new(None),
             probe_rx: None,
@@ -786,6 +790,7 @@ impl App {
     pub fn reload_hosts(&mut self) -> Result<()> {
         let selected_name = self.selected_entry().map(|e| e.name().to_string());
         self.load_collapsed_groups();
+        self.load_sftp_hidden();
         self.load_ui_zoom();
 
         sync_ssh_config_hosts(self.resolver.as_ref(), &self.store)?;

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -463,6 +463,7 @@ impl App {
             if sent {
                 self.sftp_prompt = None;
                 self.mode = AppMode::Normal;
+                self.note_if_hidden(&name);
             } else if let Some(p) = self.sftp_prompt.as_mut() {
                 p.error = Some("not connected".into());
             }
@@ -495,6 +496,7 @@ impl App {
                         self.sftp_prompt = None;
                         self.mode = AppMode::Normal;
                         self.sftp_refresh_panes();
+                        self.note_if_hidden(&name);
                     }
                     Err(e) => {
                         if let Some(p) = self.sftp_prompt.as_mut() {
@@ -740,6 +742,18 @@ impl App {
     pub(crate) fn load_sftp_hidden(&mut self) {
         if let Ok(Some(raw)) = self.store.get_ui_state(SFTP_HIDDEN_KEY) {
             self.sftp_show_hidden = raw == "1";
+        }
+    }
+
+    /// Warn when an entry just created or renamed lands under the dotfile
+    /// filter: it would otherwise vanish from the listing on success, which
+    /// reads as the operation having failed.
+    fn note_if_hidden(&mut self, name: &str) {
+        if self.sftp_show_hidden || !name.starts_with('.') {
+            return;
+        }
+        if let Some(s) = self.sftp.as_mut() {
+            s.notice = Some(format!("{name} is hidden — press . to show dotfiles"));
         }
     }
 

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -6,6 +6,9 @@ use crate::sftp::model::{Direction, FileEntry, Phase, QueuedTransfer, SftpState,
 
 /// Time constant of the SFTP progress bar's chase (#35).
 const SFTP_PROGRESS_TAU: f32 = 0.12;
+
+/// `ui_state` key holding whether SFTP lists dotfiles.
+const SFTP_HIDDEN_KEY: &str = "sftp_show_hidden";
 use crate::sftp::SftpCommand;
 
 impl App {
@@ -286,6 +289,8 @@ impl App {
             KeyCode::Char('r') => self.sftp_refresh_panes(),
             // Open an SSH session to this same host (SFTP stays in the background).
             KeyCode::Char('s') => self.open_ssh_for_sftp_host()?,
+            // Show or hide dotfiles in both panes.
+            KeyCode::Char('.') => self.sftp_toggle_hidden(),
             // Point the left pane at a second server, or send it back to the
             // local filesystem.
             KeyCode::Char('o') => self.open_host_picker(PickerTarget::SftpLeftPane),
@@ -725,9 +730,38 @@ impl App {
         self.sftp_tx = Some(tx);
         self.sftp_rx = Some(rx);
         self.sftp_host = Some(entry.name().to_string());
+        self.apply_saved_hidden();
         // Slide the "connecting…" layer in from the right over the picker (#35).
         self.stamp_sftp_anim(SftpAnim::ConnectIn);
         Ok(())
+    }
+
+    /// Read the remembered dotfile setting at startup.
+    pub(crate) fn load_sftp_hidden(&mut self) {
+        if let Ok(Some(raw)) = self.store.get_ui_state(SFTP_HIDDEN_KEY) {
+            self.sftp_show_hidden = raw == "1";
+        }
+    }
+
+    /// Flip dotfile visibility in both panes and remember it, so the choice
+    /// survives a restart the way collapsed host groups do.
+    fn sftp_toggle_hidden(&mut self) {
+        let Some(show) = self.sftp.as_mut().map(|s| s.toggle_hidden()) else {
+            return;
+        };
+        self.sftp_show_hidden = show;
+        let _ = self
+            .store
+            .set_ui_state(SFTP_HIDDEN_KEY, if show { "1" } else { "0" });
+    }
+
+    /// Restore the remembered dotfile setting into a freshly opened browser.
+    fn apply_saved_hidden(&mut self) {
+        let show = self.sftp_show_hidden;
+        if let Some(s) = self.sftp.as_mut() {
+            s.local.show_hidden = show;
+            s.remote.show_hidden = show;
+        }
     }
 
     /// The worker that owns `side`: the browser's own for the right pane, the

--- a/src/app/tests/sftp.rs
+++ b/src/app/tests/sftp.rs
@@ -336,3 +336,66 @@ fn failed_run_does_not_dispatch_another_pass() {
         "a failed run waits for the user rather than dispatching another pass"
     );
 }
+
+/// The dotfile setting survives a restart: it is written to `ui_state` on
+/// toggle and read back when the next session builds its browser.
+#[test]
+fn hidden_setting_round_trips_through_the_store() {
+    use crate::sftp::model::SftpState;
+
+    let store = test_store();
+    let mut app = App::new_with_deps(
+        AppConfig::default(),
+        AppDeps {
+            resolver: Box::new(MockResolver::new(vec![])),
+            metadata: Arc::new(MetadataDb::default()),
+            store: store.clone(),
+            password_store: Box::new(crate::credentials::NoopPasswordStore),
+        },
+    );
+    app.reload_hosts().unwrap();
+    assert!(!app.sftp_show_hidden, "dotfiles start hidden");
+
+    app.sftp = Some(SftpState::new("/srv", "/home/me"));
+    app.active_tab = 1;
+    app.handle_key(key(KeyCode::Char('.'))).unwrap();
+    assert!(app.sftp_show_hidden);
+    assert!(app.sftp.as_ref().unwrap().local.show_hidden);
+    assert!(app.sftp.as_ref().unwrap().remote.show_hidden);
+
+    // A fresh App over the same store comes up with dotfiles shown, and a
+    // browser opened in it inherits that.
+    let mut next = App::new_with_deps(
+        AppConfig::default(),
+        AppDeps {
+            resolver: Box::new(MockResolver::new(vec![])),
+            metadata: Arc::new(MetadataDb::default()),
+            store,
+            password_store: Box::new(crate::credentials::NoopPasswordStore),
+        },
+    );
+    next.reload_hosts().unwrap();
+    assert!(next.sftp_show_hidden, "setting did not survive the restart");
+}
+
+/// Regression: `.` is a toggle in the browser but an ordinary character while
+/// filtering. The search guard sits at the top of the SFTP dispatch and is easy
+/// to lose in a refactor, so pin it.
+#[test]
+fn dot_types_into_the_filter_instead_of_toggling() {
+    use crate::sftp::model::SftpState;
+
+    let mut app = test_app(vec![]);
+    let mut state = SftpState::new("/srv", "/home/me");
+    state.start_search();
+    app.sftp = Some(state);
+    app.active_tab = 1;
+
+    app.handle_key(key(KeyCode::Char('.'))).unwrap();
+    app.handle_key(key(KeyCode::Char('s'))).unwrap();
+    app.handle_key(key(KeyCode::Char('s'))).unwrap();
+
+    let state = app.sftp.as_ref().unwrap();
+    assert_eq!(state.remote.filter, ".ss", "the dot went into the filter");
+    assert!(!app.sftp_show_hidden, "and did not flip the setting");
+}

--- a/src/sftp/model.rs
+++ b/src/sftp/model.rs
@@ -132,11 +132,16 @@ impl Pane {
     /// entry in it. It is *not* exempt from the text filter: while searching,
     /// the user is after something specific, and a `..` sitting at the top of
     /// the results would take the cursor `set_filter` parks on row zero.
+    ///
+    /// A search that *starts with a dot* lifts the hiding: typing `.ssh` is an
+    /// unambiguous request for a dotfile, and answering it with "no matches"
+    /// while the entry sits right there would be obtuse.
     fn is_visible(&self, entry: &FileEntry, needle: &str) -> bool {
         if entry.is_parent() {
             return needle.is_empty();
         }
-        if !self.show_hidden && entry.name.starts_with('.') {
+        let asked_for_dotfiles = needle.starts_with('.');
+        if !self.show_hidden && !asked_for_dotfiles && entry.name.starts_with('.') {
             return false;
         }
         needle.is_empty() || entry.name.to_lowercase().contains(needle)
@@ -171,7 +176,7 @@ impl Pane {
     /// Entries the dotfile filter is currently keeping off screen, so the pane
     /// can say so instead of looking mysteriously short.
     pub fn hidden_len(&self) -> usize {
-        if self.show_hidden {
+        if self.show_hidden || self.filter.starts_with('.') {
             return 0;
         }
         self.entries
@@ -845,6 +850,20 @@ mod tests {
         s.remote.set_filter("app".into());
         assert_eq!(s.remote.visible_len(), 1);
         assert_eq!(s.remote.selected_entry().unwrap().name, "app.log");
+    }
+
+    /// Typing a leading dot is an explicit request for dotfiles, so the hiding
+    /// steps aside rather than answering "no matches" about a file in plain
+    /// sight -- `/` + `.ssh` is the likeliest search in an SSH tool.
+    #[test]
+    fn a_search_starting_with_a_dot_finds_hidden_entries() {
+        let mut s = with_dotfiles();
+        assert!(!s.remote.show_hidden);
+        s.remote.set_filter(".ss".into());
+        assert_eq!(s.remote.visible_len(), 1);
+        assert_eq!(s.remote.selected_entry().unwrap().name, ".ssh");
+        // And nothing is reported as held back, since nothing is.
+        assert_eq!(s.remote.hidden_len(), 0);
     }
 
     /// The text filter and the dotfile filter compose rather than override.

--- a/src/sftp/model.rs
+++ b/src/sftp/model.rs
@@ -108,6 +108,9 @@ pub struct Pane {
     pub entries: Vec<FileEntry>,
     pub selected: usize,
     pub filter: String,
+    /// Whether dotfiles are listed. Off by default: in a home directory they
+    /// are most of the listing, and what someone came for sits below them.
+    pub show_hidden: bool,
 }
 
 impl Pane {
@@ -117,33 +120,45 @@ impl Pane {
             entries: Vec::new(),
             selected: 0,
             filter: String::new(),
+            show_hidden: false,
         }
     }
 
-    /// Indices into `entries` matching the current filter (all if the filter is empty).
-    pub fn visible_indices(&self) -> Vec<usize> {
-        if self.filter.is_empty() {
-            return (0..self.entries.len()).collect();
+    /// Whether `entry` is listed right now: it must survive the text filter
+    /// and, unless dotfiles are shown, not be one.
+    ///
+    /// The synthetic `..` row is exempt from the dotfile rule -- its name
+    /// starts with a dot, but it is the way out of the directory rather than an
+    /// entry in it. It is *not* exempt from the text filter: while searching,
+    /// the user is after something specific, and a `..` sitting at the top of
+    /// the results would take the cursor `set_filter` parks on row zero.
+    fn is_visible(&self, entry: &FileEntry) -> bool {
+        if entry.is_parent() {
+            return self.filter.is_empty();
         }
-        let needle = self.filter.to_lowercase();
+        if !self.show_hidden && entry.name.starts_with('.') {
+            return false;
+        }
+        self.filter.is_empty()
+            || entry
+                .name
+                .to_lowercase()
+                .contains(&self.filter.to_lowercase())
+    }
+
+    /// Indices into `entries` that are currently listed.
+    pub fn visible_indices(&self) -> Vec<usize> {
         self.entries
             .iter()
             .enumerate()
-            .filter(|(_, e)| e.name.to_lowercase().contains(&needle))
+            .filter(|(_, e)| self.is_visible(e))
             .map(|(i, _)| i)
             .collect()
     }
 
-    /// Number of entries currently visible under the filter.
+    /// Number of entries currently listed.
     pub fn visible_len(&self) -> usize {
-        if self.filter.is_empty() {
-            return self.entries.len();
-        }
-        let needle = self.filter.to_lowercase();
-        self.entries
-            .iter()
-            .filter(|e| e.name.to_lowercase().contains(&needle))
-            .count()
+        self.entries.iter().filter(|e| self.is_visible(e)).count()
     }
 
     /// Set the filter text and move the cursor to the top of the filtered view.
@@ -154,13 +169,9 @@ impl Pane {
 
     /// The entry under the cursor, if any.
     pub fn selected_entry(&self) -> Option<&FileEntry> {
-        if self.filter.is_empty() {
-            return self.entries.get(self.selected);
-        }
-        let needle = self.filter.to_lowercase();
         self.entries
             .iter()
-            .filter(|e| e.name.to_lowercase().contains(&needle))
+            .filter(|e| self.is_visible(e))
             .nth(self.selected)
     }
 
@@ -188,7 +199,7 @@ impl Pane {
         }
     }
 
-    fn clamp_selection(&mut self) {
+    pub(crate) fn clamp_selection(&mut self) {
         let len = self.visible_len();
         if len == 0 {
             self.selected = 0;
@@ -437,6 +448,19 @@ impl SftpState {
         Ok(())
     }
 
+    /// Show or hide dotfiles in both panes at once -- they are browsed as a
+    /// pair, so splitting the setting would just be two keys to press. Returns
+    /// the new state so the caller can persist it.
+    pub fn toggle_hidden(&mut self) -> bool {
+        let show = !self.local.show_hidden;
+        self.local.show_hidden = show;
+        self.remote.show_hidden = show;
+        // The cursor was indexing the old listing; keep it inside the new one.
+        self.local.clamp_selection();
+        self.remote.clamp_selection();
+        show
+    }
+
     /// Whether the left pane is browsing a second server rather than the local
     /// filesystem, which decides where its listings and file ops are sent.
     pub fn left_is_remote(&self) -> bool {
@@ -665,6 +689,95 @@ mod tests {
         assert!(s.stage_upload().is_ok());
         assert_eq!(s.queue.len(), 1);
         assert!(s.queue[0].is_dir);
+    }
+
+    fn with_dotfiles() -> SftpState {
+        let mut s = SftpState::new("/srv", "/home/me");
+        let entry = |name: &str| FileEntry {
+            name: name.into(),
+            is_dir: false,
+            size: 1,
+            is_symlink: false,
+            perm: None,
+        };
+        s.remote
+            .set_entries(vec![entry(".ssh"), entry("app.log"), entry(".bashrc")]);
+        s.local
+            .set_entries(vec![entry(".config"), entry("notes.txt")]);
+        s
+    }
+
+    #[test]
+    fn dotfiles_are_hidden_until_toggled() {
+        let mut s = with_dotfiles();
+        // Listed: "..", "app.log". The two dotfiles are filtered out.
+        assert_eq!(s.remote.visible_len(), 2);
+        let names: Vec<&str> = s
+            .remote
+            .visible_indices()
+            .iter()
+            .map(|i| s.remote.entries[*i].name.as_str())
+            .collect();
+        assert_eq!(names, vec![PARENT_ROW, "app.log"]);
+
+        // The toggle applies to both panes at once and reports the new state.
+        assert!(s.toggle_hidden());
+        assert_eq!(s.remote.visible_len(), 4);
+        assert_eq!(s.local.visible_len(), 3);
+        assert!(!s.toggle_hidden());
+        assert_eq!(s.remote.visible_len(), 2);
+    }
+
+    /// The parent row's name starts with a dot but is the way out of the
+    /// directory, not an entry in it: hiding dotfiles must not hide it.
+    #[test]
+    fn parent_row_survives_the_dotfile_filter() {
+        let s = with_dotfiles();
+        assert!(!s.remote.show_hidden);
+        assert!(s.remote.selected_entry().unwrap().is_parent());
+        assert!(s
+            .remote
+            .visible_indices()
+            .iter()
+            .any(|i| s.remote.entries[*i].is_parent()));
+    }
+
+    /// Hiding entries under the cursor must not leave it pointing past the end
+    /// of the listing.
+    #[test]
+    fn toggling_hidden_keeps_the_cursor_in_range() {
+        let mut s = with_dotfiles();
+        s.toggle_hidden();
+        s.remote.selected = 3; // ".bashrc", only reachable while shown
+        s.toggle_hidden();
+        assert!(
+            s.remote.selected < s.remote.visible_len(),
+            "cursor left past the end of the listing"
+        );
+        assert!(s.remote.selected_entry().is_some());
+    }
+
+    /// Searching is for finding entries, so the way-out row steps aside --
+    /// otherwise it would take row zero, where `set_filter` parks the cursor,
+    /// and Enter on a search result would walk up instead.
+    #[test]
+    fn parent_row_steps_aside_while_filtering() {
+        let mut s = with_dotfiles();
+        assert!(s.remote.selected_entry().unwrap().is_parent());
+        s.remote.set_filter("app".into());
+        assert_eq!(s.remote.visible_len(), 1);
+        assert_eq!(s.remote.selected_entry().unwrap().name, "app.log");
+    }
+
+    /// The text filter and the dotfile filter compose rather than override.
+    #[test]
+    fn text_filter_still_respects_hidden() {
+        let mut s = with_dotfiles();
+        s.remote.set_filter("sh".into());
+        // ".ssh" and ".bashrc" both match "sh" but are hidden.
+        assert_eq!(s.remote.visible_len(), 0);
+        s.toggle_hidden();
+        assert_eq!(s.remote.visible_len(), 2);
     }
 
     #[test]

--- a/src/sftp/model.rs
+++ b/src/sftp/model.rs
@@ -132,33 +132,52 @@ impl Pane {
     /// entry in it. It is *not* exempt from the text filter: while searching,
     /// the user is after something specific, and a `..` sitting at the top of
     /// the results would take the cursor `set_filter` parks on row zero.
-    fn is_visible(&self, entry: &FileEntry) -> bool {
+    fn is_visible(&self, entry: &FileEntry, needle: &str) -> bool {
         if entry.is_parent() {
-            return self.filter.is_empty();
+            return needle.is_empty();
         }
         if !self.show_hidden && entry.name.starts_with('.') {
             return false;
         }
-        self.filter.is_empty()
-            || entry
-                .name
-                .to_lowercase()
-                .contains(&self.filter.to_lowercase())
+        needle.is_empty() || entry.name.to_lowercase().contains(needle)
+    }
+
+    /// The text filter, lowercased once per query rather than per entry:
+    /// `visible_indices` runs for both panes on every frame.
+    fn needle(&self) -> String {
+        self.filter.to_lowercase()
     }
 
     /// Indices into `entries` that are currently listed.
     pub fn visible_indices(&self) -> Vec<usize> {
+        let needle = self.needle();
         self.entries
             .iter()
             .enumerate()
-            .filter(|(_, e)| self.is_visible(e))
+            .filter(|(_, e)| self.is_visible(e, &needle))
             .map(|(i, _)| i)
             .collect()
     }
 
     /// Number of entries currently listed.
     pub fn visible_len(&self) -> usize {
-        self.entries.iter().filter(|e| self.is_visible(e)).count()
+        let needle = self.needle();
+        self.entries
+            .iter()
+            .filter(|e| self.is_visible(e, &needle))
+            .count()
+    }
+
+    /// Entries the dotfile filter is currently keeping off screen, so the pane
+    /// can say so instead of looking mysteriously short.
+    pub fn hidden_len(&self) -> usize {
+        if self.show_hidden {
+            return 0;
+        }
+        self.entries
+            .iter()
+            .filter(|e| !e.is_parent() && e.name.starts_with('.'))
+            .count()
     }
 
     /// Set the filter text and move the cursor to the top of the filtered view.
@@ -169,9 +188,10 @@ impl Pane {
 
     /// The entry under the cursor, if any.
     pub fn selected_entry(&self) -> Option<&FileEntry> {
+        let needle = self.needle();
         self.entries
             .iter()
-            .filter(|e| self.is_visible(e))
+            .filter(|e| self.is_visible(e, &needle))
             .nth(self.selected)
     }
 
@@ -453,11 +473,21 @@ impl SftpState {
     /// the new state so the caller can persist it.
     pub fn toggle_hidden(&mut self) -> bool {
         let show = !self.local.show_hidden;
-        self.local.show_hidden = show;
-        self.remote.show_hidden = show;
-        // The cursor was indexing the old listing; keep it inside the new one.
-        self.local.clamp_selection();
-        self.remote.clamp_selection();
+        for pane in [&mut self.local, &mut self.remote] {
+            // `selected` indexes the *visible* listing, so revealing rows above
+            // the cursor would slide it onto a different entry. Re-find the one
+            // it was on instead.
+            let was_on = pane.selected_entry().map(|e| e.name.clone());
+            pane.show_hidden = show;
+            match was_on.and_then(|name| {
+                pane.visible_indices()
+                    .iter()
+                    .position(|i| pane.entries[*i].name == name)
+            }) {
+                Some(pos) => pane.selected = pos,
+                None => pane.clamp_selection(),
+            }
+        }
         show
     }
 
@@ -755,6 +785,54 @@ mod tests {
             "cursor left past the end of the listing"
         );
         assert!(s.remote.selected_entry().is_some());
+    }
+
+    /// Revealing rows above the cursor must not slide it onto a different
+    /// entry: `selected` indexes the visible listing, not `entries`.
+    #[test]
+    fn toggling_hidden_keeps_the_cursor_on_its_entry() {
+        let mut s = with_dotfiles();
+        // Listed: "..", "app.log". Sit on the file.
+        s.remote.selected = 1;
+        assert_eq!(s.remote.selected_entry().unwrap().name, "app.log");
+        // Revealing ".ssh" and ".bashrc" inserts rows above it.
+        s.toggle_hidden();
+        assert_eq!(
+            s.remote.selected_entry().unwrap().name,
+            "app.log",
+            "cursor slid onto another entry"
+        );
+        // And back again.
+        s.toggle_hidden();
+        assert_eq!(s.remote.selected_entry().unwrap().name, "app.log");
+    }
+
+    /// Hiding the entry the cursor is on has to land it somewhere valid.
+    #[test]
+    fn hiding_the_selected_entry_lands_the_cursor_in_range() {
+        let mut s = with_dotfiles();
+        s.toggle_hidden();
+        let idx = s
+            .remote
+            .visible_indices()
+            .iter()
+            .position(|i| s.remote.entries[*i].name == ".bashrc")
+            .unwrap();
+        s.remote.selected = idx;
+        s.toggle_hidden();
+        assert!(s.remote.selected < s.remote.visible_len());
+        assert!(s.remote.selected_entry().is_some());
+    }
+
+    /// The pane reports what it is holding back, so a short listing isn't a
+    /// mystery once the setting has persisted into a later session.
+    #[test]
+    fn hidden_len_counts_what_the_filter_holds_back() {
+        let mut s = with_dotfiles();
+        assert_eq!(s.remote.hidden_len(), 2, ".ssh and .bashrc");
+        assert_eq!(s.local.hidden_len(), 1, ".config");
+        s.toggle_hidden();
+        assert_eq!(s.remote.hidden_len(), 0, "nothing held back when shown");
     }
 
     /// Searching is for finding entries, so the way-out row steps aside --

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -538,6 +538,7 @@ fn footer_keybinds(app: &App) -> Vec<(String, &'static str)> {
             ("r".into(), "refresh"),
             ("s".into(), "ssh"),
             ("o".into(), "2nd host"),
+            (".".into(), "hidden"),
             ("/".into(), "search"),
             ("Esc".into(), "back"),
             ("?".into(), "help"),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -538,7 +538,14 @@ fn footer_keybinds(app: &App) -> Vec<(String, &'static str)> {
             ("r".into(), "refresh"),
             ("s".into(), "ssh"),
             ("o".into(), "2nd host"),
-            (".".into(), "hidden"),
+            (
+                ".".into(),
+                if app.sftp_show_hidden {
+                    "hide dotfiles"
+                } else {
+                    "show hidden"
+                },
+            ),
             ("/".into(), "search"),
             ("Esc".into(), "back"),
             ("?".into(), "help"),

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -163,6 +163,7 @@ fn help_lines() -> Vec<Line<'static>> {
             "o / O",
             "Point the left pane at a second server / back to local files",
         ),
+        entry(".", "Show or hide dotfiles in both panes (remembered)"),
         entry("c / u", "Run queue / remove last queued transfer"),
         entry("d", "Delete selected file/folder (recursive)"),
         entry("n / R", "New folder / rename in the focused pane"),

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -325,11 +325,14 @@ fn render_pane(
         // filtered out -- which is exactly what a root directory of dotfiles
         // looks like, since it has no ".." row to fall back on.
         let msg = match (pane.filter.is_empty(), hidden > 0) {
-            (true, true) => "(all hidden — press . to show)",
-            (true, false) => "(empty)",
-            (false, _) => "(no matches)",
+            (true, true) => "(all hidden — press . to show)".to_string(),
+            (true, false) => "(empty)".to_string(),
+            // A search can come up empty *because* of the dotfile filter; say
+            // so rather than letting the user conclude the entry isn't there.
+            (false, true) => format!("(no matches — {hidden} hidden, . to show)"),
+            (false, false) => "(no matches)".to_string(),
         };
-        buf.set_string(inner_x, top, msg, theme::dim());
+        buf.set_string(inner_x, top, &msg, theme::dim());
         return;
     }
 

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -391,7 +391,7 @@ fn render_queue(
         let (text, style) = match notice {
             Some(n) => (format!("⚠ {n}"), theme::amber()),
             None => (
-                "queue: empty  (← download · → upload · u remove · c run · o second host)"
+                "queue: empty  (← download · → upload · c run · . hidden · o second host)"
                     .to_string(),
                 theme::dim(),
             ),

--- a/src/tui/screens/sftp.rs
+++ b/src/tui/screens/sftp.rs
@@ -272,11 +272,24 @@ fn render_pane(
     let total = pane.entries.len();
     let vis = pane.visible_indices();
     let vis_n = vis.len();
+    // The count has to be of what's on screen: counting entries the dotfile
+    // filter is holding back would leave the pane claiming rows it isn't
+    // drawing. Say how many are held back instead, since the setting persists
+    // and would otherwise be invisible on a later run.
+    let hidden = pane.hidden_len();
+    let hidden_note = if hidden > 0 {
+        format!(" · {hidden} hidden")
+    } else {
+        String::new()
+    };
     // Subtitle makes an *applied* filter obvious even when not actively typing.
     let count = if pane.filter.is_empty() {
-        format!("{} · {}", pane.cwd.display(), total)
+        format!("{} · {}{}", pane.cwd.display(), vis_n, hidden_note)
     } else {
-        format!("filter: {} ({}/{})", pane.filter, vis_n, total)
+        format!(
+            "filter: {} ({}/{}){}",
+            pane.filter, vis_n, total, hidden_note
+        )
     };
     render_panel_box(buf, rect, title, Some(&count), false);
 
@@ -308,10 +321,13 @@ fn render_pane(
     }
 
     if vis.is_empty() {
-        let msg = if pane.filter.is_empty() {
-            "(empty)"
-        } else {
-            "(no matches)"
+        // "(empty)" would be a lie when the only entries are dotfiles being
+        // filtered out -- which is exactly what a root directory of dotfiles
+        // looks like, since it has no ".." row to fall back on.
+        let msg = match (pane.filter.is_empty(), hidden > 0) {
+            (true, true) => "(all hidden — press . to show)",
+            (true, false) => "(empty)",
+            (false, _) => "(no matches)",
         };
         buf.set_string(inner_x, top, msg, theme::dim());
         return;


### PR DESCRIPTION
Closes #44

A home directory listed `.cache`, `.config`, `.docker`, `.local` and `.ssh`
before anything a person came for. Dotfiles are now hidden, `.` shows them, the
toggle covers both panes and persists through `ui_state` like collapsed host
groups.

## Behaviour change

This changes what an existing install shows on first run, so the change is
visible rather than silent:

- The pane subtitle says how many entries it is holding back (`~ · 4 · 20 hidden`).
- A directory of nothing but dotfiles says `(all hidden — press . to show)`
  rather than `(empty)` — reachable at the filesystem root, which has no `..`
  row to soften it.
- The footer label says what `.` will do, rather than reading "hidden" in both
  states.
- A search that comes up empty says how many entries are held back.

Reverting the default is one line (`show_hidden: false` in `Pane::new`) if it
turns out wrong in daily use.

## The `..` row and searching

Two rules that took a round of tests to get right:

- `..` is exempt from the dotfile rule — its name starts with a dot, but it is
  the way out of a directory, not an entry in it.
- `..` is **not** exempt from the text filter. `set_filter` parks the cursor on
  row zero, so leaving it at the top of a search meant Enter on a result walked
  up instead of opening it. Two existing tests caught this.
- A search **beginning** with a dot lifts the hiding entirely: `/` + `.ssh` is
  the likeliest search in an SSH tool, and answering it with "no matches" about
  a directory in plain sight would be obtuse.

## Also

`n` or `R` with a dotted name succeeded and the entry vanished, which reads as
failure; both now leave a notice. Filtering had lived in three copies
(`visible_indices`, `visible_len`, `selected_entry`), each repeating the match —
they now share one `is_visible` predicate instead of gaining a fourth.

## What the adversarial review changed

Two independent critics, every finding reproduced before acting:

- The subtitle counted `entries.len()`, announcing "42" above two drawn rows.
- Toggling slid the cursor onto a different entry, since `selected` indexes the
  visible listing and revealing rows above it shifts everything down. It now
  re-finds the entry by name.
- Consolidating the filter had lost the hoisted lowercase needle, so it was
  recomputed per entry — on a path that runs for both panes every frame.
- The two tests above (persistence round-trip, `.` as a filter character) were
  missing; the first pass tested only the pure model.

## Testing

`just test` green: 498 unit (+11), 59 e2e, 42 smoke. `cargo fmt --check` and
`cargo clippy --all-targets` clean.

Not covered, and worth knowing: `.` is hardcoded rather than a `KeyAction`, so
it can't be rebound through Ctrl+K. That matches the existing `o`/`c`/`u`/`n`/`R`/`M`
keys in this screen; making the set configurable is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Written by Claude Opus 5 (Claude Code) on behalf of the maintainer._
