### PR TITLE
test(watcher): assert what the debouncer promises, not a lucky count

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -152,7 +152,7 @@ mod tests {
 
     // Same real-FSEvents caveat as spawn_config_watcher_emits_after_write: the
     // debounce coalescing logic is validated on Linux; macOS CI can't deliver
-    // FSEvents reliably enough to assert "exactly one" within any bound.
+    // FSEvents reliably enough to assert anything about counts within a bound.
     #[test]
     #[cfg_attr(
         target_os = "macos",
@@ -170,7 +170,8 @@ mod tests {
             Duration::from_millis(100)
         };
         thread::sleep(settle);
-        for i in 0..5 {
+        const WRITES: u32 = 5;
+        for i in 0..WRITES {
             writeln!(file, "Host line-{i}").unwrap();
             file.flush().unwrap();
             let _ = file.as_file().sync_all();
@@ -182,20 +183,27 @@ mod tests {
         let mut events = 0u32;
         while Instant::now() < deadline {
             match rx.recv_timeout(Duration::from_millis(200)) {
-                Ok(WatchEvent::ConfigChanged) => {
-                    events += 1;
-                    assert!(
-                        events <= 1,
-                        "expected single debounced event, got at least {events}"
-                    );
-                }
+                Ok(WatchEvent::ConfigChanged) => events += 1,
                 Err(RecvTimeoutError::Timeout) => {}
                 Err(RecvTimeoutError::Disconnected) => break,
             }
         }
-        assert_eq!(
-            events, 1,
-            "expected exactly one debounced event within {window:?}"
+
+        // What the debouncer promises is that a burst does not arrive one event
+        // per write, not that it always collapses to exactly one. The window is
+        // wall-clock time and the writes are real inotify events, so a loaded
+        // machine can straddle the boundary and deliver two: asserting `== 1`
+        // failed at random on CI (issue #62).
+        //
+        // Both bounds still catch a break: zero means delivery stopped, WRITES
+        // means nothing was coalesced at all.
+        assert!(
+            events >= 1,
+            "expected at least one event from {WRITES} writes within {window:?}"
+        );
+        assert!(
+            events < WRITES,
+            "expected the burst coalesced, got {events} events from {WRITES} writes"
         );
     }
 


### PR DESCRIPTION
Closes #62.

`debounce_coalesces_rapid_writes` asserted that five rapid writes produce **exactly one** event.
The debounce window is wall-clock time and the writes are real inotify events, so a loaded runner
can straddle the boundary and deliver two. It failed on `Test (ubuntu-latest)` in the CI run for
#61, a PR that touches no watcher code, and passed on a rerun of the same job.

What the debouncer actually promises is that a burst does not arrive one event per write. That is
what the test says now: at least one event, fewer than the number of writes. Both bounds keep their
teeth, zero catches delivery breaking and five catches coalescing being lost, without depending on
how busy the machine is.

The write count is a named constant, so the assertions cannot drift from the loop.

## Verified

- Eight consecutive runs of the test, all green (the repeat check #62 asked for).
- `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` passes, full suite green.

Not done here, and worth its own issue if the debounce logic grows any more rules: injecting a
clock so the coalescing can be asserted exactly with no sleeps at all. Today's rules are simple
enough that a real-inotify test plus these bounds is the honest trade.