### PR TITLE
feat(known-hosts): known_hosts manager overlay with deletion and first-connect fingerprint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,52 @@ just worktree-rm agent-foo        # remove worktree; keeps shared target
 
 Do **not** run two `cargo`/`just test` builds at once against the shared
 target — fingerprint races. Serialize builds (one agent compiling at a time).
+
+## Implementation rules
+
+Canonical source: [docs/implementation-flow.md](docs/implementation-flow.md). These are the agent-enforced highlights.
+
+### Workflow
+
+1. Claim the issue on GitHub before coding. Sign every issue/PR comment: `_Written by {Model} ({Platform}) on behalf of the maintainer._`
+2. Branch `feature/*` (or `fix/*`) from `development`. Never from `main`. Never bump `Cargo.toml` version.
+3. Small, logical commits. Conventional commit titles (`feat:`, `fix:`, `test:`, `docs:`, etc.).
+4. PR targets `development` only. Body includes `Closes #N`, what changed, how tested, and the signature.
+
+### Verify before every push
+
+```bash
+just test
+cargo fmt
+cargo fmt --check
+cargo clippy --all-targets
+```
+
+All must pass. CI runs the same and fails on any warning.
+
+### Adversarial review
+
+After local green, run an independent adversarial review on the diff (2+ critics for focused changes, 3+ for features). Fix verified blockers/highs before pushing. Verdict must be `SAFE TO COMMIT` or equivalent.
+
+### Review findings discipline
+
+- **Verify every finding against code and test output before fixing.** Do not trust critic summaries blindly. Re-open the code, reproduce the claim, confirm it is real.
+- If a finding is wrong, explain why with evidence. Do not apply speculative fixes.
+- Separate blockers from nice-to-haves. Do not broaden scope unless the change created a real risk.
+- Pre-existing issues found during review: note them, do not fix in the same PR unless they are blockers for the current change.
+
+### Docs and changelog
+
+- `CHANGELOG.md` under `[Unreleased]` for user-visible changes. Name external contributors per entry.
+- Update `README.md`, in-app help (`src/tui/screens/help.rs`), and footer hints (`src/tui/mod.rs`) when UX or keybindings change. Undiscoverable features are bugs.
+- Update `openwiki/` when architecture or operational behaviour changes.
+
+### Tests
+
+- Use fixtures and `tempfile`. Never touch real `~/.ssh`, keyring, or user config dirs.
+- Tests that mutate process-wide env vars must serialize via `config::with_test_config_dir`.
+- New overlays/screens need a render smoke test. New key actions need the full keybinds.rs insertion (macro arm, enum, ALL, label, config field, Default, default_for, binds, set).
+
+### CI
+
+Watch GitHub Actions after push (`gh pr checks <n> --watch`). Local green is not enough. Do not mark work complete until every required check passes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to SSHub are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Known hosts manager** (`H` on the Keys tab, issue #7) - an overlay listing
+  every entry in `~/.ssh/known_hosts`: host (or `(hashed)`), `@cert-authority` /
+  `@revoked` marker, key type, and `SHA256:` fingerprint (joined from
+  `ssh-keygen -l`). Type to filter by host or fingerprint, `d` to delete all
+  keys for a host via `ssh-keygen -R` (with confirmation; hashed entries are
+  refused with an explanation), `r` to refresh from disk. The connect screen now
+  shows the server host key fingerprint from the `-v` output while connecting,
+  so a first-connect fingerprint can be read and compared without digging
+  through the scrollback. Help is now bound to `?` only; `H` / `Shift+H` opens
+  the known hosts manager.
+
 ### Fixed
 
 - **The README GIFs and screenshots are recorded from the terminal stream now,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ All notable changes to SSHub are documented in this file.
 - **Known hosts manager** (`H` on the Keys tab, issue #7) - an overlay listing
   every entry in `~/.ssh/known_hosts`: host (or `(hashed)`), `@cert-authority` /
   `@revoked` marker, key type, and `SHA256:` fingerprint (joined from
-  `ssh-keygen -l`). Type to filter by host or fingerprint, `d` to delete all
+  `ssh-keygen -l`). Type to filter by host or fingerprint, `Ctrl+D` to delete all
   keys for a host via `ssh-keygen -R` (with confirmation; hashed entries are
-  refused with an explanation), `r` to refresh from disk. The connect screen now
+  refused with an explanation), `Ctrl+R` to refresh from disk. The connect screen now
   shows the server host key fingerprint from the `-v` output while connecting,
   so a first-connect fingerprint can be read and compared without digging
   through the scrollback. Help is now bound to `?` only; `H` / `Shift+H` opens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,21 @@ All notable changes to SSHub are documented in this file.
 - **Known hosts manager** (`H` on the Keys tab, issue #7) - an overlay listing
   every entry in `~/.ssh/known_hosts`: host (or `(hashed)`), `@cert-authority` /
   `@revoked` marker, key type, and `SHA256:` fingerprint (joined from
-  `ssh-keygen -l`). Type to filter by host or fingerprint, `Ctrl+D` to delete all
-  keys for a host via `ssh-keygen -R` (with confirmation; hashed entries are
-  refused with an explanation), `Ctrl+R` to refresh from disk. The connect screen now
-  shows the server host key fingerprint from the `-v` output while connecting,
-  so a first-connect fingerprint can be read and compared without digging
-  through the scrollback. Help is now bound to `?` only; `H` / `Shift+H` opens
-  the known hosts manager.
+  `ssh-keygen -l`; marker rows stay blank because `ssh-keygen -l` omits them).
+  Type to filter by host or fingerprint, `Ctrl+D` to delete all keys for a host
+  via `ssh-keygen -R` (with confirmation; hashed / `@cert-authority` /
+  `@revoked` / wildcard rows are refused, and plain deletes that would also
+  remove a matching wildcard are refused), `Ctrl+R` to refresh from disk. The
+  connect screen now shows the server host key fingerprint from the `-v` output
+  while connecting (cached first-wins so a banner flood cannot replace it), so a
+  first-connect fingerprint can be read and compared without digging through the
+  scrollback.
+
+### Changed
+
+- Help is bound to `?` only. `H` (Shift+H) opens the known hosts manager. Existing
+  configs that still have `help = ["?", "Shift+H"]` are migrated once on load so
+  the new binding is reachable.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Defaults below. Rebind any action with **Ctrl+K** (saved to `config.toml`). Pres
 | `Tab`            | Toggle detail panel             |
 | `Esc`            | Back / close overlay            |
 | `Ctrl+K`         | Keybind editor                  |
-| `?` / `Shift+H`  | Help screen                     |
+| `?`              | Help screen                     |
 | `q`              | Quit                            |
 
 ### Session (embedded PTY)
@@ -310,6 +310,7 @@ Defaults below. Rebind any action with **Ctrl+K** (saved to `config.toml`). Pres
 | `r`        | Remove key from agent    |
 | `Shift+A`  | Add key to agent         |
 | `Shift+P`  | Push public key to host  |
+| `H`        | Known hosts manager      |
 
 ### Audit (tab 4)
 

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -91,6 +91,7 @@ impl App {
             AppMode::BroadcastCommand => self.handle_key_broadcast_command(key),
             AppMode::BroadcastPreview => self.handle_key_broadcast_preview(key),
             AppMode::Notice => self.handle_key_notice(key),
+            AppMode::KnownHosts => self.handle_key_known_hosts(key),
             AppMode::Connecting | AppMode::Session => self.handle_key_session(key),
             AppMode::Normal => match self.active_tab {
                 1 => self.handle_key_sftp(key),
@@ -604,6 +605,9 @@ impl App {
             _ if self.is_action(KeyAction::Help, &key) => {
                 self.open_help();
             }
+            _ if self.is_action(KeyAction::KnownHosts, &key) => {
+                self.open_known_hosts();
+            }
             _ => {}
         }
         Ok(())
@@ -722,6 +726,122 @@ impl App {
             {
                 self.help_query.push(c);
                 self.help_scroll = 0;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    pub(crate) fn open_known_hosts(&mut self) {
+        let path = crate::known_hosts::known_hosts_path();
+        let entries = crate::known_hosts::load_known_hosts(&path).unwrap_or_default();
+        self.known_hosts = Some(KnownHostsState {
+            entries,
+            selected: 0,
+            scroll: 0,
+            query: String::new(),
+            confirming_delete: false,
+            notice: None,
+        });
+        self.mode = AppMode::KnownHosts;
+    }
+
+    pub(crate) fn handle_key_known_hosts(&mut self, key: KeyEvent) -> Result<()> {
+        let Some(state) = self.known_hosts.as_mut() else {
+            self.mode = AppMode::Normal;
+            return Ok(());
+        };
+
+        if state.confirming_delete {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    let filtered = crate::tui::screens::known_hosts::filtered_indices_pub(state);
+                    if let Some(&fi) = filtered.get(state.selected) {
+                        let entry = state.entries[fi].clone();
+                        if entry.is_hashed() {
+                            state.notice = Some(
+                                "Cannot delete hashed entry \u{2014} run ssh-keygen -R <host> manually, or set HashKnownHosts no".to_string()
+                            );
+                        } else {
+                            let path = crate::known_hosts::known_hosts_path();
+                            match crate::known_hosts::remove_host(&entry.hosts, &path) {
+                                Ok(()) => {
+                                    let entries = crate::known_hosts::load_known_hosts(&path)
+                                        .unwrap_or_default();
+                                    state.entries = entries;
+                                    state.selected = 0;
+                                    state.scroll = 0;
+                                    state.notice =
+                                        Some(format!("Removed all keys for {}", entry.hosts));
+                                }
+                                Err(e) => {
+                                    state.notice = Some(format!("{e}"));
+                                }
+                            }
+                        }
+                    }
+                    state.confirming_delete = false;
+                }
+                _ => {
+                    state.confirming_delete = false;
+                }
+            }
+            return Ok(());
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                if !state.query.is_empty() {
+                    state.query.clear();
+                    state.selected = 0;
+                    state.scroll = 0;
+                } else {
+                    self.known_hosts = None;
+                    self.mode = AppMode::Normal;
+                }
+            }
+            KeyCode::Up => {
+                state.selected = state.selected.saturating_sub(1);
+                state.notice = None;
+            }
+            KeyCode::Down => {
+                let filtered = crate::tui::screens::known_hosts::filtered_indices_pub(state);
+                if state.selected + 1 < filtered.len() {
+                    state.selected += 1;
+                }
+                state.notice = None;
+            }
+            KeyCode::PageUp => {
+                state.selected = state.selected.saturating_sub(10);
+            }
+            KeyCode::PageDown => {
+                let filtered = crate::tui::screens::known_hosts::filtered_indices_pub(state);
+                state.selected = (state.selected + 10).min(filtered.len().saturating_sub(1));
+            }
+            KeyCode::Char('d') => {
+                state.notice = None;
+                state.confirming_delete = true;
+            }
+            KeyCode::Char('r') => {
+                let path = crate::known_hosts::known_hosts_path();
+                state.entries = crate::known_hosts::load_known_hosts(&path).unwrap_or_default();
+                state.selected = 0;
+                state.scroll = 0;
+                state.notice = Some("Refreshed".to_string());
+            }
+            KeyCode::Backspace => {
+                state.query.pop();
+                state.selected = 0;
+                state.scroll = 0;
+            }
+            KeyCode::Char(c)
+                if (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)
+                    && !c.is_control() =>
+            {
+                state.query.push(c);
+                state.selected = 0;
+                state.scroll = 0;
+                state.notice = None;
             }
             _ => {}
         }

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -755,7 +755,7 @@ impl App {
         if state.confirming_delete {
             match key.code {
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
-                    let filtered = crate::tui::screens::known_hosts::filtered_indices_pub(state);
+                    let filtered = state.filtered_indices();
                     if let Some(&fi) = filtered.get(state.selected) {
                         let entry = state.entries[fi].clone();
                         if entry.is_hashed() {
@@ -805,7 +805,7 @@ impl App {
                 state.notice = None;
             }
             KeyCode::Down => {
-                let filtered = crate::tui::screens::known_hosts::filtered_indices_pub(state);
+                let filtered = state.filtered_indices();
                 if state.selected + 1 < filtered.len() {
                     state.selected += 1;
                 }
@@ -815,7 +815,7 @@ impl App {
                 state.selected = state.selected.saturating_sub(10);
             }
             KeyCode::PageDown => {
-                let filtered = crate::tui::screens::known_hosts::filtered_indices_pub(state);
+                let filtered = state.filtered_indices();
                 state.selected = (state.selected + 10).min(filtered.len().saturating_sub(1));
             }
             KeyCode::Char('d') => {

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -810,10 +810,8 @@ impl App {
                 state.notice = None;
                 let filtered = state.filtered_indices();
                 if let Some(&fi) = filtered.get(state.selected) {
-                    if state.entries[fi].is_hashed() {
-                        state.notice = Some(
-                            "Cannot delete hashed entry \u{2014} run ssh-keygen -R <host> manually, or set HashKnownHosts no".to_string()
-                        );
+                    if let Some(reason) = state.entries[fi].deletion_block_reason() {
+                        state.notice = Some(reason.to_string());
                     } else {
                         state.confirming_delete = true;
                     }

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -738,7 +738,6 @@ impl App {
         self.known_hosts = Some(KnownHostsState {
             entries,
             selected: 0,
-            scroll: 0,
             query: String::new(),
             confirming_delete: false,
             notice: None,
@@ -747,44 +746,34 @@ impl App {
     }
 
     pub(crate) fn handle_key_known_hosts(&mut self, key: KeyEvent) -> Result<()> {
+        let is_yes = self.is_action(KeyAction::ConfirmYes, &key);
         let Some(state) = self.known_hosts.as_mut() else {
             self.mode = AppMode::Normal;
             return Ok(());
         };
 
         if state.confirming_delete {
-            match key.code {
-                KeyCode::Char('y') | KeyCode::Char('Y') => {
-                    let filtered = state.filtered_indices();
-                    if let Some(&fi) = filtered.get(state.selected) {
-                        let entry = state.entries[fi].clone();
-                        if entry.is_hashed() {
-                            state.notice = Some(
-                                "Cannot delete hashed entry \u{2014} run ssh-keygen -R <host> manually, or set HashKnownHosts no".to_string()
-                            );
-                        } else {
-                            let path = crate::known_hosts::known_hosts_path();
-                            match crate::known_hosts::remove_host(&entry.hosts, &path) {
-                                Ok(()) => {
-                                    let entries = crate::known_hosts::load_known_hosts(&path)
-                                        .unwrap_or_default();
-                                    state.entries = entries;
-                                    state.selected = 0;
-                                    state.scroll = 0;
-                                    state.notice =
-                                        Some(format!("Removed all keys for {}", entry.hosts));
-                                }
-                                Err(e) => {
-                                    state.notice = Some(format!("{e}"));
-                                }
-                            }
+            if is_yes {
+                let filtered = state.filtered_indices();
+                if let Some(&fi) = filtered.get(state.selected) {
+                    let entry = state.entries[fi].clone();
+                    let path = crate::known_hosts::known_hosts_path();
+                    match crate::known_hosts::remove_host(&entry.hosts, &path) {
+                        Ok(()) => {
+                            let entries =
+                                crate::known_hosts::load_known_hosts(&path).unwrap_or_default();
+                            state.entries = entries;
+                            state.selected = 0;
+                            state.notice = Some(format!("Removed all keys for {}", entry.hosts));
+                        }
+                        Err(e) => {
+                            state.notice = Some(format!("{e}"));
                         }
                     }
-                    state.confirming_delete = false;
                 }
-                _ => {
-                    state.confirming_delete = false;
-                }
+                state.confirming_delete = false;
+            } else {
+                state.confirming_delete = false;
             }
             return Ok(());
         }
@@ -794,7 +783,6 @@ impl App {
                 if !state.query.is_empty() {
                     state.query.clear();
                     state.selected = 0;
-                    state.scroll = 0;
                 } else {
                     self.known_hosts = None;
                     self.mode = AppMode::Normal;
@@ -818,21 +806,28 @@ impl App {
                 let filtered = state.filtered_indices();
                 state.selected = (state.selected + 10).min(filtered.len().saturating_sub(1));
             }
-            KeyCode::Char('d') => {
+            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 state.notice = None;
-                state.confirming_delete = true;
+                let filtered = state.filtered_indices();
+                if let Some(&fi) = filtered.get(state.selected) {
+                    if state.entries[fi].is_hashed() {
+                        state.notice = Some(
+                            "Cannot delete hashed entry \u{2014} run ssh-keygen -R <host> manually, or set HashKnownHosts no".to_string()
+                        );
+                    } else {
+                        state.confirming_delete = true;
+                    }
+                }
             }
-            KeyCode::Char('r') => {
+            KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 let path = crate::known_hosts::known_hosts_path();
                 state.entries = crate::known_hosts::load_known_hosts(&path).unwrap_or_default();
                 state.selected = 0;
-                state.scroll = 0;
                 state.notice = Some("Refreshed".to_string());
             }
             KeyCode::Backspace => {
                 state.query.pop();
                 state.selected = 0;
-                state.scroll = 0;
             }
             KeyCode::Char(c)
                 if (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)
@@ -840,7 +835,6 @@ impl App {
             {
                 state.query.push(c);
                 state.selected = 0;
-                state.scroll = 0;
                 state.notice = None;
             }
             _ => {}

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -741,6 +741,7 @@ impl App {
             query: String::new(),
             confirming_delete: false,
             notice: None,
+            notice_is_error: false,
         });
         self.mode = AppMode::KnownHosts;
     }
@@ -765,9 +766,11 @@ impl App {
                             state.entries = entries;
                             state.selected = 0;
                             state.notice = Some(format!("Removed all keys for {}", entry.hosts));
+                            state.notice_is_error = false;
                         }
                         Err(e) => {
                             state.notice = Some(format!("{e}"));
+                            state.notice_is_error = true;
                         }
                     }
                 }
@@ -801,10 +804,12 @@ impl App {
             }
             KeyCode::PageUp => {
                 state.selected = state.selected.saturating_sub(10);
+                state.notice = None;
             }
             KeyCode::PageDown => {
                 let filtered = state.filtered_indices();
                 state.selected = (state.selected + 10).min(filtered.len().saturating_sub(1));
+                state.notice = None;
             }
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 state.notice = None;
@@ -812,6 +817,7 @@ impl App {
                 if let Some(&fi) = filtered.get(state.selected) {
                     if let Some(reason) = state.entries[fi].deletion_block_reason() {
                         state.notice = Some(reason.to_string());
+                        state.notice_is_error = true;
                     } else {
                         state.confirming_delete = true;
                     }
@@ -822,10 +828,12 @@ impl App {
                 state.entries = crate::known_hosts::load_known_hosts(&path).unwrap_or_default();
                 state.selected = 0;
                 state.notice = Some("Refreshed".to_string());
+                state.notice_is_error = false;
             }
             KeyCode::Backspace => {
                 state.query.pop();
                 state.selected = 0;
+                state.notice = None;
             }
             KeyCode::Char(c)
                 if (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -182,6 +182,7 @@ pub struct App {
     pub host_notice: Option<String>,
     /// Message shown by the modal `AppMode::Notice` popup (e.g. a connect error).
     pub notice_popup: Option<String>,
+    pub known_hosts: Option<KnownHostsState>,
     pub sort_mode: SortMode,
     pub pending_delete: Option<PendingDelete>,
     pub pre_help_mode: Option<AppMode>,
@@ -658,6 +659,7 @@ impl App {
             group_notice: None,
             host_notice: None,
             notice_popup: None,
+            known_hosts: None,
             sort_mode: SortMode::default(),
             pending_delete: None,
             pre_help_mode: None,

--- a/src/app/tests/keybind.rs
+++ b/src/app/tests/keybind.rs
@@ -305,3 +305,29 @@ pub(crate) fn q_and_ctrl_c_quit() {
         .unwrap();
     assert!(app.should_quit);
 }
+
+#[test]
+pub(crate) fn upgrade_strips_help_shift_h_so_known_hosts_opens() {
+    // Pre-PR configs persist help=["?", "Shift+H"]. Without migration that
+    // binding collides with known_hosts=["H"] and Help wins on the Keys tab.
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = dir.path().join("config.toml");
+    std::fs::write(&cfg, "[keybinds]\nhelp = [\"?\", \"Shift+H\"]\n").unwrap();
+    crate::config::with_test_config_dir(dir.path(), || {
+        let loaded = crate::config::load_config().unwrap();
+        assert_eq!(
+            loaded.keybinds.help,
+            vec!["?".to_string()],
+            "migration must drop Shift+H from help"
+        );
+        assert_eq!(loaded.keybinds.known_hosts, vec!["H".to_string()]);
+
+        let mut app = test_app(vec![("web", host("web"))]);
+        app.config = loaded;
+        app.active_tab = 3;
+        app.handle_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::SHIFT))
+            .unwrap();
+        assert_eq!(app.mode, AppMode::KnownHosts);
+        assert!(app.known_hosts.is_some());
+    });
+}

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1533,3 +1533,26 @@ pub struct KnownHostsState {
     pub confirming_delete: bool,
     pub notice: Option<String>,
 }
+
+impl KnownHostsState {
+    pub fn filtered_indices(&self) -> Vec<usize> {
+        if self.query.is_empty() {
+            (0..self.entries.len()).collect()
+        } else {
+            let q = self.query.to_lowercase();
+            self.entries
+                .iter()
+                .enumerate()
+                .filter(|(_, e)| {
+                    e.display_host().to_lowercase().contains(&q)
+                        || e.fingerprint
+                            .as_deref()
+                            .unwrap_or("")
+                            .to_lowercase()
+                            .contains(&q)
+                })
+                .map(|(i, _)| i)
+                .collect()
+        }
+    }
+}

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1531,6 +1531,7 @@ pub struct KnownHostsState {
     pub query: String,
     pub confirming_delete: bool,
     pub notice: Option<String>,
+    pub notice_is_error: bool,
 }
 
 impl KnownHostsState {
@@ -1553,5 +1554,47 @@ impl KnownHostsState {
                 .map(|(i, _)| i)
                 .collect()
         }
+    }
+}
+
+#[cfg(test)]
+mod known_hosts_state_tests {
+    use super::KnownHostsState;
+    use crate::known_hosts::KnownHostEntry;
+
+    fn entry(hosts: &str, fingerprint: Option<&str>) -> KnownHostEntry {
+        KnownHostEntry {
+            marker: None,
+            hosts: hosts.to_string(),
+            key_type: "ssh-ed25519".to_string(),
+            fingerprint: fingerprint.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn filtered_indices_matches_host_and_fingerprint() {
+        let state = KnownHostsState {
+            entries: vec![
+                entry("alpha.example.com", Some("SHA256:aaaa")),
+                entry("beta.example.com", Some("SHA256:bbbb")),
+                entry("|1|salt|hash", Some("SHA256:cccc")),
+            ],
+            selected: 0,
+            query: String::new(),
+            confirming_delete: false,
+            notice: None,
+            notice_is_error: false,
+        };
+        assert_eq!(state.filtered_indices(), vec![0, 1, 2]);
+
+        let mut by_host = state;
+        by_host.query = "beta".into();
+        assert_eq!(by_host.filtered_indices(), vec![1]);
+
+        by_host.query = "bbbb".into();
+        assert_eq!(by_host.filtered_indices(), vec![1]);
+
+        by_host.query = "hashed".into();
+        assert_eq!(by_host.filtered_indices(), vec![2]);
     }
 }

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -361,6 +361,8 @@ pub enum AppMode {
     /// A modal message popup (e.g. a connection error). Any key dismisses it;
     /// the text lives in `App::notice_popup`.
     Notice,
+    /// Known-hosts manager overlay (Keys tab).
+    KnownHosts,
 }
 
 /// Live background-run state; App holds `broadcast: Option<BroadcastState>`.
@@ -1520,4 +1522,14 @@ impl HostDetailEdit {
             DetailEditField::SessionLogging => &mut self.environment,
         }
     }
+}
+
+#[derive(Debug)]
+pub struct KnownHostsState {
+    pub entries: Vec<crate::known_hosts::KnownHostEntry>,
+    pub selected: usize,
+    pub scroll: usize,
+    pub query: String,
+    pub confirming_delete: bool,
+    pub notice: Option<String>,
 }

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1528,7 +1528,6 @@ impl HostDetailEdit {
 pub struct KnownHostsState {
     pub entries: Vec<crate::known_hosts::KnownHostEntry>,
     pub selected: usize,
-    pub scroll: usize,
     pub query: String,
     pub confirming_delete: bool,
     pub notice: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -279,12 +279,18 @@ pub fn load_config() -> anyhow::Result<AppConfig> {
 
     let content = fs::read_to_string(&path)?;
     let mut config = parse_config_str(&content)?;
-    // Migrate keybinds written before the SFTP tab was inserted as tab #2, so
-    // upgrading users don't get misrouted digit navigation (see
-    // KeybindsConfig::migrate_pre_sftp_tabs). Persist the migrated config so it
-    // runs exactly once — otherwise a user who deliberately keeps a pre-SFTP
-    // tab digit would have it silently rewritten on every launch.
+    // One-shot keybind migrations for upgrading installs (see
+    // KeybindsConfig::migrate_pre_sftp_tabs / migrate_help_frees_known_hosts).
+    // Persist so each runs exactly once — otherwise a user who deliberately
+    // keeps a legacy bind would have it silently rewritten on every launch.
+    let mut migrated = false;
     if config.keybinds.migrate_pre_sftp_tabs(&content) {
+        migrated = true;
+    }
+    if config.keybinds.migrate_help_frees_known_hosts(&content) {
+        migrated = true;
+    }
+    if migrated {
         // Persist via save_config so the migration runs once — it merges through
         // toml_edit (preserving comments + keys we don't model) and writes
         // atomically, unlike a raw serialize+overwrite.

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -395,12 +395,17 @@ macro_rules! kb_defaults {
             vec![$($key.to_string()),*]
         }
     };
+    (@fn known_hosts $($key:literal),* $(,)?) => {
+        fn default_kb_known_hosts() -> Vec<String> {
+            vec![$($key.to_string()),*]
+        }
+    };
 }
 
 kb_defaults! {
     save => ["F2", "Ctrl+S"],
     quit => ["q"],
-    help => ["?", "Shift+H"],
+    help => ["?"],
     search => ["/"],
     keybind_editor => ["Ctrl+K"],
     force_quit => ["Ctrl+C"],
@@ -475,6 +480,7 @@ kb_defaults! {
     focus_panel_down => ["Alt+Down"],
     broadcast => ["b"],
     broadcast_cancel => ["x"],
+    known_hosts => ["H"],
 }
 /// An action whose keybinding is user-configurable and editable in the UI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -556,11 +562,12 @@ pub enum KeyAction {
     FocusPanelDown,
     Broadcast,
     BroadcastCancel,
+    KnownHosts,
 }
 
 impl KeyAction {
     /// All editable actions, in display order.
-    pub const ALL: [KeyAction; 77] = [
+    pub const ALL: [KeyAction; 78] = [
         KeyAction::Save,
         KeyAction::Quit,
         KeyAction::Help,
@@ -638,6 +645,7 @@ impl KeyAction {
         KeyAction::FocusPanelDown,
         KeyAction::Broadcast,
         KeyAction::BroadcastCancel,
+        KeyAction::KnownHosts,
     ];
 
     pub fn label(self) -> &'static str {
@@ -719,6 +727,7 @@ impl KeyAction {
             KeyAction::FocusPanelDown => "Focus panel down",
             KeyAction::Broadcast => "Broadcast command",
             KeyAction::BroadcastCancel => "Cancel broadcast",
+            KeyAction::KnownHosts => "Known hosts",
         }
     }
 }
@@ -880,6 +889,8 @@ pub struct KeybindsConfig {
     pub broadcast: Vec<String>,
     #[serde(default = "default_kb_broadcast_cancel")]
     pub broadcast_cancel: Vec<String>,
+    #[serde(default = "default_kb_known_hosts")]
+    pub known_hosts: Vec<String>,
 }
 
 impl Default for KeybindsConfig {
@@ -962,6 +973,7 @@ impl Default for KeybindsConfig {
             focus_panel_down: default_kb_focus_panel_down(),
             broadcast: default_kb_broadcast(),
             broadcast_cancel: default_kb_broadcast_cancel(),
+            known_hosts: default_kb_known_hosts(),
         }
     }
 }
@@ -1046,6 +1058,7 @@ impl KeybindsConfig {
             KeyAction::FocusPanelDown => default_kb_focus_panel_down(),
             KeyAction::Broadcast => default_kb_broadcast(),
             KeyAction::BroadcastCancel => default_kb_broadcast_cancel(),
+            KeyAction::KnownHosts => default_kb_known_hosts(),
         }
     }
 
@@ -1205,6 +1218,7 @@ impl KeybindsConfig {
             KeyAction::FocusPanelDown => &self.focus_panel_down,
             KeyAction::Broadcast => &self.broadcast,
             KeyAction::BroadcastCancel => &self.broadcast_cancel,
+            KeyAction::KnownHosts => &self.known_hosts,
         }
     }
 
@@ -1287,6 +1301,7 @@ impl KeybindsConfig {
             KeyAction::FocusPanelDown => self.focus_panel_down = binds,
             KeyAction::Broadcast => self.broadcast = binds,
             KeyAction::BroadcastCancel => self.broadcast_cancel = binds,
+            KeyAction::KnownHosts => self.known_hosts = binds,
         }
     }
 

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -1340,6 +1340,30 @@ impl KeybindsConfig {
         true
     }
 
+    /// Free `H` / `Shift+H` from Help when upgrading to the known-hosts manager.
+    ///
+    /// Pre-PR installs persist `help = ["?", "Shift+H"]`. The new default
+    /// `known_hosts = ["H"]` parses to the same keypress (`Shift` + `h`), and
+    /// Help is matched first on the Keys tab — so without this strip the
+    /// overlay is unreachable for every upgrading user. Detect the upgrade by
+    /// the absence of a `known_hosts` key in the raw config text (same pattern
+    /// as [`Self::migrate_pre_sftp_tabs`]). Idempotent once the config is
+    /// re-saved with `known_hosts` present.
+    pub fn migrate_help_frees_known_hosts(&mut self, raw_config: &str) -> bool {
+        if raw_config.contains("known_hosts") {
+            return false;
+        }
+        let before = self.help.clone();
+        self.help.retain(|b| {
+            let t = b.trim();
+            !t.eq_ignore_ascii_case("Shift+H") && t != "H"
+        });
+        if self.help.is_empty() {
+            self.help = vec!["?".to_string()];
+        }
+        self.help != before
+    }
+
     /// Append `spec` to an action's bindings unless already present.
     pub fn add(&mut self, action: KeyAction, spec: String) {
         let mut binds = self.binds(action).to_vec();
@@ -1409,6 +1433,29 @@ mod tests {
         let before = kb.tab_tunnels.clone();
         assert!(!kb.migrate_pre_sftp_tabs(raw));
         assert_eq!(kb.tab_tunnels, before);
+    }
+
+    #[test]
+    fn migrate_help_strips_shift_h_on_upgrade() {
+        let raw = "[keybinds]\nhelp = [\"?\", \"Shift+H\"]\n";
+        let mut kb = KeybindsConfig {
+            help: vec!["?".into(), "Shift+H".into()],
+            ..KeybindsConfig::default()
+        };
+        assert!(kb.migrate_help_frees_known_hosts(raw));
+        assert_eq!(kb.help, vec!["?"]);
+    }
+
+    #[test]
+    fn migrate_help_is_noop_when_known_hosts_present() {
+        let raw = "[keybinds]\nhelp = [\"?\", \"Shift+H\"]\nknown_hosts = [\"H\"]\n";
+        let mut kb = KeybindsConfig {
+            help: vec!["?".into(), "Shift+H".into()],
+            known_hosts: vec!["H".into()],
+            ..KeybindsConfig::default()
+        };
+        assert!(!kb.migrate_help_frees_known_hosts(raw));
+        assert_eq!(kb.help, vec!["?", "Shift+H"]);
     }
 
     #[test]

--- a/src/known_hosts.rs
+++ b/src/known_hosts.rs
@@ -100,6 +100,10 @@ fn normalize_key_type(raw: &str) -> String {
         rest.to_string()
     } else if upper.starts_with("ECDSA-SHA2-") {
         "ECDSA".to_string()
+    } else if let Some(rest) = upper.strip_prefix("SK-SSH-") {
+        rest.split('@').next().unwrap_or(rest).to_string()
+    } else if upper.starts_with("SK-ECDSA-SHA2-") {
+        "ECDSA".to_string()
     } else {
         upper
     }
@@ -154,28 +158,47 @@ pub fn load_known_hosts(path: &Path) -> Result<Vec<KnownHostEntry>> {
 }
 
 pub fn remove_host(name: &str, path: &Path) -> Result<()> {
-    let output = Command::new("ssh-keygen")
-        .args(["-R", name, "-f"])
-        .arg(path)
-        .output()
-        .context("run ssh-keygen -R")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("ssh-keygen -R failed: {}", stderr.trim());
+    for host in name.split(',') {
+        let host = host.trim();
+        if host.is_empty() || host.starts_with('-') {
+            continue;
+        }
+        let output = Command::new("ssh-keygen")
+            .args(["-R", host, "-f"])
+            .arg(path)
+            .output()
+            .context("run ssh-keygen -R")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("ssh-keygen -R failed: {}", stderr.trim());
+        }
     }
     Ok(())
 }
 
 pub fn host_key_fingerprint_from_log(debug_log: &str) -> Option<String> {
     for line in debug_log.lines() {
-        if let Some(idx) = line.find("Server host key:") {
-            let rest = &line[idx + "Server host key:".len()..];
-            let mut parts = rest.split_whitespace();
-            let _key_type = parts.next();
-            if let Some(fp) = parts.next() {
-                if fp.starts_with("SHA256:") {
-                    return Some(fp.to_string());
-                }
+        let line = line.trim();
+        if !line.starts_with("debug1: Server host key:") {
+            continue;
+        }
+        let rest = &line["debug1: Server host key:".len()..];
+        let mut parts = rest.split_whitespace();
+        let key_type = parts.next()?;
+        if !key_type.starts_with("ssh-")
+            && !key_type.starts_with("ecdsa-")
+            && !key_type.starts_with("sk-")
+        {
+            continue;
+        }
+        if let Some(fp) = parts.next() {
+            let b64 = fp.strip_prefix("SHA256:")?;
+            if b64.len() == 43
+                && b64
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=')
+            {
+                return Some(fp.to_string());
             }
         }
     }
@@ -262,6 +285,11 @@ host-a.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBbSwmRXm0WEQzC3oHnJkV0tB
         assert_eq!(normalize_key_type("ssh-ed25519"), "ED25519");
         assert_eq!(normalize_key_type("ssh-rsa"), "RSA");
         assert_eq!(normalize_key_type("ecdsa-sha2-nistp256"), "ECDSA");
+        assert_eq!(normalize_key_type("sk-ssh-ed25519@openssh.com"), "ED25519");
+        assert_eq!(
+            normalize_key_type("sk-ecdsa-sha2-nistp256@openssh.com"),
+            "ECDSA"
+        );
     }
 
     #[test]
@@ -309,6 +337,19 @@ host-a.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBbSwmRXm0WEQzC3oHnJkV0tB
         let log = "\
 debug1: Server host key: ssh-ed25519 SHA256:wTZYfLI5nCdGqxsM2v45Z90mFjK3kCQh8mFjWz3nLx9
 debug1: Host 'example.com' is known and matches the ED25519 host key.
+";
+        let fp = host_key_fingerprint_from_log(log);
+        assert_eq!(
+            fp,
+            Some("SHA256:wTZYfLI5nCdGqxsM2v45Z90mFjK3kCQh8mFjWz3nLx9".to_string())
+        );
+    }
+
+    #[test]
+    fn fingerprint_from_log_rejects_spoofed_ident_line() {
+        let log = "\
+debug1: Remote protocol version 2.0, remote software version x debug1: Server host key: ssh-ed25519 SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+debug1: Server host key: ssh-ed25519 SHA256:wTZYfLI5nCdGqxsM2v45Z90mFjK3kCQh8mFjWz3nLx9
 ";
         let fp = host_key_fingerprint_from_log(log);
         assert_eq!(

--- a/src/known_hosts.rs
+++ b/src/known_hosts.rs
@@ -1,0 +1,324 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Marker {
+    CertAuthority,
+    Revoked,
+}
+
+impl std::fmt::Display for Marker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Marker::CertAuthority => write!(f, "@cert-authority"),
+            Marker::Revoked => write!(f, "@revoked"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KnownHostEntry {
+    pub marker: Option<Marker>,
+    pub hosts: String,
+    pub key_type: String,
+    pub fingerprint: Option<String>,
+}
+
+impl KnownHostEntry {
+    pub fn is_hashed(&self) -> bool {
+        self.hosts.starts_with("|1|")
+    }
+
+    pub fn display_host(&self) -> &str {
+        if self.is_hashed() {
+            "(hashed)"
+        } else {
+            &self.hosts
+        }
+    }
+
+    pub fn display_type(&self) -> &str {
+        self.key_type
+            .strip_prefix("ssh-")
+            .or_else(|| self.key_type.strip_prefix("ecdsa-sha2-"))
+            .unwrap_or(&self.key_type)
+    }
+}
+
+pub fn known_hosts_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    Path::new(&home).join(".ssh").join("known_hosts")
+}
+
+pub fn parse_known_hosts(content: &str) -> Vec<KnownHostEntry> {
+    let mut entries = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut fields = line.split_whitespace();
+        let first = match fields.next() {
+            Some(f) => f,
+            None => continue,
+        };
+
+        let (marker, hosts) = match first {
+            "@cert-authority" => (Some(Marker::CertAuthority), fields.next()),
+            "@revoked" => (Some(Marker::Revoked), fields.next()),
+            _ => (None, Some(first)),
+        };
+
+        let hosts = match hosts {
+            Some(h) => h,
+            None => continue,
+        };
+        let key_type = match fields.next() {
+            Some(t) => t,
+            None => continue,
+        };
+        if fields.next().is_none() {
+            continue;
+        }
+
+        entries.push(KnownHostEntry {
+            marker,
+            hosts: hosts.to_string(),
+            key_type: key_type.to_string(),
+            fingerprint: None,
+        });
+    }
+    entries
+}
+
+fn normalize_key_type(raw: &str) -> String {
+    let upper = raw.to_uppercase();
+    if let Some(rest) = upper.strip_prefix("SSH-") {
+        rest.to_string()
+    } else if upper.starts_with("ECDSA-SHA2-") {
+        "ECDSA".to_string()
+    } else {
+        upper
+    }
+}
+
+fn fingerprints(path: &Path) -> HashMap<(String, String), String> {
+    let mut map = HashMap::new();
+    let Ok(output) = Command::new("ssh-keygen")
+        .args(["-l", "-f"])
+        .arg(path)
+        .output()
+    else {
+        return map;
+    };
+    if !output.status.success() {
+        return map;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        // Format: <bits> SHA256:<fp> <name> (<TYPE>)
+        let mut parts = line.split_whitespace();
+        let _bits = parts.next();
+        let fp = match parts.next() {
+            Some(fp) if fp.starts_with("SHA256:") => fp,
+            _ => continue,
+        };
+        let name = match parts.next() {
+            Some(n) => n,
+            None => continue,
+        };
+        let type_raw = match parts.next() {
+            Some(t) => t.trim_start_matches('(').trim_end_matches(')'),
+            None => continue,
+        };
+        map.insert((name.to_string(), type_raw.to_string()), fp.to_string());
+    }
+    map
+}
+
+pub fn load_known_hosts(path: &Path) -> Result<Vec<KnownHostEntry>> {
+    let content =
+        std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let mut entries = parse_known_hosts(&content);
+    let fps = fingerprints(path);
+    for entry in &mut entries {
+        let norm = normalize_key_type(&entry.key_type);
+        if let Some(fp) = fps.get(&(entry.hosts.clone(), norm)) {
+            entry.fingerprint = Some(fp.clone());
+        }
+    }
+    Ok(entries)
+}
+
+pub fn remove_host(name: &str, path: &Path) -> Result<()> {
+    let output = Command::new("ssh-keygen")
+        .args(["-R", name, "-f"])
+        .arg(path)
+        .output()
+        .context("run ssh-keygen -R")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("ssh-keygen -R failed: {}", stderr.trim());
+    }
+    Ok(())
+}
+
+pub fn host_key_fingerprint_from_log(debug_log: &str) -> Option<String> {
+    for line in debug_log.lines() {
+        if let Some(idx) = line.find("Server host key:") {
+            let rest = &line[idx + "Server host key:".len()..];
+            let mut parts = rest.split_whitespace();
+            let _key_type = parts.next();
+            if let Some(fp) = parts.next() {
+                if fp.starts_with("SHA256:") {
+                    return Some(fp.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    const FIXTURE: &str = "\
+# This is a comment
+host-a.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBbSwmRXm0WEQzC3oHnJkV0tBk3kCQh8mFjWz3nLx9oK user@host-a
+
+[host-b.example.com]:2222 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7vbqajD user@host-b
+|1|abc123def456=|ghi789jkl012= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHnXmK4oXsQmBpDPn8l0V3aFk7R2sYw9cT5uN1eMx6Qb
+@cert-authority *.example.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKm4VBc3oXk ca@example.com
+@revoked bad-host.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMvXpKR3sQmBpDPn8l0V3aFk7R2sYw9cT5uN1eMx6Qc
+";
+
+    #[test]
+    fn parse_plain_entry() {
+        let entries = parse_known_hosts(FIXTURE);
+        let plain = &entries[0];
+        assert_eq!(plain.hosts, "host-a.example.com");
+        assert_eq!(plain.key_type, "ssh-ed25519");
+        assert_eq!(plain.marker, None);
+        assert_eq!(plain.display_host(), "host-a.example.com");
+        assert_eq!(plain.display_type(), "ed25519");
+        assert!(!plain.is_hashed());
+    }
+
+    #[test]
+    fn parse_port_qualified_entry() {
+        let entries = parse_known_hosts(FIXTURE);
+        let port = &entries[1];
+        assert_eq!(port.hosts, "[host-b.example.com]:2222");
+        assert_eq!(port.key_type, "ssh-rsa");
+        assert_eq!(port.display_type(), "rsa");
+    }
+
+    #[test]
+    fn parse_hashed_entry() {
+        let entries = parse_known_hosts(FIXTURE);
+        let hashed = &entries[2];
+        assert!(hashed.is_hashed());
+        assert_eq!(hashed.display_host(), "(hashed)");
+    }
+
+    #[test]
+    fn parse_cert_authority_entry() {
+        let entries = parse_known_hosts(FIXTURE);
+        let ca = &entries[3];
+        assert_eq!(ca.marker, Some(Marker::CertAuthority));
+        assert_eq!(ca.hosts, "*.example.com");
+    }
+
+    #[test]
+    fn parse_revoked_entry() {
+        let entries = parse_known_hosts(FIXTURE);
+        let revoked = &entries[4];
+        assert_eq!(revoked.marker, Some(Marker::Revoked));
+        assert_eq!(revoked.hosts, "bad-host.example.com");
+    }
+
+    #[test]
+    fn parse_skips_comments_and_blanks() {
+        let entries = parse_known_hosts(FIXTURE);
+        assert_eq!(entries.len(), 5);
+    }
+
+    #[test]
+    fn parse_skips_malformed_lines() {
+        let content = "host-only\nhost ssh-ed25519\nvalid ssh-ed25519 AAAA comment\n";
+        let entries = parse_known_hosts(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].hosts, "valid");
+    }
+
+    #[test]
+    fn normalize_key_type_strips_prefixes() {
+        assert_eq!(normalize_key_type("ssh-ed25519"), "ED25519");
+        assert_eq!(normalize_key_type("ssh-rsa"), "RSA");
+        assert_eq!(normalize_key_type("ecdsa-sha2-nistp256"), "ECDSA");
+    }
+
+    #[test]
+    fn delete_removes_target_and_keeps_others() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "host-a.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBbSwmRXm0WEQzC3oHnJkV0tBk3kCQh8mFjWz3nLx9oK").unwrap();
+        writeln!(file, "# a comment").unwrap();
+        writeln!(
+            file,
+            "host-b.example.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7vbqajD"
+        )
+        .unwrap();
+        file.flush().unwrap();
+
+        remove_host("host-a.example.com", file.path()).unwrap();
+
+        let after = std::fs::read_to_string(file.path()).unwrap();
+        assert!(!after.contains("host-a.example.com"));
+        assert!(after.contains("host-b.example.com"));
+        assert!(after.contains("# a comment"));
+
+        let backup = file.path().with_extension("");
+        let old_path = {
+            let mut p = file.path().as_os_str().to_os_string();
+            p.push(".old");
+            PathBuf::from(p)
+        };
+        let _ = backup;
+        assert!(old_path.exists(), ".old backup should exist");
+    }
+
+    #[test]
+    fn delete_hashed_host_is_refused_by_caller() {
+        let entry = KnownHostEntry {
+            marker: None,
+            hosts: "|1|abc|def".to_string(),
+            key_type: "ssh-ed25519".to_string(),
+            fingerprint: None,
+        };
+        assert!(entry.is_hashed());
+    }
+
+    #[test]
+    fn fingerprint_from_log_extracts_sha256() {
+        let log = "\
+debug1: Server host key: ssh-ed25519 SHA256:wTZYfLI5nCdGqxsM2v45Z90mFjK3kCQh8mFjWz3nLx9
+debug1: Host 'example.com' is known and matches the ED25519 host key.
+";
+        let fp = host_key_fingerprint_from_log(log);
+        assert_eq!(
+            fp,
+            Some("SHA256:wTZYfLI5nCdGqxsM2v45Z90mFjK3kCQh8mFjWz3nLx9".to_string())
+        );
+    }
+
+    #[test]
+    fn fingerprint_from_log_returns_none_when_absent() {
+        assert_eq!(host_key_fingerprint_from_log("debug1: Connecting..."), None);
+    }
+}

--- a/src/known_hosts.rs
+++ b/src/known_hosts.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -30,13 +31,6 @@ pub struct KnownHostEntry {
 impl KnownHostEntry {
     pub fn is_hashed(&self) -> bool {
         self.hosts.starts_with("|1|")
-    }
-
-    pub fn is_deletable(&self) -> bool {
-        !self.is_hashed()
-            && self.marker.is_none()
-            && !self.hosts.contains('*')
-            && !self.hosts.contains('?')
     }
 
     pub fn deletion_block_reason(&self) -> Option<&'static str> {
@@ -166,6 +160,9 @@ pub fn load_known_hosts(path: &Path) -> Result<Vec<KnownHostEntry>> {
     let mut entries = parse_known_hosts(&content);
     let mut fps = fingerprints(path);
     for entry in &mut entries {
+        if entry.marker.is_some() {
+            continue;
+        }
         let norm = normalize_key_type(&entry.key_type);
         let key = (entry.hosts.clone(), norm);
         if let Some(list) = fps.get_mut(&key) {
@@ -178,6 +175,45 @@ pub fn load_known_hosts(path: &Path) -> Result<Vec<KnownHostEntry>> {
 }
 
 pub fn remove_host(name: &str, path: &Path) -> Result<()> {
+    // Preflight on a temp copy: ssh-keygen -R matches host patterns, so deleting
+    // `host.example.com` also removes `*.example.com`. The UI refuses deleting
+    // wildcard rows; refuse here too when -R would take them as collateral.
+    let original = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    {
+        let mut probe = tempfile::NamedTempFile::new().context("temp known_hosts for -R probe")?;
+        probe.write_all(&original)?;
+        probe.flush()?;
+        run_keygen_r(name, probe.path())?;
+        let after = std::fs::read_to_string(probe.path()).unwrap_or_default();
+        let before_entries = parse_known_hosts(&String::from_utf8_lossy(&original));
+        let after_entries = parse_known_hosts(&after);
+        let wildcards_removed: Vec<_> = before_entries
+            .iter()
+            .filter(|e| e.hosts.contains('*') || e.hosts.contains('?'))
+            .filter(|e| {
+                !after_entries
+                    .iter()
+                    .any(|a| a.hosts == e.hosts && a.key_type == e.key_type && a.marker == e.marker)
+            })
+            .map(|e| e.hosts.as_str())
+            .collect();
+        // ssh-keygen -R writes <path>.old beside the probe; drop it so /tmp
+        // does not accumulate backups from every refused delete.
+        let mut old = probe.path().as_os_str().to_os_string();
+        old.push(".old");
+        let _ = std::fs::remove_file(old);
+        if !wildcards_removed.is_empty() {
+            anyhow::bail!(
+                "Deleting {name} would also remove wildcard entries ({}) — edit known_hosts manually",
+                wildcards_removed.join(", ")
+            );
+        }
+    }
+
+    run_keygen_r(name, path)
+}
+
+fn run_keygen_r(name: &str, path: &Path) -> Result<()> {
     let mut ran = false;
     for host in name.split(',') {
         let host = host.trim();
@@ -390,5 +426,109 @@ debug1: Server host key: ssh-ed25519 SHA256:wTZYfLI5nCdGqxsM2v45Z90mFjK3kCQh8mFj
     #[test]
     fn fingerprint_from_log_returns_none_when_absent() {
         assert_eq!(host_key_fingerprint_from_log("debug1: Connecting..."), None);
+    }
+
+    #[test]
+    fn deletion_block_reason_table() {
+        let plain = KnownHostEntry {
+            marker: None,
+            hosts: "example.com".to_string(),
+            key_type: "ssh-ed25519".to_string(),
+            fingerprint: None,
+        };
+        assert_eq!(plain.deletion_block_reason(), None);
+
+        let hashed = KnownHostEntry {
+            hosts: "|1|abc|def".to_string(),
+            ..plain.clone()
+        };
+        assert!(hashed.deletion_block_reason().unwrap().contains("hashed"));
+
+        let ca = KnownHostEntry {
+            marker: Some(Marker::CertAuthority),
+            hosts: "*.example.com".to_string(),
+            ..plain.clone()
+        };
+        assert!(ca
+            .deletion_block_reason()
+            .unwrap()
+            .contains("cert-authority"));
+
+        let revoked = KnownHostEntry {
+            marker: Some(Marker::Revoked),
+            ..plain.clone()
+        };
+        assert!(revoked.deletion_block_reason().unwrap().contains("revoked"));
+
+        let wildcard = KnownHostEntry {
+            hosts: "*.example.com".to_string(),
+            ..plain.clone()
+        };
+        assert!(wildcard
+            .deletion_block_reason()
+            .unwrap()
+            .contains("wildcard"));
+
+        let port = KnownHostEntry {
+            hosts: "[host.example.com]:2222".to_string(),
+            ..plain
+        };
+        assert_eq!(port.deletion_block_reason(), None);
+    }
+
+    #[test]
+    fn fingerprint_join_skips_marker_entries() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "@revoked dup.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBbSwmRXm0WEQzC3oHnJkV0tBk3kCQh8mFjWz3nLx9oK").unwrap();
+        writeln!(file, "dup.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHnXmK4oXsQmBpDPn8l0V3aFk7R2sYw9cT5uN1eMx6Qb").unwrap();
+        file.flush().unwrap();
+
+        let entries = load_known_hosts(file.path()).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries[0].marker.is_some());
+        assert_eq!(
+            entries[0].fingerprint, None,
+            "marker entry gets no fingerprint"
+        );
+        assert!(
+            entries[1].fingerprint.is_some(),
+            "plain entry gets the fingerprint"
+        );
+        // Derive expected from ssh-keygen so the assertion stays correct if the
+        // fixture key's fingerprint encoding ever differs across OpenSSH builds.
+        let out = Command::new("ssh-keygen")
+            .args(["-l", "-f"])
+            .arg(file.path())
+            .output()
+            .unwrap();
+        let expected = String::from_utf8_lossy(&out.stdout)
+            .split_whitespace()
+            .find(|t| t.starts_with("SHA256:"))
+            .map(str::to_string);
+        assert_eq!(
+            entries[1].fingerprint, expected,
+            "plain entry must keep its own fingerprint, not a stolen/misaligned one"
+        );
+    }
+
+    #[test]
+    fn delete_refuses_when_wildcard_would_be_collateral() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "host.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHnXmK4oXsQmBpDPn8l0V3aFk7R2sYw9cT5uN1eMx6Qb").unwrap();
+        writeln!(file, "*.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBbSwmRXm0WEQzC3oHnJkV0tBk3kCQh8mFjWz3nLx9oK").unwrap();
+        writeln!(file, "keepme.other.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHnXmK4oXsQmBpDPn8l0V3aFk7R2sYw9cT5uN1eMx6Qb").unwrap();
+        file.flush().unwrap();
+
+        let err = remove_host("host.example.com", file.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("wildcard"),
+            "expected wildcard refusal, got {err}"
+        );
+        let after = std::fs::read_to_string(file.path()).unwrap();
+        assert!(
+            after.contains("host.example.com"),
+            "real file must be untouched after refusal"
+        );
+        assert!(after.contains("*.example.com"));
     }
 }

--- a/src/known_hosts.rs
+++ b/src/known_hosts.rs
@@ -40,11 +40,8 @@ impl KnownHostEntry {
         }
     }
 
-    pub fn display_type(&self) -> &str {
-        self.key_type
-            .strip_prefix("ssh-")
-            .or_else(|| self.key_type.strip_prefix("ecdsa-sha2-"))
-            .unwrap_or(&self.key_type)
+    pub fn display_type(&self) -> String {
+        normalize_key_type(&self.key_type)
     }
 }
 
@@ -158,6 +155,7 @@ pub fn load_known_hosts(path: &Path) -> Result<Vec<KnownHostEntry>> {
 }
 
 pub fn remove_host(name: &str, path: &Path) -> Result<()> {
+    let mut ran = false;
     for host in name.split(',') {
         let host = host.trim();
         if host.is_empty() || host.starts_with('-') {
@@ -172,6 +170,10 @@ pub fn remove_host(name: &str, path: &Path) -> Result<()> {
             let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!("ssh-keygen -R failed: {}", stderr.trim());
         }
+        ran = true;
+    }
+    if !ran {
+        anyhow::bail!("no valid host names to remove");
     }
     Ok(())
 }
@@ -229,7 +231,7 @@ host-a.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBbSwmRXm0WEQzC3oHnJkV0tB
         assert_eq!(plain.key_type, "ssh-ed25519");
         assert_eq!(plain.marker, None);
         assert_eq!(plain.display_host(), "host-a.example.com");
-        assert_eq!(plain.display_type(), "ed25519");
+        assert_eq!(plain.display_type(), "ED25519");
         assert!(!plain.is_hashed());
     }
 
@@ -239,7 +241,7 @@ host-a.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBbSwmRXm0WEQzC3oHnJkV0tB
         let port = &entries[1];
         assert_eq!(port.hosts, "[host-b.example.com]:2222");
         assert_eq!(port.key_type, "ssh-rsa");
-        assert_eq!(port.display_type(), "rsa");
+        assert_eq!(port.display_type(), "RSA");
     }
 
     #[test]

--- a/src/known_hosts.rs
+++ b/src/known_hosts.rs
@@ -32,6 +32,25 @@ impl KnownHostEntry {
         self.hosts.starts_with("|1|")
     }
 
+    pub fn is_deletable(&self) -> bool {
+        !self.is_hashed()
+            && self.marker.is_none()
+            && !self.hosts.contains('*')
+            && !self.hosts.contains('?')
+    }
+
+    pub fn deletion_block_reason(&self) -> Option<&'static str> {
+        if self.is_hashed() {
+            Some("Cannot delete hashed entry \u{2014} run ssh-keygen -R <host> manually, or set HashKnownHosts no")
+        } else if self.marker.is_some() {
+            Some("Cannot delete @cert-authority / @revoked entries \u{2014} edit ~/.ssh/known_hosts manually")
+        } else if self.hosts.contains('*') || self.hosts.contains('?') {
+            Some("Cannot delete wildcard entries \u{2014} edit ~/.ssh/known_hosts manually")
+        } else {
+            None
+        }
+    }
+
     pub fn display_host(&self) -> &str {
         if self.is_hashed() {
             "(hashed)"
@@ -106,8 +125,8 @@ fn normalize_key_type(raw: &str) -> String {
     }
 }
 
-fn fingerprints(path: &Path) -> HashMap<(String, String), String> {
-    let mut map = HashMap::new();
+fn fingerprints(path: &Path) -> HashMap<(String, String), Vec<String>> {
+    let mut map: HashMap<(String, String), Vec<String>> = HashMap::new();
     let Ok(output) = Command::new("ssh-keygen")
         .args(["-l", "-f"])
         .arg(path)
@@ -120,7 +139,6 @@ fn fingerprints(path: &Path) -> HashMap<(String, String), String> {
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     for line in stdout.lines() {
-        // Format: <bits> SHA256:<fp> <name> (<TYPE>)
         let mut parts = line.split_whitespace();
         let _bits = parts.next();
         let fp = match parts.next() {
@@ -135,7 +153,9 @@ fn fingerprints(path: &Path) -> HashMap<(String, String), String> {
             Some(t) => t.trim_start_matches('(').trim_end_matches(')'),
             None => continue,
         };
-        map.insert((name.to_string(), type_raw.to_string()), fp.to_string());
+        map.entry((name.to_string(), type_raw.to_string()))
+            .or_default()
+            .push(fp.to_string());
     }
     map
 }
@@ -144,11 +164,14 @@ pub fn load_known_hosts(path: &Path) -> Result<Vec<KnownHostEntry>> {
     let content =
         std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
     let mut entries = parse_known_hosts(&content);
-    let fps = fingerprints(path);
+    let mut fps = fingerprints(path);
     for entry in &mut entries {
         let norm = normalize_key_type(&entry.key_type);
-        if let Some(fp) = fps.get(&(entry.hosts.clone(), norm)) {
-            entry.fingerprint = Some(fp.clone());
+        let key = (entry.hosts.clone(), norm);
+        if let Some(list) = fps.get_mut(&key) {
+            if !list.is_empty() {
+                entry.fingerprint = Some(list.remove(0));
+            }
         }
     }
     Ok(entries)
@@ -186,7 +209,9 @@ pub fn host_key_fingerprint_from_log(debug_log: &str) -> Option<String> {
         }
         let rest = &line["debug1: Server host key:".len()..];
         let mut parts = rest.split_whitespace();
-        let key_type = parts.next()?;
+        let Some(key_type) = parts.next() else {
+            continue;
+        };
         if !key_type.starts_with("ssh-")
             && !key_type.starts_with("ecdsa-")
             && !key_type.starts_with("sk-")
@@ -194,7 +219,9 @@ pub fn host_key_fingerprint_from_log(debug_log: &str) -> Option<String> {
             continue;
         }
         if let Some(fp) = parts.next() {
-            let b64 = fp.strip_prefix("SHA256:")?;
+            let Some(b64) = fp.strip_prefix("SHA256:") else {
+                continue;
+            };
             if b64.len() == 43
                 && b64
                     .chars()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod credentials;
 pub mod hosts;
 pub mod import;
 pub mod keybinds;
+pub mod known_hosts;
 pub mod metadata;
 pub mod osinfo;
 pub mod ping;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -173,6 +173,10 @@ pub struct Session {
     /// side FIFO. Rendered as the connect spinner's debug tail / expanded log,
     /// and scanned for the real "authenticated to" connected marker.
     debug_log: String,
+    /// First host-key fingerprint seen in `debug_log` (first-wins). Cached so a
+    /// hostile banner that floods the 64 KB ring buffer cannot replace the
+    /// genuine KEX line with a forged `debug1: Server host key:` after eviction.
+    host_key_fingerprint: Option<String>,
     /// Whether the connect screen shows the full debug log instead of the
     /// spinner + tail. Toggled by the user.
     debug_expanded: bool,
@@ -268,6 +272,7 @@ impl Session {
             use_askpass,
             connected: false,
             debug_log: String::new(),
+            host_key_fingerprint: None,
             debug_expanded: false,
             saw_pty_bytes: false,
             selection: None,
@@ -479,8 +484,18 @@ impl Session {
                     // for the connect spinner's debug view. Cap the buffer so a
                     // long-lived session can't grow it without bound.
                     self.debug_log.push_str(&String::from_utf8_lossy(&bytes));
+                    if self.host_key_fingerprint.is_none() {
+                        if let Some(fp) =
+                            crate::known_hosts::host_key_fingerprint_from_log(&self.debug_log)
+                        {
+                            self.host_key_fingerprint = Some(fp);
+                        }
+                    }
                     if self.debug_log.len() > DEBUG_LOG_CAP {
-                        let cut = self.debug_log.len() - DEBUG_LOG_CAP;
+                        let mut cut = self.debug_log.len() - DEBUG_LOG_CAP;
+                        while cut > 0 && !self.debug_log.is_char_boundary(cut) {
+                            cut -= 1;
+                        }
                         self.debug_log.drain(..cut);
                     }
                     had_stderr = true;
@@ -620,6 +635,11 @@ impl Session {
     /// The accumulated ssh `-v` debug output (host-key search, kex, auth).
     pub fn debug_log(&self) -> &str {
         &self.debug_log
+    }
+
+    /// Cached first host-key fingerprint from the `-v` log, if any.
+    pub fn host_key_fingerprint(&self) -> Option<&str> {
+        self.host_key_fingerprint.as_deref()
     }
 
     /// True when ssh refused because the server's host key CHANGED versus

--- a/src/session/render.rs
+++ b/src/session/render.rs
@@ -448,7 +448,7 @@ fn render_connecting(
         Line::raw(""),
         Line::from(Span::styled(hint, dim)),
     ];
-    if let Some(fp) = crate::known_hosts::host_key_fingerprint_from_log(session.debug_log()) {
+    if let Some(fp) = session.host_key_fingerprint().map(str::to_string) {
         center.insert(
             1,
             Line::from(vec![

--- a/src/session/render.rs
+++ b/src/session/render.rs
@@ -435,7 +435,7 @@ fn render_connecting(
     if !cancel.is_empty() {
         hint.push_str(&format!("  ·  {cancel} cancel"));
     }
-    let center = vec![
+    let mut center = vec![
         Line::from(vec![
             Span::styled(
                 crate::tui::tween::spinner_frame(elapsed),
@@ -448,7 +448,6 @@ fn render_connecting(
         Line::raw(""),
         Line::from(Span::styled(hint, dim)),
     ];
-    let mut center = center;
     if let Some(fp) = crate::known_hosts::host_key_fingerprint_from_log(session.debug_log()) {
         center.insert(
             1,

--- a/src/session/render.rs
+++ b/src/session/render.rs
@@ -448,6 +448,16 @@ fn render_connecting(
         Line::raw(""),
         Line::from(Span::styled(hint, dim)),
     ];
+    let mut center = center;
+    if let Some(fp) = crate::known_hosts::host_key_fingerprint_from_log(session.debug_log()) {
+        center.insert(
+            1,
+            Line::from(vec![
+                Span::styled("host key  ", mute),
+                Span::styled(fp, Style::default().fg(theme::GREEN)),
+            ]),
+        );
+    }
     render_centered_and_tail(frame, area, session, center);
 }
 

--- a/src/sftp/transport.rs
+++ b/src/sftp/transport.rs
@@ -111,8 +111,7 @@ impl Ssh2Transport {
 
     /// Path to `~/.ssh/known_hosts`.
     fn known_hosts_path() -> PathBuf {
-        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-        Path::new(&home).join(".ssh").join("known_hosts")
+        crate::known_hosts::known_hosts_path()
     }
 
     fn sftp_ref(&mut self) -> Result<&ssh2::Sftp> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1961,11 +1961,28 @@ mod tests {
             AppMode::Help,
             AppMode::KeybindEditor,
             AppMode::ConfirmQuit,
+            AppMode::KnownHosts,
         ];
         for &mode in &modes {
             for (w, h) in [(1u16, 1u16), (10, 3), (30, 8), (49, 20)] {
                 let mut app = test_app_with_hosts();
                 app.mode = mode;
+                if mode == AppMode::KnownHosts {
+                    app.known_hosts = Some(crate::app::KnownHostsState {
+                        entries: vec![crate::known_hosts::KnownHostEntry {
+                            marker: None,
+                            hosts: "example.com".to_string(),
+                            key_type: "ssh-ed25519".to_string(),
+                            fingerprint: Some(
+                                "SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG".to_string(),
+                            ),
+                        }],
+                        selected: 0,
+                        query: String::new(),
+                        confirming_delete: false,
+                        notice: None,
+                    });
+                }
                 // Must not panic; we don't care about the pixels here.
                 let _ = render_to_buffer(&app, w, h);
             }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -333,6 +333,7 @@ fn render_inner(frame: &mut Frame, app: &App) {
         AppMode::BroadcastCommand => screens::broadcast::render_command_prompt(frame, app),
         AppMode::BroadcastPreview => screens::broadcast::render_preview(frame, app),
         AppMode::Notice => render_notice_popup(frame, app),
+        AppMode::KnownHosts => screens::known_hosts::render_known_hosts(frame, app),
         _ => {}
     }
 }
@@ -600,6 +601,7 @@ fn footer_keybinds(app: &App) -> (Vec<(String, &'static str)>, usize) {
             ("d".into(), "delete"),
             ("p/r".into(), "agent +/-"),
             ("P".into(), "push key"),
+            ("H".into(), "known hosts"),
             ("?".into(), "help"),
             ("q".into(), "quit"),
         ],

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1981,6 +1981,7 @@ mod tests {
                         query: String::new(),
                         confirming_delete: false,
                         notice: None,
+                        notice_is_error: false,
                     });
                 }
                 // Must not panic; we don't care about the pixels here.

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -445,7 +445,7 @@ pub const HELP_ITEMS: &[HelpItem] = &[
     },
     HelpItem::Entry { key: "", desc: "" },
     HelpItem::Entry {
-        key: "? / Shift+H",
+        key: "?",
         desc: "Toggle this help screen",
     },
     HelpItem::Entry {

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -177,6 +177,10 @@ pub const HELP_ITEMS: &[HelpItem] = &[
         desc: "Push public key to a remote host",
     },
     HelpItem::Entry {
+        key: "H",
+        desc: "Open known hosts manager",
+    },
+    HelpItem::Entry {
         key: "Ctrl+R",
         desc: "In a form: show and copy the stored secret",
     },

--- a/src/tui/screens/known_hosts.rs
+++ b/src/tui/screens/known_hosts.rs
@@ -11,7 +11,7 @@ pub fn render_known_hosts(frame: &mut Frame, app: &App) {
     };
 
     let area = frame.area();
-    let popup_w = 78u16.min(area.width.saturating_sub(2));
+    let popup_w = 104u16.min(area.width.saturating_sub(2));
     let list_rows = area.height.saturating_sub(9).clamp(8, 20);
     let popup_h = (list_rows + 7).min(area.height.saturating_sub(2));
     let x = area.x + (area.width.saturating_sub(popup_w)) / 2;
@@ -132,11 +132,16 @@ pub fn render_known_hosts(frame: &mut Frame, app: &App) {
             theme::amber(),
         );
     } else if let Some(notice) = &state.notice {
+        let style = if notice.starts_with("Cannot") || notice.contains("failed") {
+            theme::red()
+        } else {
+            theme::green()
+        };
         buf.set_string(
             row_x,
             footer_y,
             crate::tui::text::ellipsize(notice, content_w),
-            theme::red(),
+            style,
         );
     } else {
         let hint = "\u{2191}\u{2193} move \u{00b7} type to filter \u{00b7} Ctrl+D delete \u{00b7} Ctrl+R refresh \u{00b7} Esc close";

--- a/src/tui/screens/known_hosts.rs
+++ b/src/tui/screens/known_hosts.rs
@@ -132,7 +132,7 @@ pub fn render_known_hosts(frame: &mut Frame, app: &App) {
             theme::amber(),
         );
     } else if let Some(notice) = &state.notice {
-        let style = if notice.starts_with("Cannot") || notice.contains("failed") {
+        let style = if state.notice_is_error {
             theme::red()
         } else {
             theme::green()

--- a/src/tui/screens/known_hosts.rs
+++ b/src/tui/screens/known_hosts.rs
@@ -99,10 +99,11 @@ pub fn render_known_hosts(frame: &mut Frame, app: &App) {
         );
 
         let type_col = (fp_x.saturating_sub(type_x)) as usize;
+        let type_str = entry.display_type();
         buf.set_string(
             type_x,
             ry,
-            crate::tui::text::ellipsize(&entry.display_type().to_uppercase(), type_col),
+            crate::tui::text::ellipsize(&type_str, type_col),
             dim,
         );
 
@@ -138,7 +139,7 @@ pub fn render_known_hosts(frame: &mut Frame, app: &App) {
             theme::red(),
         );
     } else {
-        let hint = "\u{2191}\u{2193} move \u{00b7} type to filter \u{00b7} d delete \u{00b7} r refresh \u{00b7} Esc close";
+        let hint = "\u{2191}\u{2193} move \u{00b7} type to filter \u{00b7} Ctrl+D delete \u{00b7} Ctrl+R refresh \u{00b7} Esc close";
         buf.set_string(
             row_x,
             footer_y,

--- a/src/tui/screens/known_hosts.rs
+++ b/src/tui/screens/known_hosts.rs
@@ -1,0 +1,182 @@
+use ratatui::layout::Rect;
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Clear};
+
+use crate::app::App;
+use crate::tui::theme;
+
+pub fn render_known_hosts(frame: &mut Frame, app: &App) {
+    let Some(state) = app.known_hosts.as_ref() else {
+        return;
+    };
+
+    let area = frame.area();
+    let popup_w = 78u16.min(area.width.saturating_sub(2));
+    let list_rows = area.height.saturating_sub(9).clamp(8, 20);
+    let popup_h = (list_rows + 7).min(area.height.saturating_sub(2));
+    let x = area.x + (area.width.saturating_sub(popup_w)) / 2;
+    let y = area.y + (area.height.saturating_sub(popup_h)) / 2;
+    let popup = Rect::new(x, y, popup_w, popup_h);
+
+    let popup = crate::tui::popup_open_rect(popup, app);
+
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(Span::styled(" Known Hosts ", theme::heading()))
+            .border_style(theme::popup_border()),
+        popup,
+    );
+
+    let buf = frame.buffer_mut();
+    let row_x = popup.x + 2;
+    let content_w = popup.width.saturating_sub(4) as usize;
+
+    let query_line = format!("\u{203a} {}\u{2588}", state.query);
+    buf.set_string(
+        row_x,
+        popup.y + 1,
+        crate::tui::text::ellipsize(&query_line, content_w),
+        theme::bright(),
+    );
+
+    let filtered: Vec<usize> = filtered_indices(state);
+    let visible = popup.height.saturating_sub(5) as usize;
+    let total = filtered.len();
+    let scroll = state.scroll.min(total.saturating_sub(visible));
+    let selected = if total == 0 {
+        0
+    } else {
+        state.selected.min(total - 1)
+    };
+
+    let host_x = row_x;
+    let marker_x = popup.x + 28;
+    let type_x = popup.x + 43;
+    let fp_x = popup.x + 52;
+
+    for (row, &fi) in filtered.iter().skip(scroll).take(visible).enumerate() {
+        let entry = &state.entries[fi];
+        let ry = popup.y + 3 + row as u16;
+        let is_sel = row == selected;
+        if is_sel {
+            let blank = " ".repeat(popup.width.saturating_sub(2) as usize);
+            buf.set_string(popup.x + 1, ry, &blank, theme::selected());
+        }
+        let base = if is_sel {
+            theme::white().bg(theme::SEL_BG)
+        } else {
+            theme::text()
+        };
+        let dim = if is_sel {
+            theme::mute().bg(theme::SEL_BG)
+        } else {
+            theme::mute()
+        };
+        let marker_str = if is_sel { "\u{203a} " } else { "  " };
+
+        let host_col = (marker_x.saturating_sub(host_x + 1)) as usize;
+        buf.set_string(
+            host_x,
+            ry,
+            crate::tui::text::ellipsize(&format!("{marker_str}{}", entry.display_host()), host_col),
+            base,
+        );
+
+        let marker_col = (type_x.saturating_sub(marker_x)) as usize;
+        let marker_text = match entry.marker {
+            Some(m) => m.to_string(),
+            None => String::new(),
+        };
+        buf.set_string(
+            marker_x,
+            ry,
+            crate::tui::text::ellipsize(&marker_text, marker_col),
+            dim,
+        );
+
+        let type_col = (fp_x.saturating_sub(type_x)) as usize;
+        buf.set_string(
+            type_x,
+            ry,
+            crate::tui::text::ellipsize(&entry.display_type().to_uppercase(), type_col),
+            dim,
+        );
+
+        let fp_col = popup.x.saturating_add(popup.width).saturating_sub(fp_x + 1) as usize;
+        let fp = entry.fingerprint.as_deref().unwrap_or("");
+        buf.set_string(fp_x, ry, crate::tui::text::ellipsize(fp, fp_col), dim);
+    }
+
+    let footer_y = popup.y + popup.height.saturating_sub(2);
+    if state.confirming_delete {
+        let sel_idx = filtered.get(selected).copied();
+        let msg = if let Some(fi) = sel_idx {
+            let e = &state.entries[fi];
+            if e.is_hashed() {
+                "Cannot delete hashed entry \u{2014} use ssh-keygen -R <host> manually".to_string()
+            } else {
+                format!("Delete ALL keys for {}? [y] yes  [n] no", e.display_host())
+            }
+        } else {
+            String::new()
+        };
+        buf.set_string(
+            row_x,
+            footer_y,
+            crate::tui::text::ellipsize(&msg, content_w),
+            theme::amber(),
+        );
+    } else if let Some(notice) = &state.notice {
+        buf.set_string(
+            row_x,
+            footer_y,
+            crate::tui::text::ellipsize(notice, content_w),
+            theme::red(),
+        );
+    } else {
+        let hint = "\u{2191}\u{2193} move \u{00b7} type to filter \u{00b7} d delete \u{00b7} r refresh \u{00b7} Esc close";
+        buf.set_string(
+            row_x,
+            footer_y,
+            crate::tui::text::ellipsize(hint, content_w),
+            theme::mute(),
+        );
+    }
+
+    let count_y = popup.y + popup.height.saturating_sub(1);
+    let count = format!(" {total} entries ");
+    buf.set_string(
+        popup.x + popup.width.saturating_sub(count.len() as u16 + 1),
+        count_y,
+        &count,
+        theme::mute(),
+    );
+}
+
+fn filtered_indices(state: &crate::app::KnownHostsState) -> Vec<usize> {
+    if state.query.is_empty() {
+        (0..state.entries.len()).collect()
+    } else {
+        let q = state.query.to_lowercase();
+        state
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| {
+                e.display_host().to_lowercase().contains(&q)
+                    || e.fingerprint
+                        .as_deref()
+                        .unwrap_or("")
+                        .to_lowercase()
+                        .contains(&q)
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+}
+
+pub fn filtered_indices_pub(state: &crate::app::KnownHostsState) -> Vec<usize> {
+    filtered_indices(state)
+}

--- a/src/tui/screens/known_hosts.rs
+++ b/src/tui/screens/known_hosts.rs
@@ -41,15 +41,17 @@ pub fn render_known_hosts(frame: &mut Frame, app: &App) {
         theme::bright(),
     );
 
-    let filtered: Vec<usize> = filtered_indices(state);
+    let filtered: Vec<usize> = state.filtered_indices();
     let visible = popup.height.saturating_sub(5) as usize;
     let total = filtered.len();
-    let scroll = state.scroll.min(total.saturating_sub(visible));
     let selected = if total == 0 {
         0
     } else {
         state.selected.min(total - 1)
     };
+    let scroll = selected
+        .saturating_sub(visible.saturating_sub(1))
+        .min(total.saturating_sub(visible));
 
     let host_x = row_x;
     let marker_x = popup.x + 28;
@@ -59,7 +61,7 @@ pub fn render_known_hosts(frame: &mut Frame, app: &App) {
     for (row, &fi) in filtered.iter().skip(scroll).take(visible).enumerate() {
         let entry = &state.entries[fi];
         let ry = popup.y + 3 + row as u16;
-        let is_sel = row == selected;
+        let is_sel = scroll + row == selected;
         if is_sel {
             let blank = " ".repeat(popup.width.saturating_sub(2) as usize);
             buf.set_string(popup.x + 1, ry, &blank, theme::selected());
@@ -153,30 +155,4 @@ pub fn render_known_hosts(frame: &mut Frame, app: &App) {
         &count,
         theme::mute(),
     );
-}
-
-fn filtered_indices(state: &crate::app::KnownHostsState) -> Vec<usize> {
-    if state.query.is_empty() {
-        (0..state.entries.len()).collect()
-    } else {
-        let q = state.query.to_lowercase();
-        state
-            .entries
-            .iter()
-            .enumerate()
-            .filter(|(_, e)| {
-                e.display_host().to_lowercase().contains(&q)
-                    || e.fingerprint
-                        .as_deref()
-                        .unwrap_or("")
-                        .to_lowercase()
-                        .contains(&q)
-            })
-            .map(|(i, _)| i)
-            .collect()
-    }
-}
-
-pub fn filtered_indices_pub(state: &crate::app::KnownHostsState) -> Vec<usize> {
-    filtered_indices(state)
 }

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -10,6 +10,7 @@ pub mod keybind_editor;
 pub mod keychain;
 pub mod keygen;
 pub mod keys;
+pub mod known_hosts;
 pub mod palette;
 pub mod push_key_pickers;
 pub mod session_picker;


### PR DESCRIPTION
## What changed

Implements the known_hosts manager from issue #7.

### Parser (`src/known_hosts.rs`)
- Pure parser for `~/.ssh/known_hosts`: markers (`@cert-authority`, `@revoked`), hashed entries (`|1|...`), port-qualified (`[host]:port`), comments, blank lines, malformed lines skipped
- Fingerprint join from `ssh-keygen -l -f` by `(name, type)` — handles `ssh-*`, `ecdsa-*`, `sk-*` key types; marker rows skipped (ssh-keygen omits them)
- Deletion via `ssh-keygen -R` per host (splits comma-separated multi-host entries), explicit `-f`, rejects names starting with `-`
- Preflight on a temp copy refuses deletes that would also remove matching wildcard entries
- First-connect fingerprint extraction from `ssh -v` debug log — anchored to `debug1: Server host key:` prefix with key-type and base64 charset/length validation (rejects spoofed ident lines)

### Overlay (`H` on Keys tab)
- Lists entries: host (or `(hashed)`), marker, key type, fingerprint
- Type-to-filter by host or fingerprint
- `Ctrl+D` to delete with confirmation (hashed / CA / revoked / wildcard refused; plain deletes that would nuke wildcards refused)
- `Ctrl+R` to refresh from disk, `Esc` to close
- Scroll follows selection past the visible window

### First-connect fingerprint
- Connect screen shows cached first-wins host key fingerprint from the `-v` stderr stream — read-only, no changes to `StrictHostKeyChecking` or trust decisions

### Keybinding
- `KeyAction::KnownHosts` (default `H` / Shift+H)
- Help rebound to `?` only; one-shot migration strips stale `Shift+H` from persisted `help` so upgrading users can reach the overlay

### Not touched
`src/app/connect.rs`, `src/credentials.rs`, `src/app/host_form.rs`, `src/app/identities.rs`, `.github/workflows/*`.

## Test plan

- [x] `just test` green (611 unit + 73 e2e + 42 smoke + 1 config_load)
- [x] `cargo fmt --check` / `cargo clippy --all-targets` clean
- [x] Adversarial review findings addressed (keybind migration, wildcard collateral, fp cache)
- [x] Parser / deletion / spoof / upgrade-path / wildcard-collateral tests
- [x] Overlay included in tiny-terminal render smoke test

Closes #7

_Written by Cursor Grok 4.5 (Cursor) on behalf of the maintainer._