### PR TITLE
feat(ui): type-to-filter help and keybinding editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to SSHub are documented in this file.
 
 ### Added
 
+- **Type-to-filter in Help and the keybinding editor** (issue #48) - those two
+  overlays were the only long lists you could not search. Both now take a query
+  the same way the tag filter does (`› query█`): case-insensitive substring over
+  the key spec / action label and the description / configured binds. Arrows and
+  PageUp/PageDown move; `j`/`k` type into the query. Esc clears a non-empty query
+  and closes only when it is empty. Section headers with no surviving help rows
+  are dropped, and the keybinding editor rebinds the filtered row (not
+  `KeyAction::ALL[selected]`), including while a capture is in progress.
 - **Stored passwords and passphrases are no longer write-only** (issue #60) - a
   saved secret showed as `(set)` and nothing else: you could not tell which one
   was stored, could not get it out, and editing meant retyping from scratch. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ All notable changes to SSHub are documented in this file.
   the same way the tag filter does (`› query█`): case-insensitive substring over
   the key spec / action label and the description / configured binds. Arrows and
   PageUp/PageDown move; `j`/`k` type into the query. Esc clears a non-empty query
-  and closes only when it is empty. Section headers with no surviving help rows
-  are dropped, and the keybinding editor rebinds the filtered row (not
-  `KeyAction::ALL[selected]`), including while a capture is in progress.
+  and closes only when it is empty (Help also still dismisses on Enter when the
+  query is idle). Section headers with no surviving help rows are dropped, and
+  the keybinding editor rebinds the filtered row (not `KeyAction::ALL[selected]`),
+  including while a capture is in progress. Row actions there moved to Ctrl+A /
+  Ctrl+R / Ctrl+X so every unmodified letter can be part of a search.
 - **Stored passwords and passphrases are no longer write-only** (issue #60) - a
   saved secret showed as `(set)` and nothing else: you could not tell which one
   was stored, could not get it out, and editing meant retyping from scratch. The

--- a/src/app/audit.rs
+++ b/src/app/audit.rs
@@ -70,8 +70,7 @@ impl App {
                 self.refresh_audit_events();
             }
             _ if self.is_action(KeyAction::Help, &key) => {
-                self.pre_help_mode = Some(self.mode);
-                self.mode = AppMode::Help;
+                self.open_help();
             }
             _ => {}
         }

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -683,6 +683,11 @@ impl App {
                     self.help_scroll = 0;
                 }
             }
+            // Enter is not printable query input; keep it as dismiss when idle.
+            KeyCode::Enter if self.help_query.is_empty() => {
+                self.mode = self.pre_help_mode.take().unwrap_or(AppMode::Normal);
+                self.help_scroll = 0;
+            }
             // Ceiling = what the renderer can actually show, not the line count:
             // scrolling past it would silently bank presses that Up must unwind.
             KeyCode::Up => {
@@ -901,6 +906,9 @@ impl App {
             if let Some(e) = self.keybind_editor.as_mut() {
                 e.capturing = false;
             }
+            // Rebinding can drop the row out of a bind-text filter; keep selection
+            // inside the new list so Enter/Ctrl+R/Ctrl+X don't go silent.
+            self.clamp_keybind_editor_selection();
             return Ok(());
         }
 
@@ -959,9 +967,8 @@ impl App {
                     }
                 }
             }
-            // Reserved row actions (same idea as Space in the tag filter): not
-            // query input, so type-to-filter still works for every other letter.
-            KeyCode::Char('a') if key.modifiers.is_empty() => {
+            // Ctrl+letter row actions so unmodified letters stay query input.
+            KeyCode::Char('a') if key.modifiers == KeyModifiers::CONTROL => {
                 let has_rows = !self.filtered_keybind_actions().is_empty();
                 if let Some(e) = self.keybind_editor.as_mut() {
                     if has_rows {
@@ -970,18 +977,20 @@ impl App {
                     }
                 }
             }
-            KeyCode::Char('r') if key.modifiers.is_empty() => {
+            KeyCode::Char('r') if key.modifiers == KeyModifiers::CONTROL => {
                 let actions = self.filtered_keybind_actions();
                 if let Some(&action) = actions.get(editor.selected) {
                     self.config.keybinds.reset_action(action);
                     self.save_config_quietly();
+                    self.clamp_keybind_editor_selection();
                 }
             }
-            KeyCode::Char('x') if key.modifiers.is_empty() => {
+            KeyCode::Char('x') if key.modifiers == KeyModifiers::CONTROL => {
                 let actions = self.filtered_keybind_actions();
                 if let Some(&action) = actions.get(editor.selected) {
                     self.config.keybinds.set(action, Vec::new());
                     self.save_config_quietly();
+                    self.clamp_keybind_editor_selection();
                 }
             }
             KeyCode::Backspace => {
@@ -1027,6 +1036,19 @@ impl App {
                         .any(|b| b.to_lowercase().contains(&query))
             })
             .collect()
+    }
+
+    fn clamp_keybind_editor_selection(&mut self) {
+        let len = self.filtered_keybind_actions().len();
+        if let Some(e) = self.keybind_editor.as_mut() {
+            if len == 0 {
+                e.selected = 0;
+                e.scroll = 0;
+            } else if e.selected >= len {
+                e.selected = len - 1;
+            }
+            Self::clamp_keybind_editor_scroll(e);
+        }
     }
 
     fn clamp_keybind_editor_scroll(editor: &mut KeybindEditor) {

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -38,6 +38,7 @@ impl App {
                 scroll: 0,
                 capturing: false,
                 append: false,
+                query: String::new(),
             });
             self.mode = AppMode::KeybindEditor;
             return Ok(());
@@ -313,8 +314,7 @@ impl App {
                 self.mode = AppMode::Palette;
             }
             _ if self.is_action(KeyAction::Help, &key) => {
-                self.pre_help_mode = Some(self.mode);
-                self.mode = AppMode::Help;
+                self.open_help();
             }
             _ if self.is_action(KeyAction::TagFilter, &key) => self.open_tag_filter(),
             _ if self.is_action(KeyAction::ClearSshLog, &key) => {
@@ -599,8 +599,7 @@ impl App {
             _ if self.is_action(KeyAction::AddToAgent, &key) => self.add_selected_to_agent()?,
             _ if self.is_action(KeyAction::PushKey, &key) => self.trigger_push_key_from_keys()?,
             _ if self.is_action(KeyAction::Help, &key) => {
-                self.pre_help_mode = Some(self.mode);
-                self.mode = AppMode::Help;
+                self.open_help();
             }
             _ => {}
         }
@@ -666,34 +665,56 @@ impl App {
         Ok(())
     }
 
+    pub(crate) fn open_help(&mut self) {
+        self.pre_help_mode = Some(self.mode);
+        self.mode = AppMode::Help;
+        self.help_scroll = 0;
+        self.help_query.clear();
+    }
+
     pub(crate) fn handle_key_help(&mut self, key: KeyEvent) -> Result<()> {
-        if self.is_action(KeyAction::Cancel, &key)
-            || self.is_action(KeyAction::Quit, &key)
-            || self.is_action(KeyAction::Help, &key)
-            || self.is_action(KeyAction::Connect, &key)
-        {
-            self.mode = self.pre_help_mode.take().unwrap_or(AppMode::Normal);
-            self.help_scroll = 0;
-            return Ok(());
-        }
-        // Ceiling = what the renderer can actually show, not the line count:
-        // scrolling past it would silently bank presses that Up must unwind.
-        let max = crate::tui::help_max_scroll(self.terminal_area);
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
+            KeyCode::Esc => {
+                if !self.help_query.is_empty() {
+                    self.help_query.clear();
+                    self.help_scroll = 0;
+                } else {
+                    self.mode = self.pre_help_mode.take().unwrap_or(AppMode::Normal);
+                    self.help_scroll = 0;
+                }
+            }
+            // Ceiling = what the renderer can actually show, not the line count:
+            // scrolling past it would silently bank presses that Up must unwind.
+            KeyCode::Up => {
                 self.help_scroll = self.help_scroll.saturating_sub(1);
             }
-            KeyCode::Down | KeyCode::Char('j') => {
+            KeyCode::Down => {
+                let max = crate::tui::help_max_scroll(self.terminal_area, &self.help_query);
                 self.help_scroll = (self.help_scroll + 1).min(max);
             }
             KeyCode::PageUp => {
                 self.help_scroll = self.help_scroll.saturating_sub(10);
             }
             KeyCode::PageDown => {
+                let max = crate::tui::help_max_scroll(self.terminal_area, &self.help_query);
                 self.help_scroll = (self.help_scroll + 10).min(max);
             }
             KeyCode::Home => self.help_scroll = 0,
-            KeyCode::End => self.help_scroll = max,
+            KeyCode::End => {
+                self.help_scroll =
+                    crate::tui::help_max_scroll(self.terminal_area, &self.help_query);
+            }
+            KeyCode::Backspace => {
+                self.help_query.pop();
+                self.help_scroll = 0;
+            }
+            KeyCode::Char(c)
+                if (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)
+                    && !c.is_control() =>
+            {
+                self.help_query.push(c);
+                self.help_scroll = 0;
+            }
             _ => {}
         }
         Ok(())
@@ -856,7 +877,7 @@ impl App {
     }
 
     pub(crate) fn handle_key_keybind_editor(&mut self, key: KeyEvent) -> Result<()> {
-        let Some(editor) = self.keybind_editor else {
+        let Some(editor) = self.keybind_editor.clone() else {
             self.mode = AppMode::Normal;
             return Ok(());
         };
@@ -864,13 +885,17 @@ impl App {
         if editor.capturing {
             if key.code != KeyCode::Esc {
                 if let Some(spec) = keyevent_to_spec(&key) {
-                    let action = KeyAction::ALL[editor.selected];
-                    if editor.append {
-                        self.config.keybinds.add(action, spec);
-                    } else {
-                        self.config.keybinds.set(action, vec![spec]);
+                    // `selected` indexes the filtered list — rebinding ALL[selected]
+                    // would silently edit the wrong action under an active filter.
+                    let actions = self.filtered_keybind_actions();
+                    if let Some(&action) = actions.get(editor.selected) {
+                        if editor.append {
+                            self.config.keybinds.add(action, spec);
+                        } else {
+                            self.config.keybinds.set(action, vec![spec]);
+                        }
+                        self.save_config_quietly();
                     }
-                    self.save_config_quietly();
                 }
             }
             if let Some(e) = self.keybind_editor.as_mut() {
@@ -880,47 +905,128 @@ impl App {
         }
 
         match key.code {
-            _ if self.is_action(KeyAction::Cancel, &key) => {
-                self.keybind_editor = None;
-                self.mode = AppMode::Normal;
-            }
-            _ if self.is_action(KeyAction::MoveDown, &key) => {
+            KeyCode::Esc => {
                 if let Some(e) = self.keybind_editor.as_mut() {
-                    e.selected = (e.selected + 1) % KeyAction::ALL.len();
+                    if !e.query.is_empty() {
+                        e.query.clear();
+                        e.selected = 0;
+                        e.scroll = 0;
+                    } else {
+                        self.keybind_editor = None;
+                        self.mode = AppMode::Normal;
+                    }
+                }
+            }
+            KeyCode::Down => {
+                let len = self.filtered_keybind_actions().len();
+                if len > 0 {
+                    if let Some(e) = self.keybind_editor.as_mut() {
+                        e.selected = (e.selected + 1) % len;
+                        Self::clamp_keybind_editor_scroll(e);
+                    }
+                }
+            }
+            KeyCode::Up => {
+                let len = self.filtered_keybind_actions().len();
+                if len > 0 {
+                    if let Some(e) = self.keybind_editor.as_mut() {
+                        e.selected = (e.selected + len - 1) % len;
+                        Self::clamp_keybind_editor_scroll(e);
+                    }
+                }
+            }
+            KeyCode::PageDown => {
+                let len = self.filtered_keybind_actions().len();
+                if len > 0 {
+                    if let Some(e) = self.keybind_editor.as_mut() {
+                        e.selected = (e.selected + 10).min(len - 1);
+                        Self::clamp_keybind_editor_scroll(e);
+                    }
+                }
+            }
+            KeyCode::PageUp => {
+                if let Some(e) = self.keybind_editor.as_mut() {
+                    e.selected = e.selected.saturating_sub(10);
                     Self::clamp_keybind_editor_scroll(e);
                 }
             }
-            _ if self.is_action(KeyAction::MoveUp, &key) => {
+            KeyCode::Enter => {
+                let has_rows = !self.filtered_keybind_actions().is_empty();
                 if let Some(e) = self.keybind_editor.as_mut() {
-                    e.selected = (e.selected + KeyAction::ALL.len() - 1) % KeyAction::ALL.len();
-                    Self::clamp_keybind_editor_scroll(e);
+                    if has_rows {
+                        e.capturing = true;
+                        e.append = false;
+                    }
                 }
             }
-            _ if self.is_action(KeyAction::Connect, &key) => {
+            // Reserved row actions (same idea as Space in the tag filter): not
+            // query input, so type-to-filter still works for every other letter.
+            KeyCode::Char('a') if key.modifiers.is_empty() => {
+                let has_rows = !self.filtered_keybind_actions().is_empty();
                 if let Some(e) = self.keybind_editor.as_mut() {
-                    e.capturing = true;
-                    e.append = false;
-                }
-            }
-            _ if self.is_action(KeyAction::AddHost, &key) => {
-                if let Some(e) = self.keybind_editor.as_mut() {
-                    e.capturing = true;
-                    e.append = true;
+                    if has_rows {
+                        e.capturing = true;
+                        e.append = true;
+                    }
                 }
             }
             KeyCode::Char('r') if key.modifiers.is_empty() => {
-                let action = KeyAction::ALL[editor.selected];
-                self.config.keybinds.reset_action(action);
-                self.save_config_quietly();
+                let actions = self.filtered_keybind_actions();
+                if let Some(&action) = actions.get(editor.selected) {
+                    self.config.keybinds.reset_action(action);
+                    self.save_config_quietly();
+                }
             }
             KeyCode::Char('x') if key.modifiers.is_empty() => {
-                let action = KeyAction::ALL[editor.selected];
-                self.config.keybinds.set(action, Vec::new());
-                self.save_config_quietly();
+                let actions = self.filtered_keybind_actions();
+                if let Some(&action) = actions.get(editor.selected) {
+                    self.config.keybinds.set(action, Vec::new());
+                    self.save_config_quietly();
+                }
+            }
+            KeyCode::Backspace => {
+                if let Some(e) = self.keybind_editor.as_mut() {
+                    e.query.pop();
+                    e.selected = 0;
+                    e.scroll = 0;
+                }
+            }
+            KeyCode::Char(c)
+                if (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)
+                    && !c.is_control() =>
+            {
+                if let Some(e) = self.keybind_editor.as_mut() {
+                    e.query.push(c);
+                    e.selected = 0;
+                    e.scroll = 0;
+                }
             }
             _ => {}
         }
         Ok(())
+    }
+
+    /// Actions visible in the keybinding editor under the current filter query.
+    pub fn filtered_keybind_actions(&self) -> Vec<KeyAction> {
+        let query = self
+            .keybind_editor
+            .as_ref()
+            .map(|e| e.query.to_lowercase())
+            .unwrap_or_default();
+        KeyAction::ALL
+            .iter()
+            .copied()
+            .filter(|action| {
+                query.is_empty()
+                    || action.label().to_lowercase().contains(&query)
+                    || self
+                        .config
+                        .keybinds
+                        .binds(*action)
+                        .iter()
+                        .any(|b| b.to_lowercase().contains(&query))
+            })
+            .collect()
     }
 
     fn clamp_keybind_editor_scroll(editor: &mut KeybindEditor) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -186,6 +186,8 @@ pub struct App {
     pub pre_help_mode: Option<AppMode>,
     /// Vertical scroll offset (in lines) of the help overlay.
     pub help_scroll: u16,
+    /// Type-to-filter query for the help overlay.
+    pub help_query: String,
     /// Mode to return to if the quit dialog is cancelled.
     pub pre_quit_mode: Option<AppMode>,
     pub group_sections: Vec<HostGroupSection>,
@@ -659,6 +661,7 @@ impl App {
             pending_delete: None,
             pre_help_mode: None,
             help_scroll: 0,
+            help_query: String::new(),
             pre_quit_mode: None,
             group_sections: Vec::new(),
             nav_rows: Vec::new(),

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -158,8 +158,7 @@ impl App {
                 self.rebuild_filter();
             }
             _ if self.is_action(KeyAction::Help, &key) => {
-                self.pre_help_mode = Some(self.mode);
-                self.mode = AppMode::Help;
+                self.open_help();
             }
             _ => {}
         }
@@ -238,8 +237,7 @@ impl App {
             return Ok(());
         }
         if self.is_action(KeyAction::Help, &key) {
-            self.pre_help_mode = Some(self.mode);
-            self.mode = AppMode::Help;
+            self.open_help();
             return Ok(());
         }
 

--- a/src/app/tests/keybind.rs
+++ b/src/app/tests/keybind.rs
@@ -13,9 +13,9 @@ pub(crate) fn keybind_editor_captures_and_persists() {
 
     // Row 0 is "Save". Enter starts capture; press F10 to bind it.
     app.handle_key(key(KeyCode::Enter)).unwrap();
-    assert!(app.keybind_editor.unwrap().capturing);
+    assert!(app.keybind_editor.as_ref().unwrap().capturing);
     app.handle_key(key(KeyCode::F(10))).unwrap();
-    assert!(!app.keybind_editor.unwrap().capturing);
+    assert!(!app.keybind_editor.as_ref().unwrap().capturing);
 
     assert_eq!(app.config.keybinds.save, vec!["F10".to_string()]);
     assert!(app.is_save_key(&key(KeyCode::F(10))));
@@ -27,7 +27,7 @@ pub(crate) fn keybind_editor_captures_and_persists() {
 
     // 'a' adds another binding without replacing.
     app.handle_key(key_char('a')).unwrap();
-    assert!(app.keybind_editor.unwrap().append);
+    assert!(app.keybind_editor.as_ref().unwrap().append);
     app.handle_key(key(KeyCode::F(12))).unwrap();
     assert_eq!(
         app.config.keybinds.save,
@@ -46,6 +46,102 @@ pub(crate) fn keybind_editor_captures_and_persists() {
     assert_eq!(app.config.keybinds.save, vec!["F2", "Ctrl+S"]);
 
     std::env::remove_var("SSHUB_CONFIG_DIR");
+}
+
+#[test]
+pub(crate) fn keybind_editor_filter_rebinds_filtered_action() {
+    let dir = tempfile::tempdir().unwrap();
+    std::env::set_var("SSHUB_CONFIG_DIR", dir.path());
+
+    let mut app = test_app(vec![("web", host("web"))]);
+    app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL))
+        .unwrap();
+
+    // Narrow to "Help" — filtered[0] is Help, not Save (ALL[0]).
+    for c in ['h', 'e', 'l', 'p'] {
+        app.handle_key(key_char(c)).unwrap();
+    }
+    let actions = app.filtered_keybind_actions();
+    assert!(
+        actions.iter().any(|a| *a == KeyAction::Help),
+        "filter should include Help"
+    );
+    assert_eq!(app.keybind_editor.as_ref().unwrap().selected, 0);
+    assert_eq!(actions[0], KeyAction::Help);
+
+    app.handle_key(key(KeyCode::Enter)).unwrap();
+    assert!(app.keybind_editor.as_ref().unwrap().capturing);
+    // While capturing, a letter must bind — not extend the query.
+    app.handle_key(key_char('z')).unwrap();
+    assert!(!app.keybind_editor.as_ref().unwrap().capturing);
+    assert_eq!(app.keybind_editor.as_ref().unwrap().query, "help");
+    assert_eq!(app.config.keybinds.help, vec!["z".to_string()]);
+    // Save (ALL[0]) must be untouched.
+    assert_eq!(app.config.keybinds.save, vec!["F2", "Ctrl+S"]);
+
+    std::env::remove_var("SSHUB_CONFIG_DIR");
+}
+
+#[test]
+pub(crate) fn keybind_editor_esc_clears_query_then_closes() {
+    let mut app = test_app(vec![("web", host("web"))]);
+    app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL))
+        .unwrap();
+    app.handle_key(key_char('q')).unwrap();
+    assert_eq!(app.keybind_editor.as_ref().unwrap().query, "q");
+    assert_eq!(app.mode, AppMode::KeybindEditor);
+
+    app.handle_key(key(KeyCode::Esc)).unwrap();
+    assert!(app.keybind_editor.as_ref().unwrap().query.is_empty());
+    assert_eq!(app.mode, AppMode::KeybindEditor);
+
+    app.handle_key(key(KeyCode::Esc)).unwrap();
+    assert!(app.keybind_editor.is_none());
+    assert_eq!(app.mode, AppMode::Normal);
+}
+
+#[test]
+pub(crate) fn keybind_editor_selection_resets_on_keystroke() {
+    let mut app = test_app(vec![("web", host("web"))]);
+    app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL))
+        .unwrap();
+    app.handle_key(key(KeyCode::Down)).unwrap();
+    app.handle_key(key(KeyCode::Down)).unwrap();
+    assert_eq!(app.keybind_editor.as_ref().unwrap().selected, 2);
+
+    app.handle_key(key_char('m')).unwrap();
+    assert_eq!(app.keybind_editor.as_ref().unwrap().selected, 0);
+    let len = app.filtered_keybind_actions().len();
+    assert!(len < KeyAction::ALL.len());
+    assert!(len > 0);
+}
+
+#[test]
+pub(crate) fn help_filter_matches_and_esc_clears() {
+    let mut app = test_app(vec![("web", host("web"))]);
+    app.handle_key(key_char('?')).unwrap();
+    assert_eq!(app.mode, AppMode::Help);
+
+    for c in ['f', 'a', 'v'] {
+        app.handle_key(key_char(c)).unwrap();
+    }
+    assert_eq!(app.help_query, "fav");
+    assert_eq!(app.help_scroll, 0);
+    let n = crate::tui::screens::help::help_line_count(&app.help_query);
+    assert!(n < crate::tui::screens::help::help_line_count(""));
+    assert!(n > 0);
+
+    // j/k are query input, not scroll.
+    app.handle_key(key_char('j')).unwrap();
+    assert_eq!(app.help_query, "favj");
+    assert_eq!(app.help_scroll, 0);
+
+    app.handle_key(key(KeyCode::Esc)).unwrap();
+    assert!(app.help_query.is_empty());
+    assert_eq!(app.mode, AppMode::Help);
+
+    app.handle_key(key(KeyCode::Esc)).unwrap();
+    assert_eq!(app.mode, AppMode::Normal);
 }
 
 #[test]

--- a/src/app/tests/keybind.rs
+++ b/src/app/tests/keybind.rs
@@ -25,8 +25,9 @@ pub(crate) fn keybind_editor_captures_and_persists() {
     let saved = crate::config::load_config().unwrap();
     assert_eq!(saved.keybinds.save, vec!["F10".to_string()]);
 
-    // 'a' adds another binding without replacing.
-    app.handle_key(key_char('a')).unwrap();
+    // Ctrl+A adds another binding without replacing.
+    app.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL))
+        .unwrap();
     assert!(app.keybind_editor.as_ref().unwrap().append);
     app.handle_key(key(KeyCode::F(12))).unwrap();
     assert_eq!(
@@ -36,13 +37,15 @@ pub(crate) fn keybind_editor_captures_and_persists() {
     assert!(app.is_save_key(&key(KeyCode::F(10))));
     assert!(app.is_save_key(&key(KeyCode::F(12))));
 
-    // 'x' unbinds the action entirely.
-    app.handle_key(key_char('x')).unwrap();
+    // Ctrl+X unbinds the action entirely.
+    app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL))
+        .unwrap();
     assert!(app.config.keybinds.save.is_empty());
     assert!(!app.is_save_key(&key(KeyCode::F(10))));
 
-    // 'r' resets the selected action to defaults.
-    app.handle_key(key_char('r')).unwrap();
+    // Ctrl+R resets the selected action to defaults.
+    app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
+        .unwrap();
     assert_eq!(app.config.keybinds.save, vec!["F2", "Ctrl+S"]);
 
     std::env::remove_var("SSHUB_CONFIG_DIR");
@@ -63,7 +66,7 @@ pub(crate) fn keybind_editor_filter_rebinds_filtered_action() {
     }
     let actions = app.filtered_keybind_actions();
     assert!(
-        actions.iter().any(|a| *a == KeyAction::Help),
+        actions.contains(&KeyAction::Help),
         "filter should include Help"
     );
     assert_eq!(app.keybind_editor.as_ref().unwrap().selected, 0);
@@ -142,6 +145,61 @@ pub(crate) fn help_filter_matches_and_esc_clears() {
 
     app.handle_key(key(KeyCode::Esc)).unwrap();
     assert_eq!(app.mode, AppMode::Normal);
+}
+
+#[test]
+pub(crate) fn keybind_editor_letters_go_to_query_not_row_actions() {
+    let dir = tempfile::tempdir().unwrap();
+    std::env::set_var("SSHUB_CONFIG_DIR", dir.path());
+
+    let mut app = test_app(vec![("web", host("web"))]);
+    app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL))
+        .unwrap();
+    let save_before = app.config.keybinds.save.clone();
+
+    // Typing "agent" must filter, not append-capture / reset / unbind.
+    for c in ['a', 'g', 'e', 'n', 't'] {
+        app.handle_key(key_char(c)).unwrap();
+    }
+    assert_eq!(app.keybind_editor.as_ref().unwrap().query, "agent");
+    assert!(!app.keybind_editor.as_ref().unwrap().capturing);
+    assert_eq!(app.config.keybinds.save, save_before);
+
+    std::env::remove_var("SSHUB_CONFIG_DIR");
+}
+
+#[test]
+pub(crate) fn keybind_editor_clamps_selection_after_bind_leaves_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    std::env::set_var("SSHUB_CONFIG_DIR", dir.path());
+
+    let mut app = test_app(vec![("web", host("web"))]);
+    app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL))
+        .unwrap();
+    for c in "ctrl+".chars() {
+        app.handle_key(key_char(c)).unwrap();
+    }
+    let len = app.filtered_keybind_actions().len();
+    assert!(len > 1, "expected multiple Ctrl+ binds");
+    if let Some(e) = app.keybind_editor.as_mut() {
+        e.selected = len - 1;
+    }
+    let target = app.filtered_keybind_actions()[len - 1];
+    app.handle_key(key(KeyCode::Enter)).unwrap();
+    app.handle_key(key(KeyCode::F(9))).unwrap();
+    // Row dropped out of the "ctrl+" filter; selection must stay in range.
+    let after = app.filtered_keybind_actions().len();
+    assert!(after < len);
+    assert!(!app
+        .config
+        .keybinds
+        .binds(target)
+        .iter()
+        .any(|b| b.to_lowercase().contains("ctrl+")));
+    let selected = app.keybind_editor.as_ref().unwrap().selected;
+    assert!(selected < after || after == 0);
+
+    std::env::remove_var("SSHUB_CONFIG_DIR");
 }
 
 #[test]

--- a/src/app/tests/misc.rs
+++ b/src/app/tests/misc.rs
@@ -466,7 +466,7 @@ pub(crate) fn help_scroll_stops_at_render_ceiling() {
     app.handle_key(key_char('?')).unwrap();
     assert_eq!(app.mode, AppMode::Help);
 
-    let max = crate::tui::help_max_scroll(app.terminal_area);
+    let max = crate::tui::help_max_scroll(app.terminal_area, &app.help_query);
     assert!(max > 0, "help content must overflow a 24-row terminal");
     for _ in 0..500 {
         app.handle_key(key(KeyCode::Down)).unwrap();

--- a/src/app/tunnels.rs
+++ b/src/app/tunnels.rs
@@ -82,8 +82,7 @@ impl App {
                 self.mode = AppMode::TunnelReconnectSettings;
             }
             _ if self.is_action(KeyAction::Help, &key) => {
-                self.pre_help_mode = Some(self.mode);
-                self.mode = AppMode::Help;
+                self.open_help();
             }
             _ => {}
         }

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -870,9 +870,9 @@ impl HostEntry {
 }
 
 /// State of the keybinding editor overlay.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeybindEditor {
-    /// Index into [`KeyAction::ALL`].
+    /// Index into the *filtered* action list (see `App::filtered_keybind_actions`).
     pub selected: usize,
     /// First visible row in the action list (for scrolling).
     pub scroll: usize,
@@ -880,6 +880,8 @@ pub struct KeybindEditor {
     pub capturing: bool,
     /// When capturing, whether to append (`true`) or replace (`false`).
     pub append: bool,
+    /// Type-to-filter query (case-insensitive substring over label + binds).
+    pub query: String,
 }
 
 /// Which host-form field the dropdown is editing.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1390,14 +1390,14 @@ fn format_utc_clock() -> String {
 }
 
 /// Scroll ceiling for the help body given the full terminal area — the same
-/// popup geometry as `render_help_popup` (60% height, min 16; borders + fixed
-/// footer row), kept in one place so the key handler can't scroll past what
+/// popup geometry as `render_help_popup` (60% height, min 16; borders + query
+/// + fixed footer row), kept in one place so the key handler can't scroll past what
 /// the renderer will show (the excess would be invisible "debt" that Up has
 /// to unwind before the view moves).
-pub(crate) fn help_max_scroll(area: Rect) -> u16 {
+pub(crate) fn help_max_scroll(area: Rect, query: &str) -> u16 {
     let popup_height = (area.height * 60 / 100).max(16).min(area.height);
-    let body_height = popup_height.saturating_sub(3);
-    screens::help::help_line_count().saturating_sub(body_height)
+    let body_height = popup_height.saturating_sub(4);
+    screens::help::help_line_count(query).saturating_sub(body_height)
 }
 
 fn render_help_popup(frame: &mut Frame, app: &App) {
@@ -1419,16 +1419,24 @@ fn render_help_popup(frame: &mut Frame, app: &App) {
         popup_area,
     );
 
-    // Reserve the last inner row for a fixed footer; scroll only the body.
+    // Query + fixed footer; scroll only the body between them.
     let inner = popup_area.inner(Margin::new(1, 1));
-    let body = Rect::new(
+    let query_line = format!("› {}\u{2588}", app.help_query);
+    frame.buffer_mut().set_string(
         inner.x,
         inner.y,
-        inner.width,
-        inner.height.saturating_sub(1),
+        crate::tui::text::ellipsize(&query_line, inner.width as usize),
+        theme::bright(),
     );
-    let scroll = app.help_scroll.min(help_max_scroll(area));
-    frame.render_widget(screens::help::render_help(scroll), body);
+
+    let body = Rect::new(
+        inner.x,
+        inner.y.saturating_add(1),
+        inner.width,
+        inner.height.saturating_sub(2),
+    );
+    let scroll = app.help_scroll.min(help_max_scroll(area, &app.help_query));
+    frame.render_widget(screens::help::render_help(scroll, &app.help_query), body);
 
     let footer_y = inner.y + inner.height.saturating_sub(1);
     frame.buffer_mut().set_string(
@@ -2285,5 +2293,41 @@ mod tests {
             !buffer_contains(&buffer, "host-00"),
             "list did not scroll; top host still visible"
         );
+    }
+
+    #[test]
+    fn help_overlay_shows_query_and_filters() {
+        let mut app = test_app_with_hosts();
+        app.mode = AppMode::Help;
+        let full = render_to_buffer(&app, 100, 40);
+        assert!(buffer_contains(&full, "navigate"));
+        assert!(buffer_contains(&full, "type to filter"));
+        assert!(buffer_contains(&full, "›"));
+
+        app.help_query = "favorite".into();
+        let filtered = render_to_buffer(&app, 100, 40);
+        assert!(buffer_contains(&filtered, "Toggle favorite"));
+        assert!(buffer_contains(&filtered, "hosts (tab 1)"));
+        assert!(!buffer_contains(&filtered, "Cycle filter"));
+    }
+
+    #[test]
+    fn keybind_editor_shows_query_and_filters() {
+        let mut app = test_app_with_hosts();
+        app.keybind_editor = Some(crate::app::KeybindEditor {
+            selected: 0,
+            scroll: 0,
+            capturing: false,
+            append: false,
+            query: "quit".into(),
+        });
+        app.mode = AppMode::KeybindEditor;
+        let buffer = render_to_buffer(&app, 100, 40);
+        assert!(buffer_contains(&buffer, "› quit"));
+        assert!(buffer_contains(&buffer, "Quit"));
+        assert!(buffer_contains(&buffer, "type to filter"));
+        // Save form is ALL[0]; under "quit" it must not be the selected row content
+        // unless its binds somehow match — label "Save form" does not.
+        assert!(!buffer_contains(&buffer, "Save form"));
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1389,11 +1389,11 @@ fn format_utc_clock() -> String {
     format!("{} {:02}:{:02}:{:02} UTC", DAY_NAMES[weekday], h, m, s)
 }
 
-/// Scroll ceiling for the help body given the full terminal area — the same
-/// popup geometry as `render_help_popup` (60% height, min 16; borders + query
-/// + fixed footer row), kept in one place so the key handler can't scroll past what
-/// the renderer will show (the excess would be invisible "debt" that Up has
-/// to unwind before the view moves).
+/// Scroll ceiling for the help body given the full terminal area. Uses the same
+/// popup geometry as `render_help_popup` (60% height, min 16; borders, query row,
+/// and fixed footer), kept in one place so the key handler can't scroll past what
+/// the renderer will show (the excess would be invisible "debt" that Up has to
+/// unwind before the view moves).
 pub(crate) fn help_max_scroll(area: Rect, query: &str) -> u16 {
     let popup_height = (area.height * 60 / 100).max(16).min(area.height);
     let body_height = popup_height.saturating_sub(4);

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -5,7 +5,7 @@ use crate::tui::theme;
 
 /// Fixed footer hint shown below the scrollable help body.
 pub const HELP_FOOTER: &str =
-    "type to filter  ·  \u{2191}\u{2193}/PgUp/PgDn scroll  ·  Esc clear/close";
+    "type to filter  ·  \u{2191}\u{2193}/PgUp/PgDn scroll  ·  Esc clear/close  ·  Enter close";
 
 /// One row of the help overlay before it is turned into a styled [`Line`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -492,7 +492,8 @@ pub fn filtered_help_items(query: &str) -> Vec<HelpItem> {
         match item {
             HelpItem::Section(title) => {
                 pending_section = Some(title);
-                pending_blank = false;
+                // Keep pending_blank so a kept section can still emit the
+                // separator that preceded it in HELP_ITEMS.
             }
             HelpItem::Blank => {
                 pending_blank = true;

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -4,209 +4,609 @@ use ratatui::widgets::Paragraph;
 use crate::tui::theme;
 
 /// Fixed footer hint shown below the scrollable help body.
-pub const HELP_FOOTER: &str = "\u{2191}\u{2193}/PgUp/PgDn scroll  ·  ? / Esc / Enter to close";
+pub const HELP_FOOTER: &str =
+    "type to filter  ·  \u{2191}\u{2193}/PgUp/PgDn scroll  ·  Esc clear/close";
 
-fn entry(key: &'static str, desc: &'static str) -> Line<'static> {
+/// One row of the help overlay before it is turned into a styled [`Line`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelpItem {
+    Section(&'static str),
+    Entry {
+        key: &'static str,
+        desc: &'static str,
+    },
+    Blank,
+}
+
+/// Canonical help content. Filtering and rendering both walk this list so an
+/// empty query stays byte-identical to the pre-filter layout.
+pub const HELP_ITEMS: &[HelpItem] = &[
+    HelpItem::Section("navigate"),
+    HelpItem::Entry {
+        key: "\u{2191}\u{2193} / j k",
+        desc: "Move up / down",
+    },
+    HelpItem::Entry {
+        key: "1..5 / h i",
+        desc: "Switch tab (hosts, sftp, tunnels, identities, audit)",
+    },
+    HelpItem::Entry {
+        key: "Tab",
+        desc: "Toggle detail panel (hosts)",
+    },
+    HelpItem::Entry {
+        key: "Enter",
+        desc: "Connect / start tunnel",
+    },
+    HelpItem::Entry {
+        key: "Esc",
+        desc: "Back / close overlay",
+    },
+    HelpItem::Blank,
+    HelpItem::Section("hosts (tab 1)"),
+    HelpItem::Entry {
+        key: "a",
+        desc: "Add new host",
+    },
+    HelpItem::Entry {
+        key: "e",
+        desc: "Edit host, or set group default identity on a header",
+    },
+    HelpItem::Entry {
+        key: "d",
+        desc: "Delete selected host",
+    },
+    HelpItem::Entry {
+        key: "Shift+D",
+        desc: "Duplicate selected host",
+    },
+    HelpItem::Entry {
+        key: "f",
+        desc: "Toggle favorite",
+    },
+    HelpItem::Entry {
+        key: "+ / -",
+        desc: "Zoom: widen / narrow the hosts column",
+    },
+    HelpItem::Entry {
+        key: "Alt+\u{2190}\u{2192}\u{2191}\u{2193}",
+        desc: "Move dashboard panel focus",
+    },
+    HelpItem::Entry {
+        key: "z",
+        desc: "Zoom the focused panel to full screen (Esc to exit)",
+    },
+    HelpItem::Entry {
+        key: "\u{2191}\u{2193} / PgUp PgDn",
+        desc: "Scroll the zoomed panel",
+    },
+    HelpItem::Entry {
+        key: "Shift+\u{2191}\u{2193}",
+        desc: "Jump between group headers",
+    },
+    HelpItem::Entry {
+        key: "s",
+        desc: "Cycle sort mode",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+\u{2191}\u{2193}",
+        desc: "Move host up / down (manual sort)",
+    },
+    HelpItem::Entry {
+        key: "c",
+        desc: "Clear SSH log",
+    },
+    HelpItem::Entry {
+        key: "y",
+        desc: "Copy SSH log for selected host (clipboard)",
+    },
+    HelpItem::Entry {
+        key: "Shift+P",
+        desc: "Push public key to host",
+    },
+    HelpItem::Blank,
+    HelpItem::Section("tunnels (tab 3)"),
+    HelpItem::Entry {
+        key: "a",
+        desc: "Add new tunnel",
+    },
+    HelpItem::Entry {
+        key: "e",
+        desc: "Edit selected tunnel",
+    },
+    HelpItem::Entry {
+        key: "d",
+        desc: "Delete tunnel",
+    },
+    HelpItem::Entry {
+        key: "Enter",
+        desc: "Start / stop tunnel (cancels reconnect while retrying)",
+    },
+    HelpItem::Entry {
+        key: "x",
+        desc: "Kill tunnel process",
+    },
+    HelpItem::Entry {
+        key: "R",
+        desc: "Keep-alive reconnect settings (backoff, max retries)",
+    },
+    HelpItem::Entry {
+        key: "",
+        desc: "Keep alive (tunnel form): auto-start on launch + reconnect with backoff after unexpected exit.",
+    },
+    HelpItem::Entry {
+        key: "Enter/Space",
+        desc: "In form on SSH server: pick host (searchable)",
+    },
+    HelpItem::Blank,
+    HelpItem::Section("identities (tab 4)"),
+    HelpItem::Entry {
+        key: "←→ / l",
+        desc: "Move between columns (grid)",
+    },
+    HelpItem::Entry {
+        key: "[ / ]",
+        desc: "Fewer / more columns (saved)",
+    },
+    HelpItem::Entry {
+        key: "a",
+        desc: "Add identity (key or user+password)",
+    },
+    HelpItem::Entry {
+        key: "e",
+        desc: "Edit identity",
+    },
+    HelpItem::Entry {
+        key: "d",
+        desc: "Delete identity",
+    },
+    HelpItem::Entry {
+        key: "g",
+        desc: "Generate SSH key pair (ed25519 or rsa-4096)",
+    },
+    HelpItem::Entry {
+        key: "p",
+        desc: "Add key to agent",
+    },
+    HelpItem::Entry {
+        key: "r",
+        desc: "Remove key from agent",
+    },
+    HelpItem::Entry {
+        key: "Shift+P",
+        desc: "Push public key to a remote host",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+R",
+        desc: "In a form: show and copy the stored secret",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+Y",
+        desc: "In a form: copy the stored secret",
+    },
+    HelpItem::Blank,
+    HelpItem::Section("audit (tab 5)"),
+    HelpItem::Entry {
+        key: "f",
+        desc: "Cycle filter (all/ok/fail)",
+    },
+    HelpItem::Entry {
+        key: "r",
+        desc: "Cycle range (all/24h/week/month)",
+    },
+    HelpItem::Blank,
+    HelpItem::Section("search & tags"),
+    HelpItem::Entry {
+        key: "/",
+        desc: "Fuzzy palette (type to search, Enter connects)",
+    },
+    HelpItem::Entry {
+        key: "",
+        desc: "Unknown [user@]host[:port] offers ad-hoc connect (no save)",
+    },
+    HelpItem::Entry {
+        key: "#",
+        desc: "Filter hosts by tag (type to narrow the list)",
+    },
+    HelpItem::Entry {
+        key: "Space",
+        desc: "In the tag list: toggle a tag (combine several, AND)",
+    },
+    HelpItem::Entry {
+        key: "Enter",
+        desc: "In the tag list: toggle highlighted tag and close",
+    },
+    HelpItem::Entry {
+        key: "",
+        desc: "In the tag list: (all) removes every filter",
+    },
+    HelpItem::Entry {
+        key: "Esc",
+        desc: "In Normal mode: clear the active tag filter",
+    },
+    HelpItem::Entry {
+        key: "",
+        desc: "Tags are comma-separated, e.g.  prod, db, eu-west",
+    },
+    HelpItem::Blank,
+    HelpItem::Section("groups"),
+    HelpItem::Entry {
+        key: "Space / ←→",
+        desc: "Collapse / expand selected group",
+    },
+    HelpItem::Entry {
+        key: "Shift+\u{2191}\u{2193}",
+        desc: "Jump between group headers (from any row in the group)",
+    },
+    HelpItem::Entry {
+        key: "Enter",
+        desc: "On a group header: collapse/expand; on a host: connect",
+    },
+    HelpItem::Entry {
+        key: "Shift+Z",
+        desc: "Collapse / expand all groups",
+    },
+    HelpItem::Entry {
+        key: "Enter",
+        desc: "In host form on Group: open dropdown (+ create new)",
+    },
+    HelpItem::Entry {
+        key: "Shift+G",
+        desc: "Manage groups",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+G",
+        desc: "Edit selected group (name + default identity)",
+    },
+    HelpItem::Entry {
+        key: "e",
+        desc: "On a group header: pick its default identity",
+    },
+    HelpItem::Entry {
+        key: "←/→",
+        desc: "In group form: cycle default identity",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+Shift+G",
+        desc: "Delete selected group",
+    },
+    HelpItem::Blank,
+    HelpItem::Section("import / export"),
+    HelpItem::Entry {
+        key: "Shift+I",
+        desc: "Import from ssh config",
+    },
+    HelpItem::Entry {
+        key: "Shift+E",
+        desc: "Export hosts to ssh config",
+    },
+    HelpItem::Entry {
+        key: "Shift+T",
+        desc: "Import from Termius export folder",
+    },
+    HelpItem::Blank,
+    HelpItem::Section("termius import (Shift+T)"),
+    HelpItem::Entry {
+        key: "",
+        desc: "Point the prompt at the export folder holding",
+    },
+    HelpItem::Entry {
+        key: "",
+        desc: "L00t.csv (+ ssh_keys/). Imports hosts, logins,",
+    },
+    HelpItem::Entry {
+        key: "",
+        desc: "passwords & keys; existing hosts are skipped.",
+    },
+    HelpItem::Blank,
+    HelpItem::Section("tools"),
+    HelpItem::Entry { key: "", desc: "" },
+    HelpItem::Entry {
+        key: "Ctrl+H",
+        desc: "Settings (session logging, opaque background, …)",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+K",
+        desc: "Edit all keybindings (navigation, tabs, session, …)",
+    },
+    HelpItem::Entry {
+        key: "",
+        desc: "Defaults listed below; rebind any action in the editor.",
+    },
+    HelpItem::Entry {
+        key: "[session]",
+        desc: "",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+T",
+        desc: "New session tab (pick host)",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+Shift+T",
+        desc: "Open a local shell tab",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+W",
+        desc: "Close session tab",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+D",
+        desc: "Detach to dashboard (session keeps running)",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+Shift+F",
+        desc: "Open SFTP for this host (session keeps running)",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+[ / Ctrl+]",
+        desc: "Previous / next session tab",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+PgUp/PgDn",
+        desc: "Previous / next session tab (alternate)",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+Shift+S",
+        desc: "Focus session from dashboard",
+    },
+    HelpItem::Entry {
+        key: "PgUp/PgDn",
+        desc: "Scroll session history",
+    },
+    HelpItem::Entry {
+        key: "",
+        desc: "Session logs (opt-in): ~/.local/share/sshub/logs/<host-dir>/ — managed hosts use {name}-{id}; pure ssh_config aliases may share a dir when names sanitize the same. Captures all PTY output including secrets echoed on screen.",
+    },
+    HelpItem::Entry { key: "", desc: "" },
+    HelpItem::Entry {
+        key: "[sftp]",
+        desc: "",
+    },
+    HelpItem::Entry {
+        key: "2",
+        desc: "Open the SFTP tab",
+    },
+    HelpItem::Entry {
+        key: "Enter",
+        desc: "Connect to host · descend into dir · fold group",
+    },
+    HelpItem::Entry {
+        key: "Tab",
+        desc: "Switch focus between the two panes",
+    },
+    HelpItem::Entry {
+        key: "Backspace",
+        desc: "Up one directory (or select the \"..\" row)",
+    },
+    HelpItem::Entry {
+        key: "\u{2190} / \u{2192}",
+        desc: "Stage the focused pane's selection toward the other one",
+    },
+    HelpItem::Entry {
+        key: "o / O",
+        desc: "Point the left pane at a second server / back to local files",
+    },
+    HelpItem::Entry {
+        key: ".",
+        desc: "Show or hide dotfiles in both panes (remembered)",
+    },
+    HelpItem::Entry {
+        key: "c / u",
+        desc: "Run queue / remove last queued transfer",
+    },
+    HelpItem::Entry {
+        key: "d",
+        desc: "Delete selected file/folder (recursive)",
+    },
+    HelpItem::Entry {
+        key: "n / R",
+        desc: "New folder / rename in the focused pane",
+    },
+    HelpItem::Entry {
+        key: "M",
+        desc: "Change permissions (chmod, octal)",
+    },
+    HelpItem::Entry {
+        key: "r",
+        desc: "Refresh both panes",
+    },
+    HelpItem::Entry {
+        key: "/",
+        desc: "Filter files in the focused pane / search hosts in the picker",
+    },
+    HelpItem::Entry {
+        key: "s",
+        desc: "Open SSH session for this host (SFTP stays live)",
+    },
+    HelpItem::Entry {
+        key: "Esc",
+        desc: "Disconnect · back to picker",
+    },
+    HelpItem::Entry { key: "", desc: "" },
+    HelpItem::Entry {
+        key: "[cli]",
+        desc: "",
+    },
+    HelpItem::Entry {
+        key: "",
+        desc: "Headless CLI available: run  sshub --help  (or  sshub <cmd> --help)",
+    },
+    HelpItem::Entry {
+        key: "",
+        desc: "for connect, tunnel, sftp, import/export from scripts (no TUI).",
+    },
+    HelpItem::Entry { key: "", desc: "" },
+    HelpItem::Entry {
+        key: "? / Shift+H",
+        desc: "Toggle this help screen",
+    },
+    HelpItem::Entry {
+        key: "F2 / Ctrl+S",
+        desc: "Save form (rebindable)",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+K",
+        desc: "Edit keybindings (all actions)",
+    },
+    HelpItem::Entry {
+        key: "q / Ctrl+C",
+        desc: "Quit (asks to confirm; disable via appearance.confirm_quit)",
+    },
+];
+
+fn entry_line(key: &'static str, desc: &'static str) -> Line<'static> {
     Line::from(vec![
         Span::styled(format!("{:<16}", key), theme::bright()),
         Span::styled(desc, theme::text()),
     ])
 }
 
-fn section(title: &'static str) -> Line<'static> {
+fn section_line(title: &'static str) -> Line<'static> {
     Line::from(Span::styled(title, theme::heading()))
 }
 
-/// Total number of lines in the help content (for scroll clamping).
-pub fn help_line_count() -> u16 {
-    help_lines().len() as u16
+fn item_to_line(item: HelpItem) -> Line<'static> {
+    match item {
+        HelpItem::Section(title) => section_line(title),
+        HelpItem::Entry { key, desc } => entry_line(key, desc),
+        HelpItem::Blank => Line::from(""),
+    }
 }
 
-fn help_lines() -> Vec<Line<'static>> {
-    vec![
-        section("navigate"),
-        entry("\u{2191}\u{2193} / j k", "Move up / down"),
-        entry(
-            "1..5 / h i",
-            "Switch tab (hosts, sftp, tunnels, identities, audit)",
-        ),
-        entry("Tab", "Toggle detail panel (hosts)"),
-        entry("Enter", "Connect / start tunnel"),
-        entry("Esc", "Back / close overlay"),
-        Line::from(""),
-        section("hosts (tab 1)"),
-        entry("a", "Add new host"),
-        entry("e", "Edit host, or set group default identity on a header"),
-        entry("d", "Delete selected host"),
-        entry("Shift+D", "Duplicate selected host"),
-        entry("f", "Toggle favorite"),
-        entry("+ / -", "Zoom: widen / narrow the hosts column"),
-        entry("Alt+\u{2190}\u{2192}\u{2191}\u{2193}", "Move dashboard panel focus"),
-        entry("z", "Zoom the focused panel to full screen (Esc to exit)"),
-        entry("\u{2191}\u{2193} / PgUp PgDn", "Scroll the zoomed panel"),
-        entry("Shift+\u{2191}\u{2193}", "Jump between group headers"),
-        entry("s", "Cycle sort mode"),
-        entry("Ctrl+\u{2191}\u{2193}", "Move host up / down (manual sort)"),
-        entry("c", "Clear SSH log"),
-        entry("y", "Copy SSH log for selected host (clipboard)"),
-        entry("Shift+P", "Push public key to host"),
-        Line::from(""),
-        section("tunnels (tab 3)"),
-        entry("a", "Add new tunnel"),
-        entry("e", "Edit selected tunnel"),
-        entry("d", "Delete tunnel"),
-        entry("Enter", "Start / stop tunnel (cancels reconnect while retrying)"),
-        entry("x", "Kill tunnel process"),
-        entry("R", "Keep-alive reconnect settings (backoff, max retries)"),
-        entry(
-            "",
-            "Keep alive (tunnel form): auto-start on launch + reconnect with backoff after unexpected exit.",
-        ),
-        entry(
-            "Enter/Space",
-            "In form on SSH server: pick host (searchable)",
-        ),
-        Line::from(""),
-        section("identities (tab 4)"),
-        entry("←→ / l", "Move between columns (grid)"),
-        entry("[ / ]", "Fewer / more columns (saved)"),
-        entry("a", "Add identity (key or user+password)"),
-        entry("e", "Edit identity"),
-        entry("d", "Delete identity"),
-        entry("g", "Generate SSH key pair (ed25519 or rsa-4096)"),
-        entry("p", "Add key to agent"),
-        entry("r", "Remove key from agent"),
-        entry("Shift+P", "Push public key to a remote host"),
-        entry("Ctrl+R", "In a form: show and copy the stored secret"),
-        entry("Ctrl+Y", "In a form: copy the stored secret"),
-        Line::from(""),
-        section("audit (tab 5)"),
-        entry("f", "Cycle filter (all/ok/fail)"),
-        entry("r", "Cycle range (all/24h/week/month)"),
-        Line::from(""),
-        section("search & tags"),
-        entry("/", "Fuzzy palette (type to search, Enter connects)"),
-        entry(
-            "",
-            "Unknown [user@]host[:port] offers ad-hoc connect (no save)",
-        ),
-        entry("#", "Filter hosts by tag (type to narrow the list)"),
-        entry(
-            "Space",
-            "In the tag list: toggle a tag (combine several, AND)",
-        ),
-        entry("Enter", "In the tag list: toggle highlighted tag and close"),
-        entry("", "In the tag list: (all) removes every filter"),
-        entry("Esc", "In Normal mode: clear the active tag filter"),
-        entry("", "Tags are comma-separated, e.g.  prod, db, eu-west"),
-        Line::from(""),
-        section("groups"),
-        entry("Space / ←→", "Collapse / expand selected group"),
-        entry(
-            "Shift+\u{2191}\u{2193}",
-            "Jump between group headers (from any row in the group)",
-        ),
-        entry(
-            "Enter",
-            "On a group header: collapse/expand; on a host: connect",
-        ),
-        entry("Shift+Z", "Collapse / expand all groups"),
-        entry(
-            "Enter",
-            "In host form on Group: open dropdown (+ create new)",
-        ),
-        entry("Shift+G", "Manage groups"),
-        entry("Ctrl+G", "Edit selected group (name + default identity)"),
-        entry("e", "On a group header: pick its default identity"),
-        entry("←/→", "In group form: cycle default identity"),
-        entry("Ctrl+Shift+G", "Delete selected group"),
-        Line::from(""),
-        section("import / export"),
-        entry("Shift+I", "Import from ssh config"),
-        entry("Shift+E", "Export hosts to ssh config"),
-        entry("Shift+T", "Import from Termius export folder"),
-        Line::from(""),
-        section("termius import (Shift+T)"),
-        entry("", "Point the prompt at the export folder holding"),
-        entry("", "L00t.csv (+ ssh_keys/). Imports hosts, logins,"),
-        entry("", "passwords & keys; existing hosts are skipped."),
-        Line::from(""),
-        section("tools"),
-        entry("", ""),
-        entry("Ctrl+H", "Settings (session logging, opaque background, …)"),
-        entry(
-            "Ctrl+K",
-            "Edit all keybindings (navigation, tabs, session, …)",
-        ),
-        entry(
-            "",
-            "Defaults listed below; rebind any action in the editor.",
-        ),
-        entry("[session]", ""),
-        entry("Ctrl+T", "New session tab (pick host)"),
-        entry("Ctrl+Shift+T", "Open a local shell tab"),
-        entry("Ctrl+W", "Close session tab"),
-        entry("Ctrl+D", "Detach to dashboard (session keeps running)"),
-        entry(
-            "Ctrl+Shift+F",
-            "Open SFTP for this host (session keeps running)",
-        ),
-        entry("Ctrl+[ / Ctrl+]", "Previous / next session tab"),
-        entry("Ctrl+PgUp/PgDn", "Previous / next session tab (alternate)"),
-        entry("Ctrl+Shift+S", "Focus session from dashboard"),
-        entry("PgUp/PgDn", "Scroll session history"),
-        entry(
-            "",
-            "Session logs (opt-in): ~/.local/share/sshub/logs/<host-dir>/ — managed hosts use {name}-{id}; pure ssh_config aliases may share a dir when names sanitize the same. Captures all PTY output including secrets echoed on screen.",
-        ),
-        entry("", ""),
-        entry("[sftp]", ""),
-        entry("2", "Open the SFTP tab"),
-        entry("Enter", "Connect to host · descend into dir · fold group"),
-        entry("Tab", "Switch focus between the two panes"),
-        entry("Backspace", "Up one directory (or select the \"..\" row)"),
-        entry(
-            "\u{2190} / \u{2192}",
-            "Stage the focused pane's selection toward the other one",
-        ),
-        entry(
-            "o / O",
-            "Point the left pane at a second server / back to local files",
-        ),
-        entry(".", "Show or hide dotfiles in both panes (remembered)"),
-        entry("c / u", "Run queue / remove last queued transfer"),
-        entry("d", "Delete selected file/folder (recursive)"),
-        entry("n / R", "New folder / rename in the focused pane"),
-        entry("M", "Change permissions (chmod, octal)"),
-        entry("r", "Refresh both panes"),
-        entry(
-            "/",
-            "Filter files in the focused pane / search hosts in the picker",
-        ),
-        entry("s", "Open SSH session for this host (SFTP stays live)"),
-        entry("Esc", "Disconnect · back to picker"),
-        entry("", ""),
-        entry("[cli]", ""),
-        entry(
-            "",
-            "Headless CLI available: run  sshub --help  (or  sshub <cmd> --help)",
-        ),
-        entry(
-            "",
-            "for connect, tunnel, sftp, import/export from scripts (no TUI).",
-        ),
-        entry("", ""),
-        entry("? / Shift+H", "Toggle this help screen"),
-        entry("F2 / Ctrl+S", "Save form (rebindable)"),
-        entry("Ctrl+K", "Edit keybindings (all actions)"),
-        entry(
-            "q / Ctrl+C",
-            "Quit (asks to confirm; disable via appearance.confirm_quit)",
-        ),
-    ]
+fn entry_matches(key: &str, desc: &str, query: &str) -> bool {
+    key.to_lowercase().contains(query) || desc.to_lowercase().contains(query)
+}
+
+/// Case-insensitive substring filter over key specs and descriptions.
+/// Section headers with no surviving entries are dropped; blank separators are
+/// kept only when they sit between kept content.
+pub fn filtered_help_items(query: &str) -> Vec<HelpItem> {
+    if query.is_empty() {
+        return HELP_ITEMS.to_vec();
+    }
+    let q = query.to_lowercase();
+    let mut out = Vec::new();
+    let mut pending_section: Option<&'static str> = None;
+    let mut pending_blank = false;
+    for &item in HELP_ITEMS {
+        match item {
+            HelpItem::Section(title) => {
+                pending_section = Some(title);
+                pending_blank = false;
+            }
+            HelpItem::Blank => {
+                pending_blank = true;
+            }
+            HelpItem::Entry { key, desc } if entry_matches(key, desc, &q) => {
+                if let Some(title) = pending_section.take() {
+                    if pending_blank && !out.is_empty() {
+                        out.push(HelpItem::Blank);
+                    }
+                    out.push(HelpItem::Section(title));
+                }
+                pending_blank = false;
+                out.push(item);
+            }
+            HelpItem::Entry { .. } => {}
+        }
+    }
+    out
+}
+
+fn help_lines(query: &str) -> Vec<Line<'static>> {
+    filtered_help_items(query)
+        .into_iter()
+        .map(item_to_line)
+        .collect()
+}
+
+/// Total number of lines in the (possibly filtered) help content.
+pub fn help_line_count(query: &str) -> u16 {
+    filtered_help_items(query).len() as u16
 }
 
 /// The scrollable help body (no border/footer — the caller frames it).
-pub fn render_help(scroll: u16) -> Paragraph<'static> {
-    Paragraph::new(help_lines()).scroll((scroll, 0))
+pub fn render_help(scroll: u16, query: &str) -> Paragraph<'static> {
+    Paragraph::new(help_lines(query)).scroll((scroll, 0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_query_keeps_full_item_list() {
+        assert_eq!(filtered_help_items(""), HELP_ITEMS.to_vec());
+    }
+
+    #[test]
+    fn query_matches_key_spec_and_description() {
+        let by_key = filtered_help_items("Ctrl+K");
+        assert!(by_key.iter().any(|i| matches!(
+            i,
+            HelpItem::Entry {
+                key: "Ctrl+K",
+                desc
+            } if desc.contains("keybinding")
+        )));
+        assert!(by_key
+            .iter()
+            .any(|i| matches!(i, HelpItem::Section("tools"))));
+
+        let by_desc = filtered_help_items("favorite");
+        assert!(by_desc.iter().any(|i| matches!(
+            i,
+            HelpItem::Entry {
+                key: "f",
+                desc: "Toggle favorite"
+            }
+        )));
+        assert!(by_desc
+            .iter()
+            .any(|i| matches!(i, HelpItem::Section("hosts (tab 1)"))));
+        assert!(!by_desc
+            .iter()
+            .any(|i| matches!(i, HelpItem::Section("audit (tab 5)"))));
+    }
+
+    #[test]
+    fn stranded_section_headers_are_omitted() {
+        // Body rows under "termius import" mention L00t.csv, not the word
+        // "termius" — so a "termius" query must keep "import / export" (Shift+T
+        // row) and drop the empty "termius import" section header.
+        let by_name = filtered_help_items("termius");
+        assert!(by_name
+            .iter()
+            .any(|i| matches!(i, HelpItem::Section("import / export"))));
+        assert!(!by_name
+            .iter()
+            .any(|i| matches!(i, HelpItem::Section("termius import (Shift+T)"))));
+        assert!(!by_name
+            .iter()
+            .any(|i| matches!(i, HelpItem::Section("navigate"))));
+
+        let by_body = filtered_help_items("L00t");
+        assert!(by_body
+            .iter()
+            .any(|i| matches!(i, HelpItem::Section("termius import (Shift+T)"))));
+        assert!(!by_body
+            .iter()
+            .any(|i| matches!(i, HelpItem::Section("navigate"))));
+        assert!(!by_body
+            .iter()
+            .any(|i| matches!(i, HelpItem::Section("audit (tab 5)"))));
+    }
+
+    #[test]
+    fn empty_query_lines_match_pre_filter_shape() {
+        let lines = help_lines("");
+        assert_eq!(lines.len(), HELP_ITEMS.len());
+        // Spot-check first section + entry styling payload.
+        assert_eq!(lines[0], section_line("navigate"));
+        assert_eq!(
+            lines[1],
+            entry_line("\u{2191}\u{2193} / j k", "Move up / down")
+        );
+        assert_eq!(lines[6], Line::from(""));
+    }
 }

--- a/src/tui/screens/keybind_editor.rs
+++ b/src/tui/screens/keybind_editor.rs
@@ -114,7 +114,7 @@ pub fn render_keybind_editor(frame: &mut Frame, app: &App) {
             "press a key to bind  │  Esc: cancel"
         }
     } else {
-        "type to filter │ ↑↓ move │ Enter: set │ a: add │ r: reset │ x: unbind │ Esc: clear/close"
+        "type to filter │ ↑↓ move │ Enter: set │ Ctrl+A: add │ Ctrl+R: reset │ Ctrl+X: unbind │ Esc: clear/close"
     };
     buf.set_string(
         row_x,

--- a/src/tui/screens/keybind_editor.rs
+++ b/src/tui/screens/keybind_editor.rs
@@ -3,19 +3,19 @@ use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear};
 
 use crate::app::App;
-use crate::config::KeyAction;
 use crate::tui::theme;
 
 /// Keybinding editor overlay: one row per configurable action.
 pub fn render_keybind_editor(frame: &mut Frame, app: &App) {
-    let Some(editor) = app.keybind_editor else {
+    let Some(editor) = app.keybind_editor.as_ref() else {
         return;
     };
 
+    let actions = app.filtered_keybind_actions();
     let area = frame.area();
     let popup_w = 60u16.min(area.width.saturating_sub(2));
-    let list_rows = area.height.saturating_sub(8).clamp(8, 20);
-    let popup_h = (list_rows + 6).min(area.height.saturating_sub(2));
+    let list_rows = area.height.saturating_sub(9).clamp(8, 20);
+    let popup_h = (list_rows + 7).min(area.height.saturating_sub(2));
     let x = area.x + (area.width.saturating_sub(popup_w)) / 2;
     let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
     let popup = Rect::new(x, y, popup_w, popup_h);
@@ -34,14 +34,29 @@ pub fn render_keybind_editor(frame: &mut Frame, app: &App) {
     let buf = frame.buffer_mut();
     let row_x = popup.x + 2;
     let val_x = popup.x + 33;
-    let visible = popup.height.saturating_sub(4) as usize;
-    let total = KeyAction::ALL.len();
+    let content_w = popup.width.saturating_sub(4) as usize;
+
+    let query_line = format!("› {}\u{2588}", editor.query);
+    buf.set_string(
+        row_x,
+        popup.y + 1,
+        crate::tui::text::ellipsize(&query_line, content_w),
+        theme::bright(),
+    );
+
+    let visible = popup.height.saturating_sub(5) as usize;
+    let total = actions.len();
     let scroll = editor.scroll.min(total.saturating_sub(visible));
+    let selected = if total == 0 {
+        0
+    } else {
+        editor.selected.min(total - 1)
+    };
 
     for (row, i) in (scroll..total).take(visible).enumerate() {
-        let action = KeyAction::ALL[i];
-        let ry = popup.y + 1 + row as u16;
-        let is_sel = i == editor.selected;
+        let action = actions[i];
+        let ry = popup.y + 3 + row as u16;
+        let is_sel = i == selected;
         if is_sel {
             let blank = " ".repeat(popup.width.saturating_sub(2) as usize);
             buf.set_string(popup.x + 1, ry, &blank, theme::selected());
@@ -88,7 +103,7 @@ pub fn render_keybind_editor(frame: &mut Frame, app: &App) {
 
     let hint_y = popup.y + popup.height.saturating_sub(2);
     let scroll_hint = if total > visible {
-        format!(" ({}/{})", editor.selected + 1, total)
+        format!(" ({}/{})", selected + 1, total)
     } else {
         String::new()
     };
@@ -99,7 +114,7 @@ pub fn render_keybind_editor(frame: &mut Frame, app: &App) {
             "press a key to bind  │  Esc: cancel"
         }
     } else {
-        "↑↓ move │ Enter: set │ a: add │ r: reset │ x: unbind │ Esc: close"
+        "type to filter │ ↑↓ move │ Enter: set │ a: add │ r: reset │ x: unbind │ Esc: clear/close"
     };
     buf.set_string(
         row_x,


### PR DESCRIPTION
## Summary
- Help (`?`) and the keybinding editor (`Ctrl+K`) now support type-to-filter, matching the tag-filter query line (`› query█`).
- Help content is a data list first (`HelpItem`), then rendered, so an empty query keeps the same body rows; section headers with no surviving entries are omitted.
- Keybinding editor `selected` indexes the **filtered** list, so capture / Ctrl+R / Ctrl+X hit the visible row; capturing still consumes the next key as a binding.
- Closes #48.

## Decisions (not settled by the issue)
- **Matching:** case-insensitive substring (fuzzy ranking is noisy on short key/description strings; `nucleo` stays unused here).
- **Navigation:** drop `j`/`k`; arrows + PageUp/PageDown only so printable letters belong to the query.
- **Help close:** Esc clears then closes; Enter still dismisses when the query is empty. `q` / `?` type into the query (they used to close).
- **Keybind row actions:** moved from bare `a` / `r` / `x` to **Ctrl+A / Ctrl+R / Ctrl+X** so typing “agent”, “reset”, etc. cannot silently mutate and persist bindings.
- **Stranded headers:** omitted when a section has no matching entries; blank separators are kept between surviving sections.

## Test plan
- [x] `cargo fmt` / `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `just test` (unit + smoke + e2e + config_load)
- [x] Manual: `?`, type `favorite`, Esc clears, Esc closes; `Ctrl+K`, type `help`, Enter then a key rebinds Help not Save; type `agent` does not mutate Save

## Verification
Adversarial review found (and this branch fixed): reserved letters mutating config while filtering, selection left out of range after a bind-text filter shrinks, dead blank-separator path, and clippy `-D warnings` doc/test lint.

_Written by Grok 4.5 (Cursor) on behalf of the maintainer._

Made with [Cursor](https://cursor.com)