### PR TITLE
fix(sessions): motion between the dashboard and a session, and stop cycling from opening one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ All notable changes to SSHub are documented in this file.
   on connect only. Re-entering from the dashboard now slides in the same way a
   fresh connect does; re-deriving the mode while already inside a session, when an
   overlay closes over it or a phase changes, does not replay it.
+- **The session slide arrived over a black screen** - it blanked the columns it
+  had not reached yet, so connecting flashed black before the host appeared. The
+  dashboard is now snapshotted the way the session view already was, and the
+  session slides over it.
 - **Narrow footers dropped the wrong hints** - the pairs that say how to get out
   (`? help`, `q quit`) or back into a running session (`resume`) were pushed into
   the middle of the row by whatever was appended after them, panel-zoom hints,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,13 @@ All notable changes to SSHub are documented in this file.
 
 ### Fixed
 
+- **Switching session tabs from the dashboard did not animate** (issue #49) - the
+  same `Ctrl+[` / `Ctrl+]` that slide the highlight inside the full-screen view
+  changed the highlighted chip in the dashboard strip instantly. The strip now
+  carries the highlight across, reading the same travel state the full-screen tab
+  bar does, so the two surfaces cannot drift apart again. A chip collapsed into
+  the `+N` overflow marker has nowhere to travel and is left alone, and reduced
+  motion still jumps straight to the final state.
 - **Arrow keys did nothing in Midnight Commander** (PR #56) - full-screen
   applications ask for application cursor mode (DECCKM) and then expect the
   cursor keys as SS3 sequences, while SSHub always sent the normal CSI ones. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,11 @@ All notable changes to SSHub are documented in this file.
   across instead of teleporting, reading the same travel state the full-screen
   tab bar uses. A chip collapsed into the `+N` overflow marker has nowhere to
   travel and is left alone, and reduced motion jumps straight to the target.
+- **Entering a running session did not animate** - leaving one slid the session
+  off to the right, but arriving cut straight to it, because the slide was armed
+  on connect only. Re-entering from the dashboard now slides in the same way a
+  fresh connect does; re-deriving the mode while already inside a session, when an
+  overlay closes over it or a phase changes, does not replay it.
 - **Narrow footers dropped the wrong hints** - the pairs that say how to get out
   (`? help`, `q quit`) or back into a running session (`resume`) were pushed into
   the middle of the row by whatever was appended after them, panel-zoom hints,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,13 +94,20 @@ All notable changes to SSHub are documented in this file.
 
 ### Fixed
 
-- **Switching session tabs from the dashboard did not animate** (issue #49) - the
-  same `Ctrl+[` / `Ctrl+]` that slide the highlight inside the full-screen view
-  changed the highlighted chip in the dashboard strip instantly. The strip now
-  carries the highlight across, reading the same travel state the full-screen tab
-  bar does, so the two surfaces cannot drift apart again. A chip collapsed into
-  the `+N` overflow marker has nowhere to travel and is left alone, and reduced
-  motion still jumps straight to the final state.
+- **Cycling session tabs from the dashboard threw you into the session** (issue
+  #49) - `Ctrl+[` / `Ctrl+]` there moved the selection *and* immediately opened
+  the session full screen, so a key named "previous / next session tab" left the
+  dashboard entirely, with no transition. It now moves the selection along the
+  session strip and stays put; opening the selected session is what
+  `Ctrl+Shift+S` is for, and the footer says so. The strip carries its highlight
+  across instead of teleporting, reading the same travel state the full-screen
+  tab bar uses. A chip collapsed into the `+N` overflow marker has nowhere to
+  travel and is left alone, and reduced motion jumps straight to the target.
+- **Narrow footers dropped the wrong hints** - the pairs that say how to get out
+  (`? help`, `q quit`) or back into a running session (`resume`) were pushed into
+  the middle of the row by whatever was appended after them, panel-zoom hints,
+  broadcast hints, session hints, and the middle is exactly what truncation eats.
+  They are now moved to the end and pinned explicitly.
 - **Arrow keys did nothing in Midnight Commander** (PR #56) - full-screen
   applications ask for application cursor mode (DECCKM) and then expect the
   cursor keys as SS3 sequences, while SSHub always sent the normal CSI ones. The

--- a/demo/home/.config/sshub/config.toml
+++ b/demo/home/.config/sshub/config.toml
@@ -108,3 +108,28 @@ confirm_no = [
 cancel = ["Esc"]
 tab_sftp = ["2"]
 session_open_sftp = ["Ctrl+Shift+J"]
+generate_key = ["g"]
+push_key = ["Shift+P"]
+local_shell = ["Ctrl+Shift+T"]
+toggle_panel_zoom = [
+    "z",
+    "Alt+Enter",
+]
+focus_panel_left = ["Alt+Left"]
+focus_panel_right = ["Alt+Right"]
+focus_panel_up = ["Alt+Up"]
+focus_panel_down = ["Alt+Down"]
+broadcast = ["b"]
+broadcast_cancel = ["x"]
+
+[session_logging]
+enabled = false
+max_file_bytes = 10485760
+retention_files = 50
+
+[tunnel_reconnect]
+max_attempts = 12
+initial_delay_ms = 1000
+max_delay_ms = 60000
+jitter_ratio = 0.25
+stable_secs = 5

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -229,6 +229,11 @@ pub struct App {
     /// Full-frame snapshot of the last session view, captured each frame while in
     /// a session so it can be slid off to the right when the host is left (#35).
     pub session_snapshot: std::cell::RefCell<Option<ratatui::buffer::Buffer>>,
+    /// Full-frame snapshot of the last dashboard, captured each frame while off
+    /// the session view, so the session sliding in has something to slide *over*
+    /// (#35). Without it the columns the slide has not reached yet are blank, and
+    /// entering a session flashes a black screen before the host arrives.
+    pub dashboard_snapshot: std::cell::RefCell<Option<ratatui::buffer::Buffer>>,
     /// When the host view started exiting (session -> dashboard), driving the
     /// slide-out of `session_snapshot`. `None` at rest / under reduced motion.
     pub session_exit_at: Option<std::time::Instant>,
@@ -655,6 +660,7 @@ impl App {
             popup_closing_at: None,
             session_enter_at: None,
             session_snapshot: std::cell::RefCell::new(None),
+            dashboard_snapshot: std::cell::RefCell::new(None),
             session_exit_at: None,
             session_tab_switch: None,
             header_stats_pos: std::cell::Cell::new([0.0; 4]),

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -141,14 +141,15 @@ impl App {
             self.focus_active_session();
             return true;
         }
+        // Cycling moves the selection along the session strip and stays on the
+        // dashboard. Entering the selected session is `SessionFocus`, which sits
+        // right next to these in the footer.
         if self.is_action(KeyAction::SessionTabPrev, key) {
             self.switch_session(-1);
-            self.focus_active_session();
             return true;
         }
         if self.is_action(KeyAction::SessionTabNext, key) {
             self.switch_session(1);
-            self.focus_active_session();
             return true;
         }
         if self.is_action(KeyAction::SessionNewTab, key) {
@@ -395,17 +396,22 @@ impl App {
         let next = ((cur + delta) % len + len) % len;
         self.active_session = Some(next as usize);
 
-        if self.mode == AppMode::Normal {
-            return;
-        }
         // Carry the tab we're leaving off in the direction of travel (#35). The
         // strip wraps, so the direction comes from `delta`, not the indices.
+        // Armed before the dashboard returns, because the strip up there mirrors
+        // the same travel.
         if next != cur && self.motion_enabled() {
             self.session_tab_switch = Some(SessionTabSwitch {
                 dir: if delta > 0 { 1 } else { -1 },
                 from: cur as usize,
                 at: std::time::Instant::now(),
             });
+        }
+
+        // On the dashboard only the strip moves; the mode below would drag the
+        // user into the session they were merely scrolling past.
+        if self.mode == AppMode::Normal {
+            return;
         }
 
         // Reflect the new active session's phase in app.mode, so render

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -307,11 +307,18 @@ impl App {
             }
             return;
         };
+        // Entering from outside, rather than being re-derived while already in a
+        // session (an overlay closing over it, a phase change), is what earns the
+        // slide: leaving already animates, so arriving looked like a cut.
+        let entering = !is_session_mode(self.mode);
         let phase = &self.sessions[idx].phase;
         self.mode = match phase {
             crate::session::SessionPhase::Connecting { .. } => AppMode::Connecting,
             _ => AppMode::Session,
         };
+        if entering && self.motion_enabled() {
+            self.session_enter_at = Some(std::time::Instant::now());
+        }
     }
 
     /// Tear down the active embedded session and return to the dashboard when

--- a/src/session/render.rs
+++ b/src/session/render.rs
@@ -187,7 +187,10 @@ fn render_header(frame: &mut Frame, area: Rect, session: &Session, app: &App) {
 
 /// Progress of the tab-highlight travel, or `None` when it is at rest (which
 /// is also when the active label paints itself highlighted).
-fn highlight_travel(app: &App) -> Option<f32> {
+///
+/// Shared with the dashboard session strip, which mirrors the same travel, so
+/// both surfaces agree on when the highlight is moving.
+pub(crate) fn highlight_travel(app: &App) -> Option<f32> {
     if !app.motion_enabled() {
         return None;
     }
@@ -201,7 +204,7 @@ fn span_cols(span: &Span<'static>) -> u16 {
     span.content.chars().count() as u16
 }
 
-fn lerp_u16(a: u16, b: u16, t: f32) -> u16 {
+pub(crate) fn lerp_u16(a: u16, b: u16, t: f32) -> u16 {
     (a as f32 + (b as f32 - a as f32) * t).round().max(0.0) as u16
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1563,6 +1563,43 @@ mod tests {
     }
 
     #[test]
+    fn entering_a_session_from_the_dashboard_slides_it_in() {
+        use crate::config::KeyAction;
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let mut app = app_with_two_sessions();
+        app.active_session = Some(0);
+        app.mode = AppMode::Normal;
+        app.config
+            .keybinds
+            .set(KeyAction::SessionFocus, vec!["F7".into()]);
+
+        app.handle_key(KeyEvent::new(KeyCode::F(7), KeyModifiers::empty()))
+            .unwrap();
+        assert!(
+            crate::app::is_session_mode(app.mode),
+            "we are in the session"
+        );
+        assert!(
+            app.session_enter_at.is_some(),
+            "arriving animates, the same way leaving already did"
+        );
+
+        // Re-deriving the mode while already inside a session is not an entry
+        // and must not replay the slide.
+        app.session_enter_at = None;
+        app.focus_active_session();
+        assert!(app.session_enter_at.is_none());
+
+        // Reduced motion arms nothing.
+        app.mode = AppMode::Normal;
+        app.config.appearance.disable_animation = true;
+        app.focus_active_session();
+        assert!(crate::app::is_session_mode(app.mode));
+        assert!(app.session_enter_at.is_none());
+    }
+
+    #[test]
     fn dashboard_strip_highlight_travels_instead_of_teleporting() {
         let mut app = app_with_two_sessions();
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -55,6 +55,9 @@ pub fn render(frame: &mut Frame, app: &App) {
             *app.session_snapshot.borrow_mut() = Some(frame.buffer_mut().clone());
         }
     } else {
+        // Mirror of the above: keep the dashboard fresh so entering a session has
+        // something to slide over instead of blank cells.
+        *app.dashboard_snapshot.borrow_mut() = Some(frame.buffer_mut().clone());
         render_session_exit(frame, app);
     }
     // Snapshot the popup shown this frame, slide a fresh one in from the top,
@@ -823,6 +826,10 @@ fn render_session_enter(frame: &mut Frame, app: &App) {
         return;
     }
     let src = frame.buffer_mut().clone();
+    // What the session is sliding over. Without it the columns it has not reached
+    // yet come out blank, so entering a session flashed a black screen with the
+    // host arriving over it.
+    let behind = app.dashboard_snapshot.borrow();
     let fb = frame.buffer_mut();
     for y in area.y..area.y + area.height {
         // Right-to-left so each destination reads a not-yet-overwritten source.
@@ -832,7 +839,10 @@ fn render_session_enter(frame: &mut Frame, app: &App) {
                     *d = s.clone();
                 }
             } else if let Some(d) = fb.cell_mut((x, y)) {
-                d.reset();
+                match behind.as_ref().and_then(|b| b.cell((x, y))) {
+                    Some(s) => *d = s.clone(),
+                    None => d.reset(),
+                }
             }
         }
     }
@@ -1560,6 +1570,30 @@ mod tests {
             app.session_tab_switch.is_some(),
             "the travel is armed from the dashboard too"
         );
+    }
+
+    #[test]
+    fn the_session_slides_in_over_the_dashboard_not_over_black() {
+        let mut app = app_with_two_sessions();
+        app.active_session = Some(0);
+        app.mode = AppMode::Normal;
+
+        // Rendering the dashboard is what captures the snapshot the slide needs.
+        let dashboard = render_to_buffer(&app, 120, 38);
+        let (hx, hy) = find_cell(&dashboard, "web-prod").expect("dashboard drawn");
+
+        // First frame of the slide: the session is still fully off to the right,
+        // so what shows is the dashboard. It used to be blank cells, which read as
+        // a black screen flashing before the host arrived.
+        app.mode = AppMode::Session;
+        app.session_enter_at = Some(std::time::Instant::now());
+        let sliding = render_to_buffer(&app, 120, 38);
+        assert_eq!(
+            sliding[(hx, hy)].symbol(),
+            dashboard[(hx, hy)].symbol(),
+            "the vacated columns show the dashboard"
+        );
+        assert_ne!(sliding[(hx, hy)].symbol(), " ", "and are not blanked");
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -242,8 +242,8 @@ fn render_inner(frame: &mut Frame, app: &App) {
     widgets::footer::render_hrule(frame, rule3, true);
 
     // Footer keybinds (tab-specific)
-    let keybinds = footer_keybinds(app);
-    widgets::footer::render_footer(frame, areas.footer, &keybinds);
+    let (keybinds, pinned) = footer_keybinds(app);
+    widgets::footer::render_footer(frame, areas.footer, &keybinds, pinned);
 
     // Issue #18: a zoomed panel hides the normal notice surface (status bar),
     // so surface transient feedback (e.g. "copied N chars") as a toast pinned
@@ -524,7 +524,8 @@ fn compute_header_stats(app: &App) -> [usize; 4] {
     [total, online, slow, down]
 }
 
-fn footer_keybinds(app: &App) -> Vec<(String, &'static str)> {
+/// The footer's pairs, plus how many trailing ones must never be dropped.
+fn footer_keybinds(app: &App) -> (Vec<(String, &'static str)>, usize) {
     let mut binds: Vec<(String, &'static str)> = match app.active_tab {
         0 => vec![
             ("\u{2191}\u{2193}".into(), "select"),
@@ -650,7 +651,22 @@ fn footer_keybinds(app: &App) -> Vec<(String, &'static str)> {
     if !app.sessions.is_empty() {
         binds.extend(app.config.keybinds.session_footer_hints());
     }
-    binds
+
+    // Move the pairs that say how to get out, or back into a session, to the end
+    // and report how many there are, because the footer pins its tail when the
+    // row does not fit. Every conditional block above (panel zoom, broadcast,
+    // the session hints) otherwise pushes `? help` and `q quit` into the middle,
+    // which is exactly where truncation eats them.
+    const PINNED_LABELS: [&str; 3] = ["resume", "help", "quit"];
+    let mut pinned: Vec<(String, &'static str)> = Vec::new();
+    for label in PINNED_LABELS {
+        if let Some(i) = binds.iter().position(|(_, l)| *l == label) {
+            pinned.push(binds.remove(i));
+        }
+    }
+    let pinned_len = pinned.len();
+    binds.extend(pinned);
+    (binds, pinned_len)
 }
 
 /// Draw a transient notice (issue #18) as a floating chip right-aligned on the
@@ -1518,6 +1534,35 @@ mod tests {
     }
 
     #[test]
+    fn cycling_tabs_from_the_dashboard_stays_on_the_dashboard() {
+        use crate::config::KeyAction;
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let mut app = app_with_two_sessions();
+        app.active_session = Some(0);
+        app.mode = AppMode::Normal;
+        app.config
+            .keybinds
+            .set(KeyAction::SessionTabNext, vec!["F6".into()]);
+
+        app.handle_key(KeyEvent::new(KeyCode::F(6), KeyModifiers::empty()))
+            .unwrap();
+
+        // The regression: this used to call `focus_active_session`, so a key
+        // named "next session tab" threw you into the session full screen.
+        assert_eq!(
+            app.mode,
+            AppMode::Normal,
+            "cycling must not enter a session"
+        );
+        assert_eq!(app.active_session, Some(1), "the selection moved");
+        assert!(
+            app.session_tab_switch.is_some(),
+            "the travel is armed from the dashboard too"
+        );
+    }
+
+    #[test]
     fn dashboard_strip_highlight_travels_instead_of_teleporting() {
         let mut app = app_with_two_sessions();
 
@@ -1599,7 +1644,23 @@ mod tests {
             );
         }
 
+        // With sessions running, the way back into one is as essential as the
+        // way out of the app. This is the case that regressed: the session hints
+        // are appended after `? help` / `q quit` and pushed them into the middle.
+        let mut app = app_with_two_sessions();
+        app.active_tab = 1;
+        app.sftp = Some(crate::sftp::model::SftpState::new("/srv", "/home/me"));
+        for w in [120u16, 160, 200] {
+            let buffer = render_to_buffer(&app, w, 38);
+            assert!(buffer_contains(&buffer, "resume"), "width {w}: resume");
+            assert!(buffer_contains(&buffer, "? help"), "width {w}: help");
+            assert!(buffer_contains(&buffer, "q quit"), "width {w}: quit");
+        }
+
         // Wide enough for everything: no ellipsis, nothing dropped.
+        let mut app = test_app_with_hosts();
+        app.active_tab = 1;
+        app.sftp = Some(crate::sftp::model::SftpState::new("/srv", "/home/me"));
         let buffer = render_to_buffer(&app, 240, 38);
         assert!(buffer_contains(&buffer, "? help"));
         assert!(buffer_contains(&buffer, "q quit"));

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -176,7 +176,18 @@ fn render_inner(frame: &mut Frame, app: &App) {
     // Open embedded sessions — visible strip on the top header row so
     // background SSH tabs aren't hidden behind a footer hint.
     let session_chips = build_session_chips(app);
-    widgets::header::render_session_strip(frame, areas.header, &session_chips);
+    // Cycling session tabs from the dashboard used to change the highlighted
+    // chip with no motion at all, while the same keys inside the full-screen
+    // view slide it. Both now read the same travel state (#35).
+    let strip_travel = crate::session::render::highlight_travel(app).and_then(|p| {
+        let sw = app.session_tab_switch?;
+        Some(widgets::header::StripTravel {
+            from: sw.from,
+            to: app.active_session?,
+            p,
+        })
+    });
+    widgets::header::render_session_strip(frame, areas.header, &session_chips, strip_travel);
 
     // Horizontal rule 1
     let rule1 = row_in(area, areas.header.y + areas.header.height);
@@ -1472,6 +1483,83 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|frame| render(frame, app)).unwrap();
         terminal.backend().buffer().clone()
+    }
+
+    /// First column of `needle` anywhere in `buf`, searched row by row.
+    fn find_cell(buf: &Buffer, needle: &str) -> Option<(u16, u16)> {
+        let n = needle.chars().count() as u16;
+        for y in buf.area.y..buf.area.bottom() {
+            for x in buf.area.x..buf.area.right().saturating_sub(n) {
+                let got: String = (x..x + n).map(|i| buf[(i, y)].symbol()).collect();
+                if got == needle {
+                    return Some((x, y));
+                }
+            }
+        }
+        None
+    }
+
+    /// App with two spawned sessions, for the dashboard session strip.
+    fn app_with_two_sessions() -> App {
+        let mut app = test_app_with_hosts();
+        for name in ["alpha", "bravo"] {
+            let cfg = crate::session::SessionConfig {
+                argv: vec!["true".into()],
+                display_name: name.into(),
+                meta: crate::session::SessionMeta::default(),
+                pending_secret: None,
+                key_push_identity: None,
+                host_name: name.into(),
+            };
+            app.sessions
+                .push(crate::session::Session::spawn(cfg, 24, 80, None).unwrap());
+        }
+        app
+    }
+
+    #[test]
+    fn dashboard_strip_highlight_travels_instead_of_teleporting() {
+        let mut app = app_with_two_sessions();
+
+        // At rest the highlight sits on the active chip, as before.
+        app.active_session = Some(1);
+        let buffer = render_to_buffer(&app, 120, 38);
+        let (bx, by) = find_cell(&buffer, "bravo").expect("second chip rendered");
+        assert_eq!(
+            buffer[(bx, by)].bg,
+            theme::BRIGHT,
+            "at rest: on the new chip"
+        );
+
+        // Mid-switch, with progress still at ~0, the highlight must still be on
+        // the chip being left. That is the whole point: it moves across rather
+        // than appearing on the target instantly.
+        app.session_tab_switch = Some(crate::app::SessionTabSwitch {
+            dir: 1,
+            from: 0,
+            at: std::time::Instant::now(),
+        });
+        let buffer = render_to_buffer(&app, 120, 38);
+        let (ax, ay) = find_cell(&buffer, "alpha").expect("first chip rendered");
+        let (bx, by) = find_cell(&buffer, "bravo").expect("second chip rendered");
+        assert_eq!(
+            buffer[(ax, ay)].bg,
+            theme::BRIGHT,
+            "travelling: still on the chip being left"
+        );
+        assert_ne!(
+            buffer[(bx, by)].bg,
+            theme::BRIGHT,
+            "travelling: not yet on the target"
+        );
+
+        // Reduced motion jumps straight to the final state.
+        app.config.appearance.disable_animation = true;
+        let buffer = render_to_buffer(&app, 120, 38);
+        let (ax, ay) = find_cell(&buffer, "alpha").unwrap();
+        let (bx, by) = find_cell(&buffer, "bravo").unwrap();
+        assert_eq!(buffer[(bx, by)].bg, theme::BRIGHT, "reduced motion: target");
+        assert_ne!(buffer[(ax, ay)].bg, theme::BRIGHT);
     }
 
     #[test]

--- a/src/tui/widgets/footer.rs
+++ b/src/tui/widgets/footer.rs
@@ -7,9 +7,6 @@ use crate::tui::theme;
 
 /// Gap between two hint pairs.
 const GAP: u16 = 3;
-/// How many trailing pairs are pinned: every tab ends its list with `? help`
-/// and `q quit`.
-const PINNED: usize = 2;
 
 /// Cells one `(key, label)` pair occupies: key, a space, label.
 fn pair_width<K: AsRef<str>, L: AsRef<str>>((key, label): &(K, L)) -> u16 {
@@ -44,7 +41,12 @@ fn put_pair<K: AsRef<str>, L: AsRef<str>>(
 /// from the end. The SFTP tab needs 220 columns to show its full row, so plain
 /// tail truncation dropped `? help` and `q quit` on any normal terminal: the two
 /// hints telling you how to get out were the first to go.
-pub fn render_footer<K, L>(frame: &mut Frame, area: Rect, keybinds: &[(K, L)])
+///
+/// `pinned` is how many trailing pairs must survive that truncation. The caller
+/// decides, because which pairs those are depends on what is running: with a
+/// session in the background the way back into it is as essential as the way out
+/// of the app.
+pub fn render_footer<K, L>(frame: &mut Frame, area: Rect, keybinds: &[(K, L)], pinned: usize)
 where
     K: AsRef<str>,
     L: AsRef<str>,
@@ -71,7 +73,7 @@ where
         return;
     }
 
-    let pinned = keybinds.len().min(PINNED);
+    let pinned = keybinds.len().min(pinned.max(1));
     let (head, tail) = keybinds.split_at(keybinds.len() - pinned);
     let tail_width: u16 =
         tail.iter().map(pair_width).sum::<u16>() + GAP * (pinned as u16).saturating_sub(1);

--- a/src/tui/widgets/header.rs
+++ b/src/tui/widgets/header.rs
@@ -103,11 +103,20 @@ pub struct SessionChip {
 /// Each chip is `● name`; the dot is colored by lifecycle (green running,
 /// amber connecting, red exited) and the active session is reversed. Overflow
 /// past the available width collapses into a `+N` counter.
-pub fn render_session_strip(frame: &mut Frame, area: Rect, chips: &[SessionChip]) {
+pub fn render_session_strip(
+    frame: &mut Frame,
+    area: Rect,
+    chips: &[SessionChip],
+    travel: Option<StripTravel>,
+) {
     if area.height == 0 || area.width == 0 || chips.is_empty() {
         return;
     }
 
+    // Columns each chip's name occupies, so a travelling highlight knows where
+    // to start and where to land. Only names are highlighted; the lifecycle dot
+    // keeps its own colour.
+    let mut name_spans: Vec<(u16, u16)> = Vec::with_capacity(chips.len());
     let buf = frame.buffer_mut();
     let y = area.y; // top row, alongside the wordmark
     let start_x = area.x + 16; // clear of the widest wordmark line
@@ -124,7 +133,10 @@ pub fn render_session_strip(frame: &mut Frame, area: Rect, chips: &[SessionChip]
             SessionDot::Running => theme::green(),
             SessionDot::Exited => theme::red(),
         };
-        let name_style = if chip.active {
+        // While the highlight is travelling, no chip paints itself highlighted:
+        // the moving bar below is the only thing wearing `inv`, exactly as the
+        // full-screen tab strip does it.
+        let name_style = if chip.active && travel.is_none() {
             theme::inv()
         } else {
             theme::text()
@@ -142,9 +154,40 @@ pub fn render_session_strip(frame: &mut Frame, area: Rect, chips: &[SessionChip]
         }
 
         x = put(buf, x, y, "\u{25cf} ", dot_style);
+        name_spans.push((x, unicode_width(&chip.name) as u16));
         x = put(buf, x, y, &chip.name, name_style);
         x = put(buf, x, y, " ", theme::dim());
     }
+
+    // Carry the highlight from the chip being left to the new one, so switching
+    // tabs from the dashboard moves instead of teleporting (#35). A chip that
+    // collapsed into the `+N` marker has no span, and then there is nothing to
+    // travel between.
+    if let Some(t) = travel {
+        let (Some(&(fx, fw)), Some(&(tx, tw))) = (name_spans.get(t.from), name_spans.get(t.to))
+        else {
+            return;
+        };
+        let e = crate::tui::tween::ease_in_out(t.p);
+        let bar_x = crate::session::render::lerp_u16(fx, tx, e);
+        let bar_w = crate::session::render::lerp_u16(fw, tw, e);
+        for cx in bar_x..bar_x.saturating_add(bar_w).min(end_x) {
+            if let Some(cell) = buf.cell_mut((cx, y)) {
+                cell.set_style(theme::inv());
+            }
+        }
+    }
+}
+
+/// An in-flight highlight travel across the dashboard session strip (#35):
+/// `from` and `to` are chip indices, `p` is raw progress in `0..1` (the easing
+/// is applied here, so callers pass what [`crate::tui::tween::progress`] gave
+/// them).
+#[derive(Debug, Clone, Copy)]
+pub struct StripTravel {
+    pub from: usize,
+    pub to: usize,
+    pub p: f32,
 }
 
 /// Write `text` at (x, y) and return x + width.


### PR DESCRIPTION
Closes #49.

Four fixes that turned out to be one story: the dashboard and the session view had no motion
between them, and two of my own earlier assumptions were wrong.

## 1. Cycling tabs from the dashboard opened the session

`handle_key_background_sessions` followed `switch_session` with `focus_active_session()`, so
`Ctrl+[` / `Ctrl+]` on the dashboard left it entirely. And `switch_session` returned early on
`AppMode::Normal` **before** arming `SessionTabSwitch`, so there was no travel state to animate
either way. My first pass at this issue animated the strip and shipped nothing visible, because
the strip was gone by the next frame.

Cycling now moves the selection along the strip and stays put. Opening the selected session is
`SessionFocus`, which #47 put in the footer as `resume`.

## 2. The strip highlight teleported

`render_session_strip` lerps the reverse bar between the chip being left and the new one, reading
the same `highlight_travel` the full-screen tab bar uses, so the two surfaces cannot drift apart
again. A chip collapsed into the `+N` marker has no span to travel to, and then nothing is drawn.

## 3. Entering a session did not animate

Leaving one slid it off to the right; arriving cut straight to it, because `session_enter_at` was
armed on connect only. It is armed in `focus_active_session` now, and only when coming from
outside a session, so an overlay closing over one does not replay the slide. This also covers the
SFTP re-attach path.

## 4. The slide arrived over black

`render_session_enter` blanked the columns it had not reached yet, so entering flashed a black
screen with the host coming in over it. Present on connect too, just rarely noticed. The dashboard
is now snapshotted each frame while off the session view, mirroring `session_snapshot`, and the
slide fills from it. The snapshot is taken before the exit blit, so it holds a clean dashboard.

## Plus the footer pin from #58

That pinned the last two pairs, assuming every tab list ends with `? help` and `q quit`.
Panel-zoom, broadcast and session hints are all appended after them, so with a session running the
pinned pair was `Ctrl+T new tab` while help, quit and the new `resume` were dropped.
`footer_keybinds` now moves those three to the end and reports how many to pin.

## Verified

Four new tests, each pinning a property the eye had to catch this round:

- after `SessionTabNext` from the dashboard the mode is still `Normal`, the selection moved, and
  the travel is armed;
- mid-travel the highlight is still on the chip being left, not the target; reduced motion goes
  straight to the target;
- entering arms the slide, re-deriving the mode inside a session does not, reduced motion arms
  nothing;
- on the first frame of the slide the vacated columns carry dashboard content, not blanks;
- and the footer test now covers sessions running at 120, 160 and 200 columns.

`cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` passes, full suite green:
530 unit, 72 e2e, 42 smoke, 1 config_load. Verified by hand on a real install as well.

## Known gap, not in this PR

The strip keys only reach `handle_key_background_sessions` on the hosts tab, since
`handle_key_normal` is its only caller. On SFTP, Tunnels, Keys and Audit, `Ctrl+]` does nothing
even though the strip is drawn on the header from every tab. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
