### PR TITLE
build(npm): publish SSHub to npm as sshub-tui plus prebuilt platform packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,12 +80,25 @@ jobs:
     name: Publish to npm
     needs: build
     runs-on: ubuntu-latest
+    # Trusted publishing (OIDC) rather than a long-lived NPM_TOKEN: every publish
+    # authenticates with a short-lived token minted for this workflow, and npm
+    # attaches provenance on its own. npm is also retiring direct publishes from
+    # 2FA-bypass tokens (announced 2026-07-08, effective around January 2027), so
+    # a token-based job would have had to move regardless.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+      # Trusted publishing needs npm >= 11.5.1, newer than what Node bundles.
+      - name: Ensure an npm that speaks OIDC
+        run: |
+          npm install -g npm@latest
+          npm --version
       - name: Collect the built tarballs
         uses: actions/download-artifact@v4
         with:
@@ -95,11 +108,13 @@ jobs:
       # release can never diverge. The version comes from the tag rather than
       # Cargo.toml, so a mismatch fails here instead of reaching the registry.
       # Publishes the three platform packages first and the `sshub` wrapper last.
-      # Requires the NPM_TOKEN repo secret.
+      #
+      # Each of the four packages needs a trusted publisher configured on
+      # npmjs.com pointing at this repository and `release.yml`, otherwise this
+      # step stops with ENEEDAUTH.
       - name: Assemble and publish
         env:
           TARBALL_DIR: npm-tarballs
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm/build.sh "${GITHUB_REF_NAME#v}" --publish
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,32 @@ jobs:
           body_path: CHANGELOG.md
           generate_release_notes: false
 
+  npm:
+    name: Publish to npm
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Collect the built tarballs
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: npm-tarballs
+      # Repacks the very tarballs this release ships, so npm and the GitHub
+      # release can never diverge. The version comes from the tag rather than
+      # Cargo.toml, so a mismatch fails here instead of reaching the registry.
+      # Publishes the three platform packages first and the `sshub` wrapper last.
+      # Requires the NPM_TOKEN repo secret.
+      - name: Assemble and publish
+        env:
+          TARBALL_DIR: npm-tarballs
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm/build.sh "${GITHUB_REF_NAME#v}" --publish
+
   publish:
     name: Publish to crates.io
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 
 # VHS intermediates (mp4 masters + palettes) produced by demo/record.sh
 /demo/build/
+npm/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to SSHub are documented in this file.
 
 ### Added
 
+- **Install from npm** (issue #51) - `npx sshub` and `npm install -g sshub` now
+  work. The npm package ships the same prebuilt binaries the GitHub release does,
+  delivered as platform-specific optional dependencies, so there is no build step
+  and nothing is fetched from outside the registry. Prebuilt for Linux x64, macOS
+  arm64 and macOS x64; every other platform keeps using `cargo install sshub`.
 - **UI motion pass** (issue #35) - the interface moves instead of cutting
   between states. Popups drop in from off the top and are thrown back up on
   close; tab bodies slide; a zoomed panel morphs out of its grid slot; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ All notable changes to SSHub are documented in this file.
 
 ### Added
 
-- **Install from npm** (issue #51) - `npx sshub` and `npm install -g sshub` now
-  work. The npm package ships the same prebuilt binaries the GitHub release does,
-  delivered as platform-specific optional dependencies, so there is no build step
-  and nothing is fetched from outside the registry. Prebuilt for Linux x64, macOS
-  arm64 and macOS x64; every other platform keeps using `cargo install sshub`.
+- **Install from npm** (issue #51) - `npx sshub-tui` and `npm install -g sshub-tui`
+  now work, installing a command still called `sshub`. The npm package ships the
+  same prebuilt binaries the GitHub release does, delivered as platform-specific
+  optional dependencies, so there is no build step and nothing is fetched from
+  outside the registry. Prebuilt for Linux x64, macOS arm64 and macOS x64; every
+  other platform keeps using `cargo install sshub`.
 - **UI motion pass** (issue #35) - the interface moves instead of cutting
   between states. Popups drop in from off the top and are thrown back up on
   close; tab bodies slide; a zoomed panel morphs out of its grid slot; the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["command-line-utilities"]
 # Keep the published crate lean and installable: drop the heavy demo media
 # (README GIFs/screenshots render from GitHub, not the crate) and CI config.
 exclude = [
+    "npm",
     "demo/gifs",
     "demo/screenshots",
     "demo/tapes",

--- a/Justfile
+++ b/Justfile
@@ -14,6 +14,18 @@ test:
 build:
     cargo build --release
 
+# Assemble the npm packages into npm/dist from the tarballs attached to the
+# matching GitHub release. Nothing is compiled and nothing is published; the
+# shim is exercised end to end first. Version defaults to Cargo.toml's.
+npm-build version="":
+    npm/build.sh {{version}}
+
+# Assemble, verify, then publish to npm. Needs `npm login` (or a token in
+# ~/.npmrc). Platform packages publish first, the `sshub` wrapper last, so the
+# wrapper never lands pointing at binaries that do not exist yet.
+npm-publish version="":
+    npm/build.sh {{version}} --publish
+
 # Record README GIFs + screenshots with VHS (requires `vhs` and `ffmpeg` on
 # PATH). Pass tape names to record a subset: `just record-gifs overview sftp`.
 record-gifs *tapes: build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # SSHub
 
 [![crates.io](https://img.shields.io/crates/v/sshub.svg)](https://crates.io/crates/sshub)
+[![crates.io downloads](https://img.shields.io/crates/d/sshub.svg?label=crates.io%20downloads)](https://crates.io/crates/sshub)
+[![npm](https://img.shields.io/npm/v/sshub.svg)](https://www.npmjs.com/package/sshub)
+[![npm downloads](https://img.shields.io/npm/dm/sshub.svg?label=npm%20downloads%2Fmonth)](https://www.npmjs.com/package/sshub)
 
 A terminal UI for managing and connecting to SSH hosts. Combines your `~/.ssh/config` with a built-in host database, tunnels, key management, and an audit log -- all in one keyboard-driven interface.
 
@@ -65,6 +68,17 @@ The settings overlay (`Ctrl+H`) — toggle an opaque background, OS logos, quit 
 - **Mouse support** — click tabs, select rows, scroll panels, double-click to connect
 
 ## Install
+
+From [npm](https://www.npmjs.com/package/sshub), prebuilt, no toolchain required:
+
+```bash
+npx sshub              # run it without installing
+npm install -g sshub
+```
+
+Prebuilt for Linux x64, macOS arm64 and macOS x64. The binary arrives as a
+platform-specific optional dependency, so nothing is compiled and nothing is
+fetched from outside the registry. Any other platform builds from source below.
 
 From [crates.io](https://crates.io/crates/sshub):
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![crates.io](https://img.shields.io/crates/v/sshub.svg)](https://crates.io/crates/sshub)
 [![crates.io downloads](https://img.shields.io/crates/d/sshub.svg?label=crates.io%20downloads)](https://crates.io/crates/sshub)
-[![npm](https://img.shields.io/npm/v/sshub.svg)](https://www.npmjs.com/package/sshub)
-[![npm downloads](https://img.shields.io/npm/dm/sshub.svg?label=npm%20downloads%2Fmonth)](https://www.npmjs.com/package/sshub)
+[![npm](https://img.shields.io/npm/v/sshub-tui.svg)](https://www.npmjs.com/package/sshub-tui)
+[![npm downloads](https://img.shields.io/npm/dm/sshub-tui.svg?label=npm%20downloads%2Fmonth)](https://www.npmjs.com/package/sshub-tui)
 
 A terminal UI for managing and connecting to SSH hosts. Combines your `~/.ssh/config` with a built-in host database, tunnels, key management, and an audit log -- all in one keyboard-driven interface.
 
@@ -69,12 +69,15 @@ The settings overlay (`Ctrl+H`) — toggle an opaque background, OS logos, quit 
 
 ## Install
 
-From [npm](https://www.npmjs.com/package/sshub), prebuilt, no toolchain required:
+From [npm](https://www.npmjs.com/package/sshub-tui), prebuilt, no toolchain required:
 
 ```bash
-npx sshub              # run it without installing
-npm install -g sshub
+npx sshub-tui              # run it without installing
+npm install -g sshub-tui   # then just: sshub
 ```
+
+The installed command is `sshub`; the package is `sshub-tui` because npm rejects
+the bare `sshub` name as too close to the existing `ssh2` and `sshpk`.
 
 Prebuilt for Linux x64, macOS arm64 and macOS x64. The binary arrives as a
 platform-specific optional dependency, so nothing is compiled and nothing is

--- a/npm/build.sh
+++ b/npm/build.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Assemble, verify and optionally publish the npm packages for a released version.
+#
+# No binary is built here. The binaries are the tarballs the release workflow
+# already attached to the `vX.Y.Z` GitHub release, so what npm serves is byte for
+# byte what the release serves.
+#
+# Usage:
+#   npm/build.sh                      # version from Cargo.toml, assemble + verify
+#   npm/build.sh 0.10.0               # explicit version
+#   npm/build.sh --publish            # assemble, verify, then publish to npm
+#   TARBALL_DIR=dir npm/build.sh      # use tarballs from a directory instead of
+#                                     # downloading them (used by CI, which has
+#                                     # them as workflow artifacts already)
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+version=""
+publish=0
+for arg in "$@"; do
+    case "$arg" in
+        "") ;;
+        --publish) publish=1 ;;
+        -*)
+            echo "unknown flag: $arg" >&2
+            exit 2
+            ;;
+        *) version="$arg" ;;
+    esac
+done
+
+if [ -z "$version" ]; then
+    version="$(sed -n '/^\[package\]/,/^\[/ s/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+fi
+[ -n "$version" ] || {
+    echo "could not determine the version" >&2
+    exit 1
+}
+
+dist="npm/dist"
+# Release order matters: the wrapper is published last, after the packages its
+# optionalDependencies point at exist. Published the other way round, npm
+# resolves the wrapper to no binary at all and `npx sshub` fails for everyone who
+# installs in that window.
+packages=(sshub-linux-x64 sshub-darwin-arm64 sshub-darwin-x64 sshub)
+
+# triple | package | os | cpu
+targets=(
+    "x86_64-unknown-linux-gnu|sshub-linux-x64|linux|x64"
+    "aarch64-apple-darwin|sshub-darwin-arm64|darwin|arm64"
+    "x86_64-apple-darwin|sshub-darwin-x64|darwin|x64"
+)
+
+echo "==> assembling npm packages for $version"
+rm -rf "$dist"
+mkdir -p "$dist/tarballs"
+
+if [ -n "${TARBALL_DIR:-}" ]; then
+    cp "$TARBALL_DIR"/sshub-*.tar.gz "$dist/tarballs/"
+else
+    gh release download "v$version" --pattern 'sshub-*.tar.gz' --dir "$dist/tarballs"
+fi
+
+for entry in "${targets[@]}"; do
+    IFS='|' read -r triple pkg os cpu <<<"$entry"
+    tarball="$dist/tarballs/sshub-v$version-$triple.tar.gz"
+    [ -f "$tarball" ] || {
+        echo "missing $tarball" >&2
+        exit 1
+    }
+    mkdir -p "$dist/$pkg/bin"
+    tar xzf "$tarball" -C "$dist/$pkg/bin" sshub
+    chmod 755 "$dist/$pkg/bin/sshub"
+    sed -e "s|@NAME@|$pkg|g" -e "s|@VERSION@|$version|g" \
+        -e "s|@OS@|$os|g" -e "s|@CPU@|$cpu|g" \
+        npm/platform/package.json.in >"$dist/$pkg/package.json"
+    sed -e "s|@NAME@|$pkg|g" -e "s|@TRIPLE@|$triple|g" \
+        npm/platform/README.md.in >"$dist/$pkg/README.md"
+    cp LICENSE "$dist/$pkg/LICENSE"
+    echo "    $pkg  ($triple)"
+done
+
+mkdir -p "$dist/sshub"
+cp -r npm/wrapper/bin "$dist/sshub/bin"
+chmod 755 "$dist/sshub/bin/sshub.js"
+sed -e "s|@VERSION@|$version|g" npm/wrapper/package.json.in >"$dist/sshub/package.json"
+cp npm/wrapper/README.md "$dist/sshub/README.md"
+cp LICENSE "$dist/sshub/LICENSE"
+echo "    sshub  (wrapper)"
+
+echo "==> verifying"
+host="$(uname -s)-$(uname -m)"
+if [ "$host" = "Linux-x86_64" ]; then
+    # Catches the packaging pointing at a different release than it claims.
+    got="$("$dist/sshub-linux-x64/bin/sshub" --version)"
+    [ "$got" = "sshub $version" ] || {
+        echo "binary reports '$got', packaging says '$version'" >&2
+        exit 1
+    }
+    # Mirror a real install so the shim's require.resolve has somewhere to look,
+    # then drive the shim exactly the way `npx sshub` would.
+    mkdir -p "$dist/node_modules"
+    ln -sfn ../sshub-linux-x64 "$dist/node_modules/sshub-linux-x64"
+    got="$(node "$dist/sshub/bin/sshub.js" --version)"
+    [ "$got" = "sshub $version" ] || {
+        echo "the shim did not reach the binary, it printed '$got'" >&2
+        exit 1
+    }
+    echo "    binary and shim both report sshub $version"
+else
+    echo "    skipped the exec check: this host is $host, not Linux-x86_64"
+fi
+
+for pkg in "${packages[@]}"; do
+    (cd "$dist/$pkg" && npm pack --dry-run)
+done
+
+if [ "$publish" = 0 ]; then
+    echo "==> assembled in $dist, nothing published"
+    echo "    publish order: ${packages[*]}"
+    exit 0
+fi
+
+echo "==> publishing $version"
+for pkg in "${packages[@]}"; do
+    echo "    $pkg@$version"
+    (cd "$dist/$pkg" && npm publish --access public)
+done
+echo "==> published: npx sshub@$version"

--- a/npm/build.sh
+++ b/npm/build.sh
@@ -40,11 +40,15 @@ fi
 }
 
 dist="npm/dist"
+# The wrapper is `sshub-tui`, not `sshub`: npm refuses the bare name for being too
+# close to the existing `ssh2` and `sshpk`. The command it installs is still
+# `sshub`, since the bin name is independent of the package name.
+wrapper="sshub-tui"
 # Release order matters: the wrapper is published last, after the packages its
-# optionalDependencies point at exist. Published the other way round, npm
-# resolves the wrapper to no binary at all and `npx sshub` fails for everyone who
-# installs in that window.
-packages=(sshub-linux-x64 sshub-darwin-arm64 sshub-darwin-x64 sshub)
+# optionalDependencies point at exist. Published the other way round, npm resolves
+# the wrapper to no binary at all and it fails for everyone who installs in that
+# window.
+packages=(sshub-linux-x64 sshub-darwin-arm64 sshub-darwin-x64 "$wrapper")
 
 # triple | package | os | cpu
 targets=(
@@ -82,13 +86,13 @@ for entry in "${targets[@]}"; do
     echo "    $pkg  ($triple)"
 done
 
-mkdir -p "$dist/sshub"
-cp -r npm/wrapper/bin "$dist/sshub/bin"
-chmod 755 "$dist/sshub/bin/sshub.js"
-sed -e "s|@VERSION@|$version|g" npm/wrapper/package.json.in >"$dist/sshub/package.json"
-cp npm/wrapper/README.md "$dist/sshub/README.md"
-cp LICENSE "$dist/sshub/LICENSE"
-echo "    sshub  (wrapper)"
+mkdir -p "$dist/$wrapper"
+cp -r npm/wrapper/bin "$dist/$wrapper/bin"
+chmod 755 "$dist/$wrapper/bin/sshub.js"
+sed -e "s|@VERSION@|$version|g" npm/wrapper/package.json.in >"$dist/$wrapper/package.json"
+cp npm/wrapper/README.md "$dist/$wrapper/README.md"
+cp LICENSE "$dist/$wrapper/LICENSE"
+echo "    $wrapper  (wrapper)"
 
 echo "==> verifying"
 host="$(uname -s)-$(uname -m)"
@@ -103,7 +107,7 @@ if [ "$host" = "Linux-x86_64" ]; then
     # then drive the shim exactly the way `npx sshub` would.
     mkdir -p "$dist/node_modules"
     ln -sfn ../sshub-linux-x64 "$dist/node_modules/sshub-linux-x64"
-    got="$(node "$dist/sshub/bin/sshub.js" --version)"
+    got="$(node "$dist/$wrapper/bin/sshub.js" --version)"
     [ "$got" = "sshub $version" ] || {
         echo "the shim did not reach the binary, it printed '$got'" >&2
         exit 1
@@ -125,7 +129,14 @@ fi
 
 echo "==> publishing $version"
 for pkg in "${packages[@]}"; do
+    # A version in the registry is immutable, so re-running after a partial
+    # failure (or re-running a release job) must skip what already landed instead
+    # of dying on "cannot publish over the previously published version".
+    if npm view "$pkg@$version" version >/dev/null 2>&1; then
+        echo "    $pkg@$version is already published, skipping"
+        continue
+    fi
     echo "    $pkg@$version"
     (cd "$dist/$pkg" && npm publish --access public)
 done
-echo "==> published: npx sshub@$version"
+echo "==> published: npx $wrapper@$version"

--- a/npm/platform/README.md.in
+++ b/npm/platform/README.md.in
@@ -1,0 +1,8 @@
+# @NAME@
+
+The SSHub binary for `@TRIPLE@`, built by the project's release workflow.
+
+Do not install this package directly. Install [`sshub`](https://www.npmjs.com/package/sshub)
+instead; it depends on this one and picks the right build for your machine.
+
+Licensed under AGPL-3.0-or-later.

--- a/npm/platform/README.md.in
+++ b/npm/platform/README.md.in
@@ -2,7 +2,8 @@
 
 The SSHub binary for `@TRIPLE@`, built by the project's release workflow.
 
-Do not install this package directly. Install [`sshub`](https://www.npmjs.com/package/sshub)
-instead; it depends on this one and picks the right build for your machine.
+Do not install this package directly. Install
+[`sshub-tui`](https://www.npmjs.com/package/sshub-tui) instead; it depends on this one and picks
+the right build for your machine.
 
 Licensed under AGPL-3.0-or-later.

--- a/npm/platform/package.json.in
+++ b/npm/platform/package.json.in
@@ -1,0 +1,22 @@
+{
+  "name": "@NAME@",
+  "version": "@VERSION@",
+  "description": "SSHub prebuilt binary for @OS@ @CPU@",
+  "homepage": "https://github.com/Petyok/SSHub#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Petyok/SSHub.git"
+  },
+  "license": "AGPL-3.0-or-later",
+  "files": [
+    "bin",
+    "LICENSE"
+  ],
+  "os": [
+    "@OS@"
+  ],
+  "cpu": [
+    "@CPU@"
+  ],
+  "preferUnplugged": true
+}

--- a/npm/wrapper/README.md
+++ b/npm/wrapper/README.md
@@ -1,0 +1,27 @@
+# sshub
+
+A terminal UI for the SSH hosts you actually use: browse and search them, connect in embedded
+tabs, move files over SFTP with a dual-pane browser, manage keys and tunnels.
+
+```bash
+npx sshub          # run without installing
+npm install -g sshub
+```
+
+This package ships prebuilt binaries, so there is no build step and nothing is downloaded from
+outside the registry: the platform-specific binary arrives as an optional dependency and npm
+skips the ones that do not match your machine.
+
+Prebuilt for Linux x64, macOS arm64 and macOS x64. On anything else, build from source:
+
+```bash
+cargo install sshub
+```
+
+`ssh` must be on your `PATH`. On Linux, host passwords and key passphrases are stored through a
+Secret Service provider (gnome-keyring, KWallet), which has to be running and unlocked;
+otherwise SSHub says so and ssh falls back to prompting.
+
+Docs, screenshots and the changelog: https://github.com/Petyok/SSHub
+
+Licensed under AGPL-3.0-or-later.

--- a/npm/wrapper/README.md
+++ b/npm/wrapper/README.md
@@ -1,12 +1,15 @@
-# sshub
+# sshub-tui
 
 A terminal UI for the SSH hosts you actually use: browse and search them, connect in embedded
 tabs, move files over SFTP with a dual-pane browser, manage keys and tunnels.
 
 ```bash
-npx sshub          # run without installing
-npm install -g sshub
+npx sshub-tui              # run without installing
+npm install -g sshub-tui   # then just: sshub
 ```
+
+The command it installs is `sshub`. The package is `sshub-tui` because npm refuses the bare
+`sshub` name for being too close to the existing `ssh2` and `sshpk`.
 
 This package ships prebuilt binaries, so there is no build step and nothing is downloaded from
 outside the registry: the platform-specific binary arrives as an optional dependency and npm

--- a/npm/wrapper/bin/sshub.js
+++ b/npm/wrapper/bin/sshub.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// npm entry point for SSHub.
+//
+// The real binary lives in a per-platform package (`sshub-linux-x64` and
+// friends) that npm installs as an optional dependency and skips everywhere its
+// `os`/`cpu` do not match. So this shim never downloads anything: it resolves
+// the one package that did install and hands the terminal over to it.
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+
+/** Platform key -> package carrying that platform's binary. */
+const PACKAGES = {
+  'linux-x64': 'sshub-linux-x64',
+  'darwin-arm64': 'sshub-darwin-arm64',
+  'darwin-x64': 'sshub-darwin-x64',
+};
+
+function die(message) {
+  process.stderr.write(`sshub: ${message}\n`);
+  process.exit(1);
+}
+
+function main() {
+  const platform = `${process.platform}-${process.arch}`;
+  const pkg = PACKAGES[platform];
+  if (!pkg) {
+    die(
+      `no prebuilt binary for ${platform}. ` +
+        `Prebuilt platforms: ${Object.keys(PACKAGES).join(', ')}. ` +
+        'Build from source instead: cargo install sshub',
+    );
+  }
+
+  let bin;
+  try {
+    bin = require.resolve(`${pkg}/bin/sshub`);
+  } catch {
+    // The optional dependency is missing, which usually means the install ran
+    // with --no-optional or was interrupted.
+    die(`${pkg} is not installed. Reinstall with: npm install -g sshub`);
+  }
+
+  // npm preserves the executable bit, but a zip-based store or an over-eager
+  // umask can drop it. Cheaper to fix than to explain.
+  try {
+    fs.accessSync(bin, fs.constants.X_OK);
+  } catch {
+    try {
+      fs.chmodSync(bin, 0o755);
+    } catch {
+      die(`${bin} is not executable`);
+    }
+  }
+
+  // `stdio: 'inherit'` hands over the real tty, which the TUI needs, and puts
+  // the child in the same process group so Ctrl+C reaches it from the terminal
+  // rather than through us.
+  const result = spawnSync(bin, process.argv.slice(2), { stdio: 'inherit' });
+  if (result.error) {
+    die(`could not start ${bin}: ${result.error.message}`);
+  }
+  if (result.signal) {
+    // Die the same way the binary did, so a shell sees the real cause.
+    process.kill(process.pid, result.signal);
+    return;
+  }
+  process.exit(result.status ?? 1);
+}
+
+main();

--- a/npm/wrapper/package.json.in
+++ b/npm/wrapper/package.json.in
@@ -1,5 +1,5 @@
 {
-  "name": "sshub",
+  "name": "sshub-tui",
   "version": "@VERSION@",
   "description": "SSHub: a TUI launcher for SSH hosts",
   "keywords": [

--- a/npm/wrapper/package.json.in
+++ b/npm/wrapper/package.json.in
@@ -1,0 +1,38 @@
+{
+  "name": "sshub",
+  "version": "@VERSION@",
+  "description": "SSHub: a TUI launcher for SSH hosts",
+  "keywords": [
+    "ssh",
+    "tui",
+    "terminal",
+    "launcher",
+    "sftp"
+  ],
+  "homepage": "https://github.com/Petyok/SSHub#readme",
+  "bugs": "https://github.com/Petyok/SSHub/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Petyok/SSHub.git"
+  },
+  "license": "AGPL-3.0-or-later",
+  "bin": {
+    "sshub": "bin/sshub.js"
+  },
+  "files": [
+    "bin",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "linux",
+    "darwin"
+  ],
+  "optionalDependencies": {
+    "sshub-darwin-arm64": "@VERSION@",
+    "sshub-darwin-x64": "@VERSION@",
+    "sshub-linux-x64": "@VERSION@"
+  }
+}


### PR DESCRIPTION
Closes #51.

## What

`npx sshub-tui` and `npm install -g sshub-tui`, serving the same prebuilt binaries the GitHub
release already serves. The installed command is `sshub`.

A thin `sshub-tui` wrapper package carries a `bin` shim; the binary itself lives in one package
per platform (`sshub-linux-x64`, `sshub-darwin-arm64`, `sshub-darwin-x64`) declared as an
`optionalDependency` with `os`/`cpu` set, so npm installs exactly the one that matches and skips
the rest. No `postinstall`, no download outside the registry, so `npm ci --ignore-scripts`,
offline mirrors and locked-down registries all work.

`npm/build.sh` assembles the packages from the tarballs attached to the matching `vX.Y.Z`
release, so npm and the release cannot drift apart. It refuses to continue unless the unpacked
binary and the shim both report the version being packaged, then prints `npm pack --dry-run` for
each package. `just npm-build` assembles, `just npm-publish` assembles and publishes.

## Why the package is not called `sshub`

The registry rejects the bare name with a 403: "Package name too similar to existing packages
ssh2, sshpk". The three platform packages passed the same filter, so only the wrapper needed a
different name. `bin` is independent of the package name, so `sshub` remains what you type.

## State of the registry

The three platform packages are already published at `0.10.0`, from a manual run that then hit
the 403 on the wrapper. Nothing has to be republished: registry versions are immutable, the
wrapper's `optionalDependencies` point at those exact versions, and the publish loop now skips
what is already there rather than failing on it.

## Verified

- `npm/build.sh` end to end: three platform packages plus the wrapper assembled from the
  `v0.10.0` tarballs, binary and shim both reporting `sshub 0.10.0`.
- The real thing, against the live registry: `npm install ./sshub-tui-0.10.0.tgz` into a clean
  project resolved `sshub-linux-x64@0.10.0` from npm, linked `node_modules/.bin/sshub`, and both
  `./node_modules/.bin/sshub --version` and `npx sshub --version` printed `sshub 0.10.0`.
- Shim failure paths, each one line and exit 1: unsupported platform (forced
  `process.platform = win32`), platform package missing.
- Exit codes pass through: an unknown CLI subcommand exits 2 through the shim, same as the
  binary.
- `cargo package --list` does not carry `npm/`, so the packaging does not ride to crates.io.
- `cargo fmt --check` clean, `cargo clippy --all-targets` no errors, `just test` green (498 unit,
  59 e2e, 42 smoke, 1 config_load). No Rust changed in this PR.

## Before merging

1. **Publish the wrapper** (`just npm-publish`, 2FA interactively). The platform packages get
   skipped as already published. The two npm badges in the README read `package not found` until
   this lands.
2. **Configure a trusted publisher on each of the four packages** (npmjs.com → package →
   Settings → Trusted Publisher → GitHub Actions, repo `Petyok/SSHub`, workflow filename
   `release.yml`, fields are case-sensitive). A package must exist before it can get one, which
   is why the first publish is manual. No repo secret is involved.
3. Optional, recommended once step 2 is verified: per package, Settings → Publishing access →
   "Require two-factor authentication and disallow tokens".

## Why OIDC and not a token

npm [announced on 2026-07-08](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/)
that 2FA-bypass granular access tokens lose sensitive management operations in early August 2026
and direct publish rights around January 2027, keeping only staged publish behind a human 2FA
approval. A `NPM_TOKEN` job would have had to move to trusted publishing anyway, so it starts
there: nothing long-lived in the repository, credentials minted per run, and npm attaches
provenance attestations automatically for a public package from a public repo.

The same release also turned npm's install-time defaults off: no dependency lifecycle scripts, no
git dependencies, no remote tarballs unless explicitly allowed. This package has no lifecycle
scripts at all, so it is unaffected, and the `postinstall`-downloads-from-GitHub design rejected
in #51 would now be broken by default for every npm 12 user. The install tests above ran on npm
12.0.1, i.e. under the new defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
