### PR TITLE
fix(auth): keep askpass working after the binary is replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,15 @@ All notable changes to SSHub are documented in this file.
 
 ### Fixed
 
+- **Upgrading while running broke password auth until restart** (issue #63) - the
+  askpass helper is this binary, found through `current_exe()`, and an upgrade
+  replaces the file rather than writing into it, so the running process was left
+  pointing at `<path> (deleted)`. ssh could not exec that, no stored secret was
+  delivered, and the failure read as `Permission denied (publickey)`, which points
+  at the server rather than at the upgrade. The path is now re-resolved when it
+  disappears, so an in-place upgrade keeps working, and when the helper genuinely
+  cannot be found the session log says why instead of leaving a rejected-key
+  message to explain itself.
 - **The agent panel printed over the identity cards** - its position was derived
   from whole card rows while the grid scrolls by lines, so mid-scroll it landed on
   a card and its own short fields left the card showing through, giving lines like

--- a/src/broadcast/mod.rs
+++ b/src/broadcast/mod.rs
@@ -195,7 +195,7 @@ impl CommandRunner for SshCommandRunner {
         // has exited (i.e. for the whole poll loop below).
         let mut _askpass = None;
         if let Some(secret) = secret {
-            if let Ok(exe) = std::env::current_exe() {
+            if let Ok(exe) = crate::session::askpass::helper_exe() {
                 if let Ok(guard) = crate::session::askpass::AskpassSecret::new(secret.value()) {
                     for (k, v) in guard.env(&exe) {
                         cmd.env(k, v);

--- a/src/cli/host.rs
+++ b/src/cli/host.rs
@@ -201,7 +201,7 @@ fn cmd_connect(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
     let mut askpass_guard = None;
     let mut extra_env: Vec<(String, String)> = Vec::new();
     if let Some(secret) = pending_secret.as_ref() {
-        if let Ok(exe) = std::env::current_exe() {
+        if let Ok(exe) = crate::session::askpass::helper_exe() {
             if let Ok(guard) = AskpassSecret::new(secret.value()) {
                 extra_env = guard.env(&exe);
                 askpass_guard = Some(guard);

--- a/src/osinfo/detect.rs
+++ b/src/osinfo/detect.rs
@@ -83,7 +83,7 @@ impl ProbeRunner for SshProbeRunner {
         // child exits so its owner-only temp file is removed on drop.
         let mut _askpass = None;
         if let Some(secret) = secret {
-            if let Ok(exe) = std::env::current_exe() {
+            if let Ok(exe) = crate::session::askpass::helper_exe() {
                 if let Ok(guard) = crate::session::askpass::AskpassSecret::new(secret.value()) {
                     for (k, v) in guard.env(&exe) {
                         cmd.env(k, v);

--- a/src/session/askpass.rs
+++ b/src/session/askpass.rs
@@ -14,6 +14,45 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Path to hand ssh as its `SSH_ASKPASS` helper: this binary, re-executed.
+///
+/// Not simply `current_exe()`, which reads `/proc/self/exe` and reports
+/// `<path> (deleted)` once the file has been replaced. An upgrade never writes
+/// into the running binary: `npm install -g`, `cargo install`, a package manager
+/// and `just install` all unlink the old inode and create a new one. ssh then
+/// fails to exec that literal path, no stored secret is delivered, and what the
+/// user sees is `Permission denied (publickey)`, which points at the server
+/// rather than at the upgrade.
+///
+/// So when the path is gone, strip the marker and take the same path again: after
+/// an in-place upgrade a new binary is sitting right there.
+pub fn helper_exe() -> std::io::Result<PathBuf> {
+    let exe = std::env::current_exe()?;
+    if exe.exists() {
+        return Ok(exe);
+    }
+    if let Some(replaced) = strip_deleted_marker(&exe) {
+        return Ok(replaced);
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        format!(
+            "the sshub binary is no longer at {}, which happens when it is \
+             upgraded while running; restart SSHub to restore password and \
+             passphrase auth",
+            exe.display()
+        ),
+    ))
+}
+
+/// `/proc/self/exe` for a replaced binary reads as `<path> (deleted)`. Returns
+/// that path when it exists again, which is the normal outcome of an upgrade.
+fn strip_deleted_marker(exe: &Path) -> Option<PathBuf> {
+    let text = exe.to_str()?;
+    let base = PathBuf::from(text.strip_suffix(" (deleted)")?);
+    base.exists().then_some(base)
+}
+
 /// A secret staged in a short-lived, owner-only file for `SSH_ASKPASS`.
 pub struct AskpassSecret {
     path: PathBuf,
@@ -122,5 +161,45 @@ mod tests {
     fn askpass_mode_off_without_env() {
         std::env::remove_var(ASKPASS_FILE_ENV);
         assert!(!maybe_run_askpass());
+    }
+}
+
+#[cfg(test)]
+mod exe_tests {
+    use super::*;
+
+    #[test]
+    fn helper_exe_is_the_running_binary() {
+        // The test binary exists, so this is the plain path with no marker.
+        let exe = helper_exe().unwrap();
+        assert!(exe.exists(), "{exe:?}");
+        assert_eq!(exe, std::env::current_exe().unwrap());
+    }
+
+    #[test]
+    fn a_replaced_binary_resolves_to_whatever_took_its_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("sshub");
+        std::fs::write(&real, b"new binary").unwrap();
+
+        // What /proc/self/exe reads once an upgrade replaced the file.
+        let deleted = PathBuf::from(format!("{} (deleted)", real.display()));
+        assert_eq!(
+            strip_deleted_marker(&deleted).as_deref(),
+            Some(real.as_path())
+        );
+
+        // Nothing took its place: no path to offer, and the caller must say so
+        // rather than handing ssh something that cannot be executed.
+        std::fs::remove_file(&real).unwrap();
+        assert_eq!(strip_deleted_marker(&deleted), None);
+    }
+
+    #[test]
+    fn a_path_without_the_marker_is_not_rewritten() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("sshub");
+        std::fs::write(&real, b"binary").unwrap();
+        assert_eq!(strip_deleted_marker(&real), None);
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -218,13 +218,20 @@ impl Session {
         let mut env: Vec<(String, String)> = Vec::new();
         let mut askpass = None;
         let mut use_askpass = false;
+        let mut askpass_error = None;
         if let Some(secret) = config.pending_secret.as_ref() {
-            if let Ok(exe) = std::env::current_exe() {
-                if let Ok(guard) = askpass::AskpassSecret::new(secret.value()) {
-                    env = guard.env(&exe);
-                    askpass = Some(guard);
-                    use_askpass = true;
+            match askpass::helper_exe() {
+                Ok(exe) => {
+                    if let Ok(guard) = askpass::AskpassSecret::new(secret.value()) {
+                        env = guard.env(&exe);
+                        askpass = Some(guard);
+                        use_askpass = true;
+                    }
                 }
+                // Worth saying out loud: without it every stored secret goes
+                // undelivered and ssh reports a rejected key, which sends the
+                // user looking at the server instead of at the upgrade.
+                Err(e) => askpass_error = Some(e.to_string()),
             }
         }
 
@@ -238,6 +245,8 @@ impl Session {
         if config.pending_secret.is_some() {
             diagnostics.push(if use_askpass {
                 "auth: credential handed to ssh via SSH_ASKPASS".to_string()
+            } else if let Some(e) = askpass_error.as_deref() {
+                format!("auth: SSH_ASKPASS unavailable ({e}) — will type at the prompt")
             } else {
                 "auth: SSH_ASKPASS unavailable — will type at the prompt".to_string()
             });

--- a/src/tunnel/spawn.rs
+++ b/src/tunnel/spawn.rs
@@ -132,7 +132,7 @@ pub fn stage_tunnel_askpass(
     let Some(secret) = secret else {
         return Ok(None);
     };
-    let exe = std::env::current_exe()?;
+    let exe = askpass::helper_exe()?;
     let guard = askpass::AskpassSecret::new(secret.value())?;
     for (k, v) in guard.env(&exe) {
         cmd.env(k, v);


### PR DESCRIPTION
Closes #63.

Upgrading SSHub while it runs silently broke authentication for that instance, and blamed the host:

```
debug1: read_passphrase: requested to askpass
ssh_askpass: exec(/home/petruha/.local/bin/sshub (deleted)): No such file or directory
root@10.10.10.2: Permission denied (publickey).
```

`SSH_ASKPASS` points at this binary through `current_exe()`, which reads `/proc/self/exe`. An
upgrade never writes into the running binary: `npm install -g`, `cargo install`, a package manager
and `just install` all unlink the old inode and create a new one, after which the kernel reports the
running process's path with a ` (deleted)` suffix. ssh fails to exec that literal path, the stored
secret never reaches it, and the user goes digging through `authorized_keys` on a server that is
perfectly fine.

## The fix

One `helper_exe()` in `session::askpass`, used by all five call sites: embedded sessions, tunnels,
broadcast, the OS probe and the headless CLI. It takes `current_exe()`, and when that path no longer
exists, strips the marker and uses the same path again, which after an in-place upgrade holds the new
binary. So the common case keeps working without a restart.

When neither path resolves, the session's auth log carries the reason, so the failure names the
upgrade rather than leaving `Permission denied (publickey)` to explain itself.

## Correction to the issue

The issue listed `src/ssh/keyfile.rs` among the affected sites. It is not: `KeygenAskpass` writes
its own `/bin/sh` helper rather than re-executing this binary. `src/cli/host.rs` was affected and
was missing from that list; it is covered here.

## Verified

- Three tests on the resolution itself: the running binary resolves plainly, a replaced binary
  resolves to whatever took its place, and a path without the marker is never rewritten (so the
  fallback cannot fire on a normal path).
- `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` passes, full suite green:
  540 unit, 72 e2e, 42 smoke, 1 config_load.