### PR TITLE
feat(keys): show, copy and clear a stored password or passphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to SSHub are documented in this file.
   show and copy it and `Ctrl+Y` to copy without showing. Both say what they
   copied and never the value, the reveal drops as soon as the field is left, and
   the value stays out of every log, audit row and diagnostic. Both binds are
-  rebindable in the keybinding editor.
+  rebindable in the keybinding editor, and the form's hint row names them while
+  the field is focused, since a masked value gives no clue on its own.
 - **Ad-hoc connect** - typing an unknown `[user@]host[:port]` into the fuzzy
   palette (`/`), IPv6 in brackets included, now offers a "connect without saving"
   row instead of reporting no matches, and Enter opens an embedded session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to SSHub are documented in this file.
 
 ### Added
 
+- **Stored passwords and passphrases are no longer write-only** (issue #60) - a
+  saved secret showed as `(set)` and nothing else: you could not tell which one
+  was stored, could not get it out, and editing meant retyping from scratch. The
+  field now opens prefilled from the credential store, masked, with `Ctrl+R` to
+  show and copy it and `Ctrl+Y` to copy without showing. Both say what they
+  copied and never the value, the reveal drops as soon as the field is left, and
+  the value stays out of every log, audit row and diagnostic. Both binds are
+  rebindable in the keybinding editor.
 - **Ad-hoc connect** - typing an unknown `[user@]host[:port]` into the fuzzy
   palette (`/`), IPv6 in brackets included, now offers a "connect without saving"
   row instead of reporting no matches, and Enter opens an embedded session
@@ -94,6 +102,11 @@ All notable changes to SSHub are documented in this file.
 
 ### Fixed
 
+- **A stored secret could not be removed** - clearing the password field meant
+  "leave whatever is stored alone", because an empty field was the only signal
+  the save path had. It now compares against what the store held when the form
+  opened, so an emptied field deletes the entry, and the field masks while typing
+  too, since it arrives carrying a real secret.
 - **Cycling session tabs from the dashboard threw you into the session** (issue
   #49) - `Ctrl+[` / `Ctrl+]` there moved the selection *and* immediately opened
   the session full screen, so a key named "previous / next session tab" left the

--- a/src/app/host_form.rs
+++ b/src/app/host_form.rs
@@ -48,6 +48,8 @@ impl App {
                 text_input::char_len(&managed.address)
             };
 
+            let stored_password = self.stored_secret(&crate::credentials::host_key(managed.id));
+
             HostFormEdit {
                 id: Some(managed.id),
                 address: managed.address.clone(),
@@ -69,8 +71,10 @@ impl App {
                 transport: managed.transport,
                 session_logging: managed.session_logging,
                 os_icon_index: os_icon_index_from_option(&managed.os_icon),
-                password: String::new(),
+                password: stored_password.clone(),
+                password_original: stored_password,
                 has_password: managed.has_password,
+                password_revealed: false,
                 field: start_field,
                 cursor: start_cursor,
                 metadata_only,
@@ -115,7 +119,9 @@ impl App {
                 session_logging: crate::session_log::SessionLoggingOverride::Inherit,
                 os_icon_index: 0,
                 password: String::new(),
+                password_original: String::new(),
                 has_password: false,
+                password_revealed: false,
                 field: HostFormField::Address,
                 cursor: 0,
                 metadata_only: false,
@@ -165,9 +171,12 @@ impl App {
         let identity_id = self.identities.get(form.identity_index).map(|i| i.id);
         let tags = parse_tags(&form.tags);
         let label = optional_field(&form.label);
-        let host_pw_changed = !form.password.is_empty();
+        // Compared against what the store held when the form opened: prefilling
+        // the field made "not empty" useless as a signal, and an emptied field
+        // now means the secret should go.
+        let host_pw_changed = form.password != form.password_original;
         let new_has_password = if host_pw_changed {
-            true
+            !form.password.is_empty()
         } else {
             form.has_password
         };
@@ -180,10 +189,7 @@ impl App {
             };
             let saved_name = form.name.clone();
             if host_pw_changed {
-                if let Err(e) = self
-                    .password_store
-                    .set(&crate::credentials::host_key(id), &form.password)
-                {
+                if let Err(e) = self.put_secret(&crate::credentials::host_key(id), &form.password) {
                     self.host_notice = Some(format!("Saved, but storing the password failed: {e}"));
                 }
             }
@@ -247,10 +253,7 @@ impl App {
         let saved_name = name.to_string();
         if let Some(id) = form.id {
             if host_pw_changed {
-                if let Err(e) = self
-                    .password_store
-                    .set(&crate::credentials::host_key(id), &form.password)
-                {
+                if let Err(e) = self.put_secret(&crate::credentials::host_key(id), &form.password) {
                     self.host_notice = Some(format!("Saved, but storing the password failed: {e}"));
                 }
             }
@@ -298,9 +301,8 @@ impl App {
             })?;
             self.store.set_host_groups(created.id, &group_ids)?;
             if host_pw_changed {
-                if let Err(e) = self
-                    .password_store
-                    .set(&crate::credentials::host_key(created.id), &form.password)
+                if let Err(e) =
+                    self.put_secret(&crate::credentials::host_key(created.id), &form.password)
                 {
                     self.host_notice = Some(format!("Saved, but storing the password failed: {e}"));
                 }
@@ -318,6 +320,24 @@ impl App {
             return Ok(());
         };
         let field = form.field;
+
+        // Reveal / copy act on the password field only, and are checked before the
+        // field editor so a Ctrl chord cannot be typed into the value.
+        if field == HostFormField::Password
+            && (self.is_action(KeyAction::RevealSecret, &key)
+                || self.is_action(KeyAction::CopySecret, &key))
+        {
+            let reveal = self.is_action(KeyAction::RevealSecret, &key);
+            let secret = form.password.clone();
+            if reveal {
+                if let Some(form) = self.host_form.as_mut() {
+                    form.password_revealed = true;
+                }
+            }
+            self.host_notice = Some(crate::app::util::copy_secret_notice(&secret, "password"));
+            return Ok(());
+        }
+
         match key.code {
             KeyCode::Esc => self.cancel_host_form()?,
             _ if self.is_save_key(&key) => self.save_host_form()?,
@@ -372,6 +392,8 @@ impl App {
         let Some(form) = self.host_form.as_mut() else {
             return;
         };
+        // Walking away re-masks (see the identity form).
+        form.password_revealed = false;
         form.field = form.field.next();
         form.cursor = text_input::char_len(form.active_field());
     }
@@ -380,6 +402,8 @@ impl App {
         let Some(form) = self.host_form.as_mut() else {
             return;
         };
+        // Walking away re-masks (see the identity form).
+        form.password_revealed = false;
         form.field = form.field.prev();
         form.cursor = text_input::char_len(form.active_field());
     }

--- a/src/app/identities.rs
+++ b/src/app/identities.rs
@@ -101,6 +101,25 @@ impl App {
             return Ok(());
         };
         let field = form.field;
+
+        // Reveal / copy act on the passphrase field only, and are checked before
+        // the field editor so a Ctrl chord cannot be typed into the value.
+        if field == IdentityFormField::Password
+            && (self.is_action(KeyAction::RevealSecret, &key)
+                || self.is_action(KeyAction::CopySecret, &key))
+        {
+            let reveal = self.is_action(KeyAction::RevealSecret, &key);
+            let secret = form.password.clone();
+            if reveal {
+                if let Some(form) = self.identity_form.as_mut() {
+                    form.password_revealed = true;
+                }
+            }
+            self.identity_notice =
+                Some(crate::app::util::copy_secret_notice(&secret, "passphrase"));
+            return Ok(());
+        }
+
         match key.code {
             KeyCode::Esc => self.cancel_identity_form()?,
             _ if self.is_save_key(&key) => self.save_identity_form()?,
@@ -147,6 +166,8 @@ impl App {
 
     pub(crate) fn enter_identity_form(&mut self, existing: Option<&Identity>) -> Result<()> {
         let form = if let Some(identity) = existing {
+            let stored = self.stored_secret(&crate::credentials::identity_key(identity.id));
+
             IdentityFormEdit {
                 id: Some(identity.id),
                 name: identity.name.clone(),
@@ -161,8 +182,10 @@ impl App {
                     .as_ref()
                     .map(|p| p.to_string_lossy().into_owned())
                     .unwrap_or_default(),
-                password: String::new(),
+                password: stored.clone(),
+                password_original: stored,
                 has_password: identity.has_password,
+                password_revealed: false,
                 pasted_key: None,
                 field: IdentityFormField::Name,
                 cursor: text_input::char_len(&identity.name),
@@ -178,7 +201,9 @@ impl App {
                 private_key: String::new(),
                 certificate: String::new(),
                 password: String::new(),
+                password_original: String::new(),
                 has_password: false,
+                password_revealed: false,
                 pasted_key: None,
                 field: IdentityFormField::Name,
                 cursor: 0,
@@ -278,18 +303,19 @@ impl App {
             }
         }
 
-        let password_changed = !form.password.is_empty();
+        // See the host form: compared against what the store held on open, so an
+        // emptied field removes the passphrase instead of silently keeping it.
+        let password_changed = form.password != form.password_original;
         let new_has_password = if password_changed {
-            true
+            !form.password.is_empty()
         } else {
             form.has_password
         };
 
         if let Some(id) = form.id {
             if password_changed {
-                if let Err(e) = self
-                    .password_store
-                    .set(&crate::credentials::identity_key(id), &form.password)
+                if let Err(e) =
+                    self.put_secret(&crate::credentials::identity_key(id), &form.password)
                 {
                     self.identity_notice =
                         Some(format!("Saved, but storing the passphrase failed: {e}"));
@@ -339,6 +365,9 @@ impl App {
         let Some(form) = self.identity_form.as_mut() else {
             return;
         };
+        // Walking away re-masks: a form left open should not sit there with a
+        // plaintext secret on screen.
+        form.password_revealed = false;
         form.field = form.field.next();
         form.cursor = text_input::char_len(form.active_field());
     }
@@ -347,6 +376,9 @@ impl App {
         let Some(form) = self.identity_form.as_mut() else {
             return;
         };
+        // Walking away re-masks: a form left open should not sit there with a
+        // plaintext secret on screen.
+        form.password_revealed = false;
         form.field = form.field.prev();
         form.cursor = text_input::char_len(form.active_field());
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -414,6 +414,29 @@ impl App {
         !self.config.appearance.disable_animation
     }
 
+    /// The secret stored under `key`, or empty when there is none and when the
+    /// store refuses to answer (a locked or absent keyring). Used to prefill a
+    /// form field, so editing a stored password starts from what is stored
+    /// instead of from nothing.
+    pub(crate) fn stored_secret(&self, key: &str) -> String {
+        self.password_store
+            .get(key)
+            .ok()
+            .flatten()
+            .unwrap_or_default()
+    }
+
+    /// Store `secret` under `key`, or remove the entry when it is empty. A form
+    /// field cleared on purpose means "there is no secret any more", which used
+    /// to be indistinguishable from "left untouched".
+    pub(crate) fn put_secret(&self, key: &str, secret: &str) -> anyhow::Result<()> {
+        if secret.is_empty() {
+            self.password_store.delete(key)
+        } else {
+            self.password_store.set(key, secret)
+        }
+    }
+
     /// Notice a tab change (from any of the many code paths that set
     /// `active_tab`) and arm the body slide (#35). Called once per poll tick.
     pub(crate) fn detect_tab_switch(&mut self) {

--- a/src/app/tests/host_form.rs
+++ b/src/app/tests/host_form.rs
@@ -103,3 +103,164 @@ pub(crate) fn host_form_picker_at_boundary_moves_to_adjacent_field() {
         HostFormField::Identity
     );
 }
+
+/// An identity whose passphrase is already in the store, plus its id.
+fn identity_with_stored_passphrase(app: &mut App, secret: &str) -> i64 {
+    let created = app
+        .store
+        .create_identity(&crate::store::NewIdentity {
+            name: "prod-key".into(),
+            username: None,
+            private_key: None,
+            certificate: None,
+            sort_order: 0,
+            has_password: true,
+        })
+        .unwrap();
+    app.password_store
+        .set(&crate::credentials::identity_key(created.id), secret)
+        .unwrap();
+    app.reload_identities().unwrap();
+    created.id
+}
+
+#[test]
+pub(crate) fn identity_form_prefills_the_stored_passphrase() {
+    let (mut app, _secrets) = test_app_with_secrets(vec![]);
+    identity_with_stored_passphrase(&mut app, "s3cret");
+
+    let identity = app
+        .identities
+        .iter()
+        .find(|i| i.name == "prod-key")
+        .expect("the identity we just created")
+        .clone();
+    app.enter_identity_form(Some(&identity)).unwrap();
+
+    let form = app.identity_form.as_ref().unwrap();
+    assert_eq!(
+        form.password, "s3cret",
+        "the field starts from what is stored"
+    );
+    assert_eq!(
+        form.password_original, "s3cret",
+        "and remembers it, so an untouched save is a no-op"
+    );
+    assert!(!form.password_revealed, "masked until asked");
+}
+
+#[test]
+pub(crate) fn clearing_the_passphrase_removes_it_from_the_store() {
+    let (mut app, secrets) = test_app_with_secrets(vec![]);
+    let id = identity_with_stored_passphrase(&mut app, "s3cret");
+
+    let identity = app
+        .identities
+        .iter()
+        .find(|i| i.name == "prod-key")
+        .expect("the identity we just created")
+        .clone();
+    app.enter_identity_form(Some(&identity)).unwrap();
+    app.identity_form.as_mut().unwrap().password.clear();
+    app.save_identity_form().unwrap();
+
+    use crate::credentials::PasswordStore;
+    assert_eq!(
+        secrets.get(&crate::credentials::identity_key(id)).unwrap(),
+        None,
+        "an emptied field means the secret should go"
+    );
+    let saved = app
+        .identities
+        .iter()
+        .find(|i| i.name == "prod-key")
+        .unwrap();
+    assert!(!saved.has_password, "and the row stops claiming it has one");
+}
+
+#[test]
+pub(crate) fn saving_an_untouched_form_keeps_the_stored_passphrase() {
+    let (mut app, secrets) = test_app_with_secrets(vec![]);
+    let id = identity_with_stored_passphrase(&mut app, "s3cret");
+
+    let identity = app
+        .identities
+        .iter()
+        .find(|i| i.name == "prod-key")
+        .expect("the identity we just created")
+        .clone();
+    app.enter_identity_form(Some(&identity)).unwrap();
+    app.save_identity_form().unwrap();
+
+    use crate::credentials::PasswordStore;
+    assert_eq!(
+        secrets.get(&crate::credentials::identity_key(id)).unwrap(),
+        Some("s3cret".to_string())
+    );
+    let saved = app
+        .identities
+        .iter()
+        .find(|i| i.name == "prod-key")
+        .unwrap();
+    assert!(saved.has_password);
+}
+
+#[test]
+pub(crate) fn reveal_and_copy_binds_differ_and_never_echo_the_secret() {
+    let (mut app, _secrets) = test_app_with_secrets(vec![]);
+    identity_with_stored_passphrase(&mut app, "s3cret");
+    let identity = app
+        .identities
+        .iter()
+        .find(|i| i.name == "prod-key")
+        .expect("the identity we just created")
+        .clone();
+
+    // Copy only: nothing is revealed, and the notice names the secret, not its value.
+    app.enter_identity_form(Some(&identity)).unwrap();
+    app.identity_form.as_mut().unwrap().field = IdentityFormField::Password;
+    app.config
+        .keybinds
+        .set(KeyAction::CopySecret, vec!["F5".into()]);
+    app.config
+        .keybinds
+        .set(KeyAction::RevealSecret, vec!["F6".into()]);
+
+    app.handle_key(KeyEvent::new(KeyCode::F(5), KeyModifiers::empty()))
+        .unwrap();
+    assert!(!app.identity_form.as_ref().unwrap().password_revealed);
+    let notice = app.identity_notice.clone().unwrap();
+    assert!(notice.contains("passphrase"), "{notice}");
+    assert!(!notice.contains("s3cret"), "the value must not be echoed");
+
+    // Reveal: shows it, and walking off the field masks it again.
+    app.handle_key(KeyEvent::new(KeyCode::F(6), KeyModifiers::empty()))
+        .unwrap();
+    assert!(app.identity_form.as_ref().unwrap().password_revealed);
+    app.identity_form_field_next();
+    assert!(
+        !app.identity_form.as_ref().unwrap().password_revealed,
+        "leaving the field re-masks"
+    );
+}
+
+#[test]
+pub(crate) fn reveal_bind_is_ignored_away_from_the_secret_field() {
+    let (mut app, _secrets) = test_app_with_secrets(vec![]);
+    identity_with_stored_passphrase(&mut app, "s3cret");
+    let identity = app
+        .identities
+        .iter()
+        .find(|i| i.name == "prod-key")
+        .expect("the identity we just created")
+        .clone();
+    app.enter_identity_form(Some(&identity)).unwrap();
+    app.identity_form.as_mut().unwrap().field = IdentityFormField::Name;
+    app.config
+        .keybinds
+        .set(KeyAction::RevealSecret, vec!["F6".into()]);
+
+    app.handle_key(KeyEvent::new(KeyCode::F(6), KeyModifiers::empty()))
+        .unwrap();
+    assert!(!app.identity_form.as_ref().unwrap().password_revealed);
+}

--- a/src/app/tests/host_form.rs
+++ b/src/app/tests/host_form.rs
@@ -264,3 +264,20 @@ pub(crate) fn reveal_bind_is_ignored_away_from_the_secret_field() {
         .unwrap();
     assert!(!app.identity_form.as_ref().unwrap().password_revealed);
 }
+
+#[test]
+pub(crate) fn secret_field_hints_name_the_binds_and_follow_rebinds() {
+    let mut kb = crate::config::KeybindsConfig::default();
+    assert_eq!(
+        kb.secret_field_hints(),
+        "Ctrl+R: show + copy \u{2502} Ctrl+Y: copy"
+    );
+
+    kb.set(KeyAction::RevealSecret, vec!["F6".into()]);
+    kb.set(KeyAction::CopySecret, vec![]);
+    assert_eq!(
+        kb.secret_field_hints(),
+        "F6: show + copy",
+        "a rebind shows through and an unbound action says nothing"
+    );
+}

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -36,6 +36,67 @@ impl HostResolver for MockResolver {
     }
 }
 
+/// An in-memory credential store, so tests can exercise the paths that read a
+/// secret back: `NoopPasswordStore` answers `None` to everything, which makes
+/// prefilling and "was it changed" untestable.
+#[derive(Default)]
+pub(crate) struct MemoryPasswordStore {
+    entries: std::sync::Mutex<HashMap<String, String>>,
+}
+
+impl crate::credentials::PasswordStore for MemoryPasswordStore {
+    fn get(&self, key: &str) -> Result<Option<String>> {
+        Ok(self.entries.lock().unwrap().get(key).cloned())
+    }
+    fn set(&self, key: &str, password: &str) -> Result<()> {
+        self.entries
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), password.to_string());
+        Ok(())
+    }
+    fn delete(&self, key: &str) -> Result<()> {
+        self.entries.lock().unwrap().remove(key);
+        Ok(())
+    }
+}
+
+/// `test_app`, but with a credential store that actually remembers. Returns the
+/// app and a handle to the same store so a test can look inside it.
+pub(crate) fn test_app_with_secrets(
+    hosts: Vec<(&str, SshHost)>,
+) -> (App, Arc<MemoryPasswordStore>) {
+    let secrets = Arc::new(MemoryPasswordStore::default());
+    let resolver = MockResolver::new(hosts);
+    let metadata: Arc<dyn MetadataStore> = Arc::new(MetadataDb::default());
+    let mut app = App::new_with_deps(
+        AppConfig::default(),
+        AppDeps {
+            resolver: Box::new(resolver),
+            metadata,
+            store: test_store(),
+            password_store: Box::new(SharedStore(secrets.clone())),
+        },
+    );
+    app.reload_hosts().unwrap();
+    (app, secrets)
+}
+
+/// Lets the test keep a handle on the store the app owns.
+struct SharedStore(Arc<MemoryPasswordStore>);
+
+impl crate::credentials::PasswordStore for SharedStore {
+    fn get(&self, key: &str) -> Result<Option<String>> {
+        self.0.get(key)
+    }
+    fn set(&self, key: &str, password: &str) -> Result<()> {
+        self.0.set(key, password)
+    }
+    fn delete(&self, key: &str) -> Result<()> {
+        self.0.delete(key)
+    }
+}
+
 pub(crate) fn test_app(hosts: Vec<(&str, SshHost)>) -> App {
     let resolver = MockResolver::new(hosts);
     let metadata: Arc<dyn MetadataStore> = Arc::new(MetadataDb::default());

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -928,7 +928,14 @@ pub struct HostFormEdit {
     pub session_logging: crate::session_log::SessionLoggingOverride,
     pub os_icon_index: usize,
     pub password: String,
+    /// The secret as it was in the credential store when the form opened, so
+    /// saving can tell "untouched" from "changed to this exact value", and an
+    /// emptied field can mean "delete it" rather than "leave it alone".
+    pub password_original: String,
     pub has_password: bool,
+    /// Whether the password field is currently shown as text. Per-form and
+    /// deliberately not persisted: it drops on leaving the field or closing.
+    pub password_revealed: bool,
     pub field: HostFormField,
     pub cursor: usize,
     /// Connection fields (address/name/port) are read-only; only launcher metadata is saved.
@@ -1210,7 +1217,12 @@ pub struct IdentityFormEdit {
     pub private_key: String,
     pub certificate: String,
     pub password: String,
+    /// The passphrase as it was in the credential store when the form opened.
+    /// See [`HostFormEdit::password_original`].
+    pub password_original: String,
     pub has_password: bool,
+    /// Whether the passphrase is currently shown as text.
+    pub password_revealed: bool,
     /// Full key material pasted into the Private key field; written to
     /// `~/.ssh/sshub_<name>` on save (the path field then points at it).
     pub pasted_key: Option<String>,

--- a/src/app/util.rs
+++ b/src/app/util.rs
@@ -281,6 +281,19 @@ pub(crate) fn optional_path(raw: &str) -> Option<std::path::PathBuf> {
 /// "put this base64-encoded payload on the system clipboard". The
 /// sequence is invisible to the alternate-screen UI — the host terminal
 /// consumes it before it ever lands on a buffer cell.
+/// Copy `secret` to the clipboard and return the notice to show. `what` names it
+/// ("password", "passphrase"); the value itself never reaches the message, the
+/// audit log or any diagnostic.
+pub(crate) fn copy_secret_notice(secret: &str, what: &str) -> String {
+    if secret.is_empty() {
+        return format!("no {what} stored for this entry");
+    }
+    match write_osc52(secret) {
+        Ok(()) => format!("{what} copied to the clipboard"),
+        Err(e) => format!("could not copy the {what}: {e}"),
+    }
+}
+
 pub(crate) fn write_osc52(text: &str) -> std::io::Result<()> {
     use std::io::Write;
     let encoded = base64_encode(text.as_bytes());

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -1071,6 +1071,22 @@ impl KeybindsConfig {
         parts.join("  ")
     }
 
+    /// Hint shown while a password / passphrase field is focused. A stored secret
+    /// is masked, so without this the two binds that show or copy it are
+    /// invisible exactly where they are needed. Empty when both are unbound.
+    pub fn secret_field_hints(&self) -> String {
+        let mut parts = Vec::new();
+        let reveal = self.primary(KeyAction::RevealSecret);
+        if !reveal.is_empty() {
+            parts.push(format!("{reveal}: show + copy"));
+        }
+        let copy = self.primary(KeyAction::CopySecret);
+        if !copy.is_empty() {
+            parts.push(format!("{copy}: copy"));
+        }
+        parts.join(" \u{2502} ")
+    }
+
     /// Dashboard footer hints when embedded sessions are running in background.
     ///
     /// `resume` comes first on purpose: with a session running somewhere behind

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -160,6 +160,16 @@ macro_rules! kb_defaults {
             vec![$($key.to_string()),*]
         }
     };
+    (@fn reveal_secret $($key:literal),* $(,)?) => {
+        fn default_kb_reveal_secret() -> Vec<String> {
+            vec![$($key.to_string()),*]
+        }
+    };
+    (@fn copy_secret $($key:literal),* $(,)?) => {
+        fn default_kb_copy_secret() -> Vec<String> {
+            vec![$($key.to_string()),*]
+        }
+    };
     (@fn ui_zoom_in $($key:literal),* $(,)?) => {
         fn default_kb_ui_zoom_in() -> Vec<String> {
             vec![$($key.to_string()),*]
@@ -413,6 +423,8 @@ kb_defaults! {
     clear_ssh_log => ["c"],
     sort_cycle => ["s"],
     yank_log => ["y"],
+    reveal_secret => ["Ctrl+R"],
+    copy_secret => ["Ctrl+Y"],
     ui_zoom_in => ["+", "="],
     ui_zoom_out => ["-", "_"],
     export_ssh => ["Shift+E"],
@@ -491,6 +503,8 @@ pub enum KeyAction {
     ClearSshLog,
     SortCycle,
     YankLog,
+    RevealSecret,
+    CopySecret,
     UiZoomIn,
     UiZoomOut,
     ExportSsh,
@@ -539,7 +553,7 @@ pub enum KeyAction {
 
 impl KeyAction {
     /// All editable actions, in display order.
-    pub const ALL: [KeyAction; 74] = [
+    pub const ALL: [KeyAction; 76] = [
         KeyAction::Save,
         KeyAction::Quit,
         KeyAction::Help,
@@ -570,6 +584,8 @@ impl KeyAction {
         KeyAction::ClearSshLog,
         KeyAction::SortCycle,
         KeyAction::YankLog,
+        KeyAction::RevealSecret,
+        KeyAction::CopySecret,
         KeyAction::UiZoomIn,
         KeyAction::UiZoomOut,
         KeyAction::ExportSsh,
@@ -648,6 +664,8 @@ impl KeyAction {
             KeyAction::ClearSshLog => "Clear SSH log",
             KeyAction::SortCycle => "Cycle sort mode",
             KeyAction::YankLog => "Copy SSH log",
+            KeyAction::RevealSecret => "Show and copy the stored secret",
+            KeyAction::CopySecret => "Copy the stored secret",
             KeyAction::UiZoomIn => "Zoom in (hosts column)",
             KeyAction::UiZoomOut => "Zoom out (hosts column)",
             KeyAction::ExportSsh => "Export to ssh config",
@@ -759,6 +777,10 @@ pub struct KeybindsConfig {
     pub sort_cycle: Vec<String>,
     #[serde(default = "default_kb_yank_log")]
     pub yank_log: Vec<String>,
+    #[serde(default = "default_kb_reveal_secret")]
+    pub reveal_secret: Vec<String>,
+    #[serde(default = "default_kb_copy_secret")]
+    pub copy_secret: Vec<String>,
     #[serde(default = "default_kb_ui_zoom_in")]
     pub ui_zoom_in: Vec<String>,
     #[serde(default = "default_kb_ui_zoom_out")]
@@ -882,6 +904,8 @@ impl Default for KeybindsConfig {
             clear_ssh_log: default_kb_clear_ssh_log(),
             sort_cycle: default_kb_sort_cycle(),
             yank_log: default_kb_yank_log(),
+            reveal_secret: default_kb_reveal_secret(),
+            copy_secret: default_kb_copy_secret(),
             ui_zoom_in: default_kb_ui_zoom_in(),
             ui_zoom_out: default_kb_ui_zoom_out(),
             export_ssh: default_kb_export_ssh(),
@@ -963,6 +987,8 @@ impl KeybindsConfig {
             KeyAction::ClearSshLog => default_kb_clear_ssh_log(),
             KeyAction::SortCycle => default_kb_sort_cycle(),
             KeyAction::YankLog => default_kb_yank_log(),
+            KeyAction::RevealSecret => default_kb_reveal_secret(),
+            KeyAction::CopySecret => default_kb_copy_secret(),
             KeyAction::UiZoomIn => default_kb_ui_zoom_in(),
             KeyAction::UiZoomOut => default_kb_ui_zoom_out(),
             KeyAction::ExportSsh => default_kb_export_ssh(),
@@ -1094,6 +1120,8 @@ impl KeybindsConfig {
             KeyAction::ClearSshLog => &self.clear_ssh_log,
             KeyAction::SortCycle => &self.sort_cycle,
             KeyAction::YankLog => &self.yank_log,
+            KeyAction::RevealSecret => &self.reveal_secret,
+            KeyAction::CopySecret => &self.copy_secret,
             KeyAction::UiZoomIn => &self.ui_zoom_in,
             KeyAction::UiZoomOut => &self.ui_zoom_out,
             KeyAction::ExportSsh => &self.export_ssh,
@@ -1173,6 +1201,8 @@ impl KeybindsConfig {
             KeyAction::ClearSshLog => self.clear_ssh_log = binds,
             KeyAction::SortCycle => self.sort_cycle = binds,
             KeyAction::YankLog => self.yank_log = binds,
+            KeyAction::RevealSecret => self.reveal_secret = binds,
+            KeyAction::CopySecret => self.copy_secret = binds,
             KeyAction::UiZoomIn => self.ui_zoom_in = binds,
             KeyAction::UiZoomOut => self.ui_zoom_out = binds,
             KeyAction::ExportSsh => self.export_ssh = binds,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1184,6 +1184,7 @@ fn render_form_popup(frame: &mut Frame, app: &App, kind: FormKind) {
                         &app.groups,
                         &app.identities,
                         &app.save_key_label(),
+                        &app.config.keybinds.secret_field_hints(),
                     ),
                     popup_area,
                 );
@@ -1192,7 +1193,11 @@ fn render_form_popup(frame: &mut Frame, app: &App, kind: FormKind) {
         FormKind::Identity => {
             if let Some(form) = app.identity_form.as_ref() {
                 frame.render_widget(
-                    screens::keychain::render_identity_form(form, &app.save_key_label()),
+                    screens::keychain::render_identity_form(
+                        form,
+                        &app.save_key_label(),
+                        &app.config.keybinds.secret_field_hints(),
+                    ),
                     popup_area,
                 );
             }

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -77,6 +77,8 @@ fn help_lines() -> Vec<Line<'static>> {
         entry("p", "Add key to agent"),
         entry("r", "Remove key from agent"),
         entry("Shift+P", "Push public key to a remote host"),
+        entry("Ctrl+R", "In a form: show and copy the stored secret"),
+        entry("Ctrl+Y", "In a form: copy the stored secret"),
         Line::from(""),
         section("audit (tab 5)"),
         entry("f", "Cycle filter (all/ok/fail)"),

--- a/src/tui/screens/host_form.rs
+++ b/src/tui/screens/host_form.rs
@@ -124,10 +124,18 @@ pub fn render_host_form(
             HostFormField::OsIcon => ("OS icon", os_icon_label(form.os_icon_index)),
             HostFormField::Password => (
                 "Password",
-                if editing {
+                // Masked while typing too, now that the field arrives prefilled
+                // with the stored secret: walking onto it must not expose one.
+                // The reveal bind is the way to see it.
+                if editing && form.password_revealed {
                     text_input::with_cursor(&form.password, form.cursor)
+                } else if editing {
+                    text_input::with_cursor(
+                        &"\u{25CF}".repeat(form.password.chars().count()),
+                        form.cursor,
+                    )
                 } else {
-                    password_display(&form.password, form.has_password)
+                    password_display(&form.password, form.has_password, form.password_revealed)
                 },
             ),
             HostFormField::Username => (
@@ -214,13 +222,20 @@ fn os_icon_label(index: usize) -> String {
         .unwrap_or_else(|| "(none)".to_string())
 }
 
-fn password_display(password: &str, has_password: bool) -> String {
-    if !password.is_empty() {
-        "\u{25CF}".repeat(password.chars().count())
-    } else if has_password {
-        "(set)".to_string()
+fn password_display(password: &str, has_password: bool, revealed: bool) -> String {
+    if password.is_empty() {
+        // `(set)` only survives for a secret the store would not hand back, e.g.
+        // a locked keyring: otherwise the field is prefilled and this is honest.
+        return if has_password {
+            "(set)".to_string()
+        } else {
+            "(empty)".to_string()
+        };
+    }
+    if revealed {
+        password.to_string()
     } else {
-        "(empty)".to_string()
+        "\u{25CF}".repeat(password.chars().count())
     }
 }
 

--- a/src/tui/screens/host_form.rs
+++ b/src/tui/screens/host_form.rs
@@ -12,6 +12,7 @@ pub fn render_host_form(
     groups: &[HostGroup],
     identities: &[Identity],
     save_hint: &str,
+    secret_hints: &str,
 ) -> Paragraph<'static> {
     let title = if form.metadata_only {
         "Edit metadata (ssh_config)"
@@ -179,6 +180,10 @@ pub fn render_host_form(
 
     let hint = Style::default().add_modifier(Modifier::DIM);
     lines.push(Line::from(""));
+    if form.field == HostFormField::Password && !secret_hints.is_empty() {
+        // See the identity form: a masked value needs its binds said out loud.
+        lines.push(Line::from(Span::styled(secret_hints.to_string(), hint)));
+    }
     lines.push(Line::from(Span::styled(
         "Tab/↓: next field    Enter: open picker (Group/Identity)",
         hint,

--- a/src/tui/screens/keychain.rs
+++ b/src/tui/screens/keychain.rs
@@ -57,8 +57,15 @@ pub fn render_identity_form(form: &IdentityFormEdit, save_hint: &str) -> Paragra
         };
         let display = match field {
             IdentityFormField::Password => {
-                if editing {
+                if editing && form.password_revealed {
                     text_input::with_cursor(&form.password, form.cursor)
+                } else if editing {
+                    text_input::with_cursor(
+                        &"\u{25CF}".repeat(form.password.chars().count()),
+                        form.cursor,
+                    )
+                } else if form.password_revealed {
+                    form.password.clone()
                 } else if !form.password.is_empty() {
                     "\u{25CF}".repeat(form.password.chars().count())
                 } else if form.has_password {

--- a/src/tui/screens/keychain.rs
+++ b/src/tui/screens/keychain.rs
@@ -43,7 +43,11 @@ pub fn render_identity_list(app: &App) -> List<'static> {
     List::new(items)
 }
 
-pub fn render_identity_form(form: &IdentityFormEdit, save_hint: &str) -> Paragraph<'static> {
+pub fn render_identity_form(
+    form: &IdentityFormEdit,
+    save_hint: &str,
+    secret_hints: &str,
+) -> Paragraph<'static> {
     let mut lines = Vec::with_capacity(IdentityFormField::ALL.len() + 2);
     for field in IdentityFormField::ALL {
         let active = form.field == field;
@@ -127,8 +131,16 @@ pub fn render_identity_form(form: &IdentityFormEdit, save_hint: &str) -> Paragra
         ]));
     }
     lines.push(ratatui::text::Line::from(""));
+    let base = format!("type to edit │ paste a key or its path into Private key │ Tab/↓: next │ {save_hint}: save │ Esc: cancel");
+    // On the passphrase field the secret binds come first: the value is masked,
+    // so that is the moment the user needs to know how to see or copy it.
+    let hint = if form.field == IdentityFormField::Password && !secret_hints.is_empty() {
+        format!("{secret_hints} │ {base}")
+    } else {
+        base
+    };
     lines.push(ratatui::text::Line::from(ratatui::text::Span::styled(
-        format!("type to edit │ paste a key or its path into Private key │ Tab/↓: next │ {save_hint}: save │ Esc: cancel"),
+        hint,
         Style::default().add_modifier(Modifier::DIM),
     )));
     Paragraph::new(lines).block(Block::default().borders(Borders::ALL).title("Identity"))


### PR DESCRIPTION
Closes #60.

## What changes

A stored password or passphrase rendered as `(set)` and nothing else, which made the field
write-only: no way to tell which secret was stored, no way to get it out of SSHub, and editing
meant retyping from scratch.

- The field opens **prefilled** from the credential store, masked at the stored length.
- **`Ctrl+R` shows and copies.** **`Ctrl+Y` copies without showing.** Two binds on purpose:
  wanting a secret in the clipboard is not the same as wanting it on screen.
- Both report **what** they copied, never the value. Nothing reaches a notice, the audit log or a
  diagnostic.
- The reveal is per-field and drops the moment the field is left or the form closes.
- Both are `KeyAction`s, so they appear in the keybinding editor and are rebindable.

Covers the host form and the identity form, since both carry a secret.

## Two consequences worth reading

**Clearing the field now removes the secret.** The save path's only signal was "field not empty",
which prefilling would have turned into "rewrite the same secret on every save", and which also
meant a stored secret could never be deleted through the UI. Both forms now compare against what
the store held when the form opened; an emptied field deletes the entry and clears `has_password`.

**The field masks while typing too.** It used to show typed input as plain text. That was fine for
a field that always started empty, but it now arrives carrying a real secret, so walking onto it
would have exposed one. `Ctrl+R` is the way to see it.

`(set)` still exists for exactly one case: a store that will not hand the secret back, e.g. a
locked keyring. That is now an honest message instead of the normal state.

## Verified

Five new tests, plus an in-memory credential store for the harness, because `NoopPasswordStore`
answers `None` to everything and left every read-back path untestable:

- opening a form prefills the field and remembers the original;
- an emptied field removes the entry from the store and clears `has_password`;
- an untouched save leaves the stored secret exactly as it was;
- the copy bind reveals nothing and its notice names the secret without containing it; the reveal
  bind shows it, and walking off the field re-masks;
- both binds are ignored while the cursor is on any other field.

`cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` passes, full suite green:
535 unit, 72 e2e, 42 smoke, 1 config_load.

## Note

`Ctrl+R` / `Ctrl+Y` were free; every other Ctrl chord in the defaults is taken. `KeyAction::ALL`
is 76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
