### PR TITLE
test(watcher): make debounce coalescing testable without sleeping

### DIFF
--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::sync::mpsc::{self, Receiver, RecvError, RecvTimeoutError, Sender};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -42,29 +42,62 @@ pub fn spawn_config_watcher(ssh_config_path: &Path) -> Result<Receiver<WatchEven
 
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
-        debounce_loop(notify_rx, tx, &config_path);
+        let source = ChannelSource { rx: notify_rx };
+        debounce_loop(&source, tx, &config_path, WATCHER_DEBOUNCE);
         drop(watcher);
     });
 
     Ok(rx)
 }
 
-fn debounce_loop(notify_rx: Receiver<NotifyResult<Event>>, tx: Sender<WatchEvent>, config: &Path) {
+/// Time and input source for the debounce loop. Abstracted so tests inject a
+/// scripted event list with a virtual clock instead of sleeping on real time.
+trait EventSource: Send {
+    fn recv(&self) -> Result<NotifyResult<Event>, RecvError>;
+    fn recv_timeout(&self, timeout: Duration) -> Result<NotifyResult<Event>, RecvTimeoutError>;
+    fn now(&self) -> Instant;
+}
+
+struct ChannelSource {
+    rx: Receiver<NotifyResult<Event>>,
+}
+
+impl EventSource for ChannelSource {
+    fn recv(&self) -> Result<NotifyResult<Event>, RecvError> {
+        self.rx.recv()
+    }
+    fn recv_timeout(&self, timeout: Duration) -> Result<NotifyResult<Event>, RecvTimeoutError> {
+        self.rx.recv_timeout(timeout)
+    }
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+/// Fixed-window debounce: the first config-touching event opens a window;
+/// all events arriving before `start + window` are swallowed; one
+/// `ConfigChanged` is emitted when the window expires.
+fn debounce_loop<S: EventSource>(
+    source: &S,
+    tx: Sender<WatchEvent>,
+    config: &Path,
+    window: Duration,
+) {
     loop {
-        match notify_rx.recv() {
+        match source.recv() {
             Ok(Ok(event)) if is_config_change(&event, config) => {}
             Ok(Ok(_)) => continue,
             Ok(Err(_)) => continue,
             Err(_) => break,
         }
 
-        let deadline = Instant::now() + WATCHER_DEBOUNCE;
+        let deadline = source.now() + window;
         loop {
-            let remaining = deadline.saturating_duration_since(Instant::now());
+            let remaining = deadline.saturating_duration_since(source.now());
             if remaining.is_zero() {
                 break;
             }
-            match notify_rx.recv_timeout(remaining) {
+            match source.recv_timeout(remaining) {
                 Ok(Ok(event)) if is_config_change(&event, config) => continue,
                 Ok(Ok(_)) | Ok(Err(_)) => continue,
                 Err(RecvTimeoutError::Timeout) => break,
@@ -106,9 +139,108 @@ pub fn dummy_watcher() -> Receiver<WatchEvent> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::{Cell, RefCell};
+    use std::collections::VecDeque;
     use std::io::Write;
     use std::sync::mpsc::RecvTimeoutError;
     use tempfile::NamedTempFile;
+
+    struct ScriptedSource {
+        script: RefCell<VecDeque<(NotifyResult<Event>, Instant)>>,
+        clock: Cell<Instant>,
+    }
+
+    impl ScriptedSource {
+        fn new(script: Vec<(NotifyResult<Event>, Instant)>) -> Self {
+            let clock = script
+                .first()
+                .map(|(_, at)| *at)
+                .unwrap_or_else(Instant::now);
+            Self {
+                script: RefCell::new(VecDeque::from(script)),
+                clock: Cell::new(clock),
+            }
+        }
+
+        fn take_next(&self) -> Option<(NotifyResult<Event>, Instant)> {
+            let item = self.script.borrow_mut().pop_front()?;
+            self.clock.set(item.1);
+            Some(item)
+        }
+
+        fn peek_next_at(&self) -> Option<Instant> {
+            self.script.borrow().front().map(|(_, at)| *at)
+        }
+    }
+
+    impl EventSource for ScriptedSource {
+        fn recv(&self) -> Result<NotifyResult<Event>, RecvError> {
+            match self.take_next() {
+                Some((event, _)) => Ok(event),
+                None => Err(RecvError),
+            }
+        }
+
+        fn recv_timeout(&self, timeout: Duration) -> Result<NotifyResult<Event>, RecvTimeoutError> {
+            match self.peek_next_at() {
+                None => Err(RecvTimeoutError::Disconnected),
+                Some(next_at) if next_at < self.clock.get() + timeout => {
+                    Ok(self.take_next().unwrap().0)
+                }
+                Some(_) => {
+                    self.clock.set(self.clock.get() + timeout);
+                    Err(RecvTimeoutError::Timeout)
+                }
+            }
+        }
+
+        fn now(&self) -> Instant {
+            self.clock.get()
+        }
+    }
+
+    fn run_debounce(
+        script: Vec<(NotifyResult<Event>, Instant)>,
+        config: &Path,
+        window: Duration,
+    ) -> Vec<WatchEvent> {
+        let source = ScriptedSource::new(script);
+        let (tx, rx) = mpsc::channel();
+        debounce_loop(&source, tx, config, window);
+        rx.try_iter().collect()
+    }
+
+    fn config_event(path: &Path) -> Event {
+        Event {
+            kind: EventKind::Modify(notify::event::ModifyKind::Any),
+            paths: vec![path.to_path_buf()],
+            attrs: Default::default(),
+        }
+    }
+
+    fn access_event(path: &Path) -> Event {
+        Event {
+            kind: EventKind::Access(notify::event::AccessKind::Read),
+            paths: vec![path.to_path_buf()],
+            attrs: Default::default(),
+        }
+    }
+
+    fn create_event(path: &Path) -> Event {
+        Event {
+            kind: EventKind::Create(notify::event::CreateKind::File),
+            paths: vec![path.to_path_buf()],
+            attrs: Default::default(),
+        }
+    }
+
+    fn remove_event(path: &Path) -> Event {
+        Event {
+            kind: EventKind::Remove(notify::event::RemoveKind::File),
+            paths: vec![path.to_path_buf()],
+            attrs: Default::default(),
+        }
+    }
 
     /// How long to wait for a debounced `ConfigChanged` after config writes.
     fn watcher_event_timeout() -> Duration {
@@ -205,6 +337,178 @@ mod tests {
             events < WRITES,
             "expected the burst coalesced, got {events} events from {WRITES} writes"
         );
+    }
+
+    #[test]
+    fn debounce_burst_collapses_to_one_event() {
+        let config = Path::new("/tmp/config");
+        let window = Duration::from_millis(300);
+        let t0 = Instant::now();
+
+        let script: Vec<_> = (0..5)
+            .map(|i| (Ok(config_event(config)), t0 + Duration::from_millis(i * 50)))
+            .collect();
+
+        let emitted = run_debounce(script, config, window);
+        assert_eq!(emitted, vec![WatchEvent::ConfigChanged]);
+    }
+
+    #[test]
+    fn debounce_write_after_window_opens_new_event() {
+        let config = Path::new("/tmp/config");
+        let window = Duration::from_millis(300);
+        let t0 = Instant::now();
+
+        let script = vec![
+            (Ok(config_event(config)), t0),
+            (Ok(config_event(config)), t0 + Duration::from_millis(100)),
+            (Ok(config_event(config)), t0 + Duration::from_millis(500)),
+        ];
+
+        let emitted = run_debounce(script, config, window);
+        assert_eq!(
+            emitted,
+            vec![WatchEvent::ConfigChanged, WatchEvent::ConfigChanged]
+        );
+    }
+
+    #[test]
+    fn debounce_write_at_exact_deadline_opens_new_event() {
+        let config = Path::new("/tmp/config");
+        let window = Duration::from_millis(300);
+        let t0 = Instant::now();
+
+        let script = vec![
+            (Ok(config_event(config)), t0),
+            (Ok(config_event(config)), t0 + window),
+        ];
+
+        let emitted = run_debounce(script, config, window);
+        assert_eq!(
+            emitted,
+            vec![WatchEvent::ConfigChanged, WatchEvent::ConfigChanged]
+        );
+    }
+
+    #[test]
+    fn debounce_ignores_other_files() {
+        let config = Path::new("/tmp/config");
+        let other = Path::new("/tmp/other");
+        let window = Duration::from_millis(300);
+        let t0 = Instant::now();
+
+        let script = vec![
+            (Ok(config_event(other)), t0),
+            (Ok(config_event(other)), t0 + Duration::from_millis(100)),
+        ];
+
+        let emitted = run_debounce(script, config, window);
+        assert!(emitted.is_empty());
+    }
+
+    #[test]
+    fn debounce_ignores_access_kind() {
+        let config = Path::new("/tmp/config");
+        let window = Duration::from_millis(300);
+        let t0 = Instant::now();
+
+        let script = vec![
+            (Ok(access_event(config)), t0),
+            (Ok(access_event(config)), t0 + Duration::from_millis(100)),
+        ];
+
+        let emitted = run_debounce(script, config, window);
+        assert!(emitted.is_empty());
+    }
+
+    #[test]
+    fn debounce_mixed_files_only_config_counted() {
+        let config = Path::new("/tmp/config");
+        let other = Path::new("/tmp/other");
+        let window = Duration::from_millis(300);
+        let t0 = Instant::now();
+
+        let script = vec![
+            (Ok(config_event(other)), t0),
+            (Ok(config_event(config)), t0 + Duration::from_millis(10)),
+            (Ok(config_event(other)), t0 + Duration::from_millis(20)),
+            (Ok(config_event(config)), t0 + Duration::from_millis(30)),
+        ];
+
+        let emitted = run_debounce(script, config, window);
+        assert_eq!(emitted, vec![WatchEvent::ConfigChanged]);
+    }
+
+    #[test]
+    fn debounce_access_inside_window_does_not_extend_it() {
+        let config = Path::new("/tmp/config");
+        let window = Duration::from_millis(300);
+        let t0 = Instant::now();
+
+        let script = vec![
+            (Ok(config_event(config)), t0),
+            (Ok(access_event(config)), t0 + Duration::from_millis(200)),
+            (Ok(config_event(config)), t0 + Duration::from_millis(400)),
+        ];
+
+        let emitted = run_debounce(script, config, window);
+        assert_eq!(
+            emitted,
+            vec![WatchEvent::ConfigChanged, WatchEvent::ConfigChanged]
+        );
+    }
+
+    #[test]
+    fn debounce_chained_writes_spanning_two_windows_emit_twice() {
+        let config = Path::new("/tmp/config");
+        let window = Duration::from_millis(300);
+        let t0 = Instant::now();
+
+        let script = vec![
+            (Ok(config_event(config)), t0),
+            (Ok(config_event(config)), t0 + Duration::from_millis(200)),
+            (Ok(config_event(config)), t0 + Duration::from_millis(400)),
+        ];
+
+        let emitted = run_debounce(script, config, window);
+        assert_eq!(
+            emitted,
+            vec![WatchEvent::ConfigChanged, WatchEvent::ConfigChanged]
+        );
+    }
+
+    #[test]
+    fn debounce_create_and_remove_kinds_trigger_config_change() {
+        let config = Path::new("/tmp/config");
+        let window = Duration::from_millis(300);
+        let t0 = Instant::now();
+
+        let script = vec![
+            (Ok(create_event(config)), t0),
+            (Ok(remove_event(config)), t0 + Duration::from_millis(500)),
+        ];
+
+        let emitted = run_debounce(script, config, window);
+        assert_eq!(
+            emitted,
+            vec![WatchEvent::ConfigChanged, WatchEvent::ConfigChanged]
+        );
+    }
+
+    #[test]
+    fn debounce_notify_error_is_nonfatal() {
+        let config = Path::new("/tmp/config");
+        let window = Duration::from_millis(300);
+        let t0 = Instant::now();
+
+        let notify_err = notify::Error::generic("inotify queue overflow");
+        let script = vec![
+            (Err(notify_err), t0),
+            (Ok(config_event(config)), t0 + Duration::from_millis(100)),
+        ];
+
+        let emitted = run_debounce(script, config, window);
+        assert_eq!(emitted, vec![WatchEvent::ConfigChanged]);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Injected `EventSource` into `debounce_loop` so the **real production loop** runs against a virtual clock in tests. No copy of the logic, no parallel model.

- `EventSource` trait: `recv`, `recv_timeout`, `now` — matches house style (`ProbeRunner`, `CommandRunner`, `PasswordStore`)
- `ChannelSource`: production impl, three forwarding lines over `Receiver` + `Instant::now()`
- `debounce_loop<S: EventSource>`: generic, takes `window: Duration` param
- `ScriptedSource`: test impl with `Cell<Instant>` virtual clock + `VecDeque` script

Ten deterministic tests drive the real loop — no `thread::sleep`:

| Test | Pins |
|------|------|
| burst collapse | 5 writes in window → exactly 1 event |
| after-window | write past window opens new event |
| exact deadline | `at == start + window` opens new event (strict `<`) |
| other files | non-config paths produce nothing |
| access kind | `EventKind::Access` rejected |
| create/remove | `Create`/`Remove` kinds accepted |
| notify error | `Ok(Err(_))` is non-fatal, loop continues |
| mixed files | non-config events inside window swallowed |
| access in window | access event does not extend window |
| chained writes | 0/200/400ms with 300ms window → 2 events (kills sliding-window mutation) |

Mutation verified: changing to sliding window (reset deadline on config event) fails `debounce_chained_writes_spanning_two_windows_emit_twice`.

Real-delivery tests (`spawn_config_watcher_emits_after_write`, `debounce_coalesces_rapid_writes`) unchanged.

## Test plan

- [x] `just test` green (707 tests)
- [x] `cargo fmt --check` / `cargo clippy --all-targets` clean
- [x] Adversarial review passed (2 rounds, all findings addressed)
- [x] Mutation test: sliding-window change caught

Closes #68

_Written by Qwen3.8-Max-Preview (opencode) on behalf of the maintainer._