### PR TITLE
fix(session): relay OSC 52 clipboard writes out of the PTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable changes to SSHub are documented in this file.
 ### Fixed
 
 - **Copying inside a session reaches your clipboard again when the copy comes
-  from the app running in the PTY** - a nested multiplexer (herdr, tmux), or an
-  editor set to `clipboard=osc52`, would highlight a selection and report a copy
-  while the clipboard never changed. Those apps copy by writing
+  from the app running in the PTY** (PR #88 by @michabbb) - a nested multiplexer
+  (herdr, tmux), or an editor set to `clipboard=osc52`, would highlight a
+  selection and report a copy while the clipboard never changed. Those apps copy
+  by writing
   `ESC ] 52 ; c ; <base64> BEL` to their stdout, which is our PTY; `vt100` parses
   it and hands it to `Callbacks::copy_to_clipboard`, and the default `()` impl
   that SSHub used is a no-op - so the sequence was parsed and dropped, with no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to SSHub are documented in this file.
 
 ### Fixed
 
+- **Copying inside a session reaches your clipboard again when the copy comes
+  from the app running in the PTY** - a nested multiplexer (herdr, tmux), or an
+  editor set to `clipboard=osc52`, would highlight a selection and report a copy
+  while the clipboard never changed. Those apps copy by writing
+  `ESC ] 52 ; c ; <base64> BEL` to their stdout, which is our PTY; `vt100` parses
+  it and hands it to `Callbacks::copy_to_clipboard`, and the default `()` impl
+  that SSHub used is a no-op - so the sequence was parsed and dropped, with no
+  passthrough to our own stdout. The parser now collects those writes and the
+  session re-emits them toward the hosting terminal. This matters most where the
+  inner app owns the selection: SSHub's own Shift+drag can't stand in for it,
+  because SSHub sees one flat character grid and reads every intermediate line
+  out to the full terminal width - across a split layout that drags in the
+  neighbouring panes and their borders.
+
+  Since this lets the remote side write to your clipboard, every relay raises a
+  visible notice, payloads are capped at 64 KiB, and the queue is bounded so a
+  copy loop can't flood it. Clipboard *reads* stay refused: `ESC]52;c;?BEL` is
+  still unanswered, so no host can ask what you have copied.
 - **The README GIFs and screenshots are recorded from the terminal stream now,
   not screenshotted** - and four of the five GIFs had no animation in them at
   all. Two separate faults: every tape except `hero` switched

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,21 @@ All notable changes to SSHub are documented in this file.
   out to the full terminal width - across a split layout that drags in the
   neighbouring panes and their borders.
 
-  Since this lets the remote side write to your clipboard, every relay raises a
-  visible notice, payloads are capped at 64 KiB, and the queue is bounded so a
-  copy loop can't flood it. Clipboard *reads* stay refused: `ESC]52;c;?BEL` is
-  still unanswered, so no host can ask what you have copied.
+  Since this lets the remote side write to your clipboard, it is narrow and
+  visible: only the session you are actually looking at may relay, so a
+  background tab, the dashboard, SFTP or the tunnels view drop what their PTY
+  asked for on the spot - and never replay it when you switch to that tab.
+  Payloads are capped at 64 KiB and the queue is bounded, with both kinds of
+  drop counted apart and named in the notice, so a copy that was thrown away is
+  never hidden behind the success message. An empty write is ignored outright:
+  a remote cannot clear your clipboard. Clipboard *reads* stay refused:
+  `ESC]52;c;?BEL` is still unanswered, so no host can ask what you have copied.
+
+  The relay is on by default and can be switched off with `relay_from_pty =
+  false` under a new `[clipboard]` section in `config.toml`; configs written
+  before that section existed keep the default. Note that the OSC 52 sequence
+  travels in the raw PTY stream, so an enabled session log can already contain
+  it - relaying does not add it to the log, but it does not remove it either.
 - **The README GIFs and screenshots are recorded from the terminal stream now,
   not screenshotted** - and four of the five GIFs had no animation in them at
   all. Two separate faults: every tape except `hero` switched

--- a/README.md
+++ b/README.md
@@ -334,6 +334,9 @@ initial_delay_ms = 1000     # 1 s (R overlay edits delays in seconds)
 max_delay_ms = 60000        # 60 s
 stable_secs = 5             # uptime before a spawn counts as up
 jitter_ratio = 0.25
+
+[clipboard]
+relay_from_pty = true       # let apps inside a session copy to your clipboard
 ```
 
 ## Development

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -190,6 +190,67 @@ impl App {
         self.sessions.get_mut(idx)
     }
 
+    /// Does this frame hand the whole screen to the session renderer?
+    ///
+    /// The single source of truth for "a session is on screen": `render_inner`
+    /// draws from it, and the OSC 52 relay gate reads it to decide whether a
+    /// PTY may reach the host clipboard at all. The session picker draws on top
+    /// of a session that keeps rendering behind it, so that case counts.
+    pub(crate) fn session_is_rendered(&self) -> bool {
+        matches!(self.mode, AppMode::Connecting | AppMode::Session)
+            || self.session_picker_over_session()
+    }
+
+    /// The session picker opened from a session (rather than the dashboard), so
+    /// the session is still painted underneath it.
+    pub(crate) fn session_picker_over_session(&self) -> bool {
+        self.mode == AppMode::SessionPicker
+            && self
+                .session_picker
+                .as_ref()
+                .is_some_and(|p| matches!(p.return_mode, AppMode::Connecting | AppMode::Session))
+    }
+
+    /// Index of the session actually painted this frame, if any.
+    pub(crate) fn visible_session_idx(&self) -> Option<usize> {
+        self.session_is_rendered()
+            .then_some(self.active_session)
+            .flatten()
+    }
+
+    /// Per-frame OSC 52 handling for every session's PTY.
+    ///
+    /// Only the session the user is looking at may put something on the host
+    /// clipboard, and only while `clipboard.relay_from_pty` is on. Every other
+    /// session discards what it saw immediately: a background tab must not be
+    /// able to change the clipboard now, and must not replay an old write when
+    /// it later comes to the front.
+    pub(crate) fn relay_visible_session_clipboard(&mut self) {
+        self.relay_pty_clipboard_with(crate::osc52::write_b64);
+    }
+
+    /// [`Self::relay_visible_session_clipboard`] with an injectable sink, so
+    /// tests can watch the relay without touching the real clipboard.
+    pub(crate) fn relay_pty_clipboard_with(
+        &mut self,
+        emit: impl FnMut(&str) -> std::io::Result<()>,
+    ) {
+        let relaying = self
+            .config
+            .clipboard
+            .relay_from_pty
+            .then(|| self.visible_session_idx())
+            .flatten();
+        let mut emit = emit;
+        for (i, session) in self.sessions.iter_mut().enumerate() {
+            if Some(i) == relaying {
+                session.relay_clipboard_writes_with(&mut emit);
+            } else {
+                session.discard_clipboard_writes();
+            }
+        }
+    }
+
     /// Return to the dashboard without tearing down background sessions.
     pub fn detach_to_dashboard(&mut self) {
         if self.sessions.is_empty() {

--- a/src/app/tests/misc.rs
+++ b/src/app/tests/misc.rs
@@ -92,6 +92,7 @@ pub(crate) fn paste_in_normal_mode_is_ignored() {
 
 #[test]
 pub(crate) fn base64_encode_known_vectors() {
+    use crate::osc52::base64_encode;
     // Test the standard test vectors plus a few padding cases.
     assert_eq!(base64_encode(b""), "");
     assert_eq!(base64_encode(b"f"), "Zg==");

--- a/src/app/tests/session.rs
+++ b/src/app/tests/session.rs
@@ -878,3 +878,117 @@ pub(crate) fn sftp_o_still_opens_left_pane_picker_with_background_session() {
         Some(crate::app::SessionPickerPurpose::SftpLeftPane)
     );
 }
+
+// A PTY may only reach the host clipboard while the user is looking at that
+// session — otherwise a background host could change it unnoticed.
+
+// "R0VIRUlN" == base64("GEHEIM").
+fn app_with_pending_clipboard_writes(n: usize) -> App {
+    let mut app = test_app(vec![("edge", host("edge"))]);
+    app.terminal_area = ratatui::layout::Rect::new(0, 0, 80, 24);
+    for i in 0..n {
+        let cfg = crate::session::SessionConfig {
+            argv: vec!["true".into()],
+            display_name: format!("s{i}"),
+            meta: crate::session::SessionMeta::default(),
+            pending_secret: None,
+            key_push_identity: None,
+            host_name: format!("s{i}"),
+        };
+        let mut session = crate::session::Session::spawn(cfg, 24, 80, None).unwrap();
+        session.parser.process(b"\x1b]52;c;R0VIRUlN\x07");
+        app.sessions.push(session);
+    }
+    app.active_session = Some(0);
+    app
+}
+
+/// One frame's relay pass, collecting what would have reached the terminal.
+fn relay_frame(app: &mut App) -> Vec<String> {
+    let mut sent = Vec::new();
+    app.relay_pty_clipboard_with(|payload| {
+        sent.push(payload.to_string());
+        Ok(())
+    });
+    sent
+}
+
+#[test]
+pub(crate) fn only_the_visible_session_relays_its_clipboard_write() {
+    let mut app = app_with_pending_clipboard_writes(2);
+    app.mode = AppMode::Session;
+
+    assert_eq!(
+        relay_frame(&mut app).len(),
+        1,
+        "exactly the visible session may relay"
+    );
+    assert!(app.sessions[0].copy_notice.is_some());
+    assert!(
+        app.sessions[1].copy_notice.is_none(),
+        "a background tab must not announce a copy"
+    );
+}
+
+#[test]
+pub(crate) fn a_background_sessions_write_is_not_replayed_when_it_comes_to_the_front() {
+    let mut app = app_with_pending_clipboard_writes(2);
+    app.mode = AppMode::Session;
+    let _ = relay_frame(&mut app);
+
+    app.active_session = Some(1);
+    assert!(
+        relay_frame(&mut app).is_empty(),
+        "a discarded write must never be sent later"
+    );
+}
+
+#[test]
+pub(crate) fn the_dashboard_relays_nothing_and_keeps_nothing() {
+    let mut app = app_with_pending_clipboard_writes(1);
+    app.mode = AppMode::Normal;
+
+    assert!(
+        relay_frame(&mut app).is_empty(),
+        "no session is on screen, so nothing may reach the clipboard"
+    );
+
+    app.mode = AppMode::Session;
+    assert!(relay_frame(&mut app).is_empty());
+}
+
+#[test]
+pub(crate) fn the_sftp_browser_relays_nothing() {
+    let mut app = app_with_pending_clipboard_writes(1);
+    app.mode = AppMode::Normal;
+    app.active_tab = 1;
+    app.sftp = Some(crate::sftp::model::SftpState::new("/srv", "/home/me"));
+
+    assert!(relay_frame(&mut app).is_empty());
+}
+
+#[test]
+pub(crate) fn a_session_under_the_picker_is_still_visible() {
+    // The picker draws on top; the session keeps rendering behind it.
+    let mut app = app_with_pending_clipboard_writes(1);
+    app.mode = AppMode::Session;
+    app.open_session_picker(crate::app::SessionPickerPurpose::SwitchSession);
+
+    assert_eq!(relay_frame(&mut app).len(), 1);
+}
+
+#[test]
+pub(crate) fn the_config_opt_out_drops_every_relay() {
+    let mut app = app_with_pending_clipboard_writes(1);
+    app.mode = AppMode::Session;
+    app.config.clipboard.relay_from_pty = false;
+
+    assert!(
+        relay_frame(&mut app).is_empty(),
+        "relay_from_pty = false must drop PTY clipboard writes"
+    );
+    assert!(
+        app.sessions[0].copy_notice.is_none(),
+        "an opted-out relay must stay silent"
+    );
+}

--- a/src/app/util.rs
+++ b/src/app/util.rs
@@ -276,11 +276,6 @@ pub(crate) fn optional_path(raw: &str) -> Option<std::path::PathBuf> {
     optional_field(raw).map(std::path::PathBuf::from)
 }
 
-/// Write an OSC 52 set-clipboard sequence to stdout. Modern terminals
-/// (kitty / iTerm2 / wezterm / Alacritty / foot) interpret this as
-/// "put this base64-encoded payload on the system clipboard". The
-/// sequence is invisible to the alternate-screen UI — the host terminal
-/// consumes it before it ever lands on a buffer cell.
 /// Copy `secret` to the clipboard and return the notice to show. `what` names it
 /// ("password", "passphrase"); the value itself never reaches the message, the
 /// audit log or any diagnostic.
@@ -294,47 +289,14 @@ pub(crate) fn copy_secret_notice(secret: &str, what: &str) -> String {
     }
 }
 
+/// Put `text` on the host clipboard via OSC 52. Modern terminals (kitty /
+/// iTerm2 / wezterm / Alacritty / foot) interpret the sequence as "put this
+/// base64-encoded payload on the system clipboard"; it is invisible to the
+/// alternate-screen UI because the host terminal consumes it before it ever
+/// lands on a buffer cell. Framing lives in [`crate::osc52`], shared with the
+/// session's PTY clipboard relay.
 pub(crate) fn write_osc52(text: &str) -> std::io::Result<()> {
-    use std::io::Write;
-    let encoded = base64_encode(text.as_bytes());
-    let payload = format!("\x1b]52;c;{encoded}\x07");
-    let mut out = std::io::stdout().lock();
-    out.write_all(payload.as_bytes())?;
-    out.flush()
-}
-
-/// Tiny base64 (standard alphabet, padded). Inlined so we don't pull in
-/// another crate for a single ~20 line helper used in one place.
-pub(crate) fn base64_encode(input: &[u8]) -> String {
-    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
-    let mut chunks = input.chunks_exact(3);
-    for chunk in chunks.by_ref() {
-        let b = ((chunk[0] as u32) << 16) | ((chunk[1] as u32) << 8) | (chunk[2] as u32);
-        out.push(ALPHABET[((b >> 18) & 0x3f) as usize] as char);
-        out.push(ALPHABET[((b >> 12) & 0x3f) as usize] as char);
-        out.push(ALPHABET[((b >> 6) & 0x3f) as usize] as char);
-        out.push(ALPHABET[(b & 0x3f) as usize] as char);
-    }
-    let rem = chunks.remainder();
-    match rem.len() {
-        1 => {
-            let b = (rem[0] as u32) << 16;
-            out.push(ALPHABET[((b >> 18) & 0x3f) as usize] as char);
-            out.push(ALPHABET[((b >> 12) & 0x3f) as usize] as char);
-            out.push('=');
-            out.push('=');
-        }
-        2 => {
-            let b = ((rem[0] as u32) << 16) | ((rem[1] as u32) << 8);
-            out.push(ALPHABET[((b >> 18) & 0x3f) as usize] as char);
-            out.push(ALPHABET[((b >> 12) & 0x3f) as usize] as char);
-            out.push(ALPHABET[((b >> 6) & 0x3f) as usize] as char);
-            out.push('=');
-        }
-        _ => {}
-    }
-    out
+    crate::osc52::write_text(text)
 }
 
 /// Expand a leading `~` (or `~/`) in a path to the user's home directory.

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,27 @@ impl Default for SessionLoggingConfig {
     }
 }
 
+/// Clipboard behaviour. Currently only governs what the *remote* side may do:
+/// SSHub's own copy shortcuts are unaffected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClipboardConfig {
+    /// Relay OSC 52 clipboard writes emitted by applications inside a session
+    /// PTY to the host clipboard. On by default — that is what makes copying
+    /// inside a nested multiplexer or `clipboard=osc52` editor work at all.
+    /// Set to `false` to drop those writes: the remote then cannot touch the
+    /// local clipboard.
+    #[serde(default = "default_true")]
+    pub relay_from_pty: bool,
+}
+
+impl Default for ClipboardConfig {
+    fn default() -> Self {
+        Self {
+            relay_from_pty: true,
+        }
+    }
+}
+
 fn default_tunnel_reconnect_max_attempts() -> u32 {
     12
 }
@@ -247,6 +268,8 @@ pub struct AppConfig {
     pub tunnel_reconnect: TunnelReconnectConfig,
     #[serde(default)]
     pub keybinds: KeybindsConfig,
+    #[serde(default)]
+    pub clipboard: ClipboardConfig,
 }
 
 /// Path to `config.toml` inside [`config_dir`].
@@ -441,6 +464,27 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clipboard_relay_defaults_to_on_for_configs_without_the_section() {
+        // Every config written before the section existed must keep behaving
+        // exactly as it did — the relay is opt-out, not opt-in.
+        let config = parse_config_str("").unwrap();
+        assert!(config.clipboard.relay_from_pty);
+        assert!(AppConfig::default().clipboard.relay_from_pty);
+    }
+
+    #[test]
+    fn clipboard_relay_can_be_switched_off() {
+        let config = parse_config_str("[clipboard]\nrelay_from_pty = false\n").unwrap();
+        assert!(!config.clipboard.relay_from_pty);
+    }
+
+    #[test]
+    fn an_empty_clipboard_section_keeps_the_default() {
+        let config = parse_config_str("[clipboard]\n").unwrap();
+        assert!(config.clipboard.relay_from_pty);
+    }
 
     #[test]
     fn save_config_preserves_comments_and_unknown_keys() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod hosts;
 pub mod import;
 pub mod keybinds;
 pub mod metadata;
+pub(crate) mod osc52;
 pub mod osinfo;
 pub mod ping;
 pub mod search;
@@ -202,13 +203,21 @@ fn run_terminal_loop(app: &mut App, auto_quit: Option<&str>) -> Result<()> {
             if s.is_connected() && !was_connected {
                 newly_connected.push(s.display_name.clone());
             }
+        }
+
+        // Every session's PTY was drained above, but only the one on screen may
+        // put an OSC 52 write on the host clipboard; the rest is dropped now
+        // rather than queued for whenever that tab is brought to the front.
+        // Runs before diagnostics are collected so a failed relay reaches the
+        // log in this frame — a session closing right after would lose it.
+        app.relay_visible_session_clipboard();
+
+        for s in app.sessions.iter_mut() {
             let connected = s.is_connected();
             for line in s.take_diagnostics() {
-                // Handshake diagnostics only; after connect keep session-exit lines.
-                let keep = !connected
-                    || line.starts_with("session:")
-                    || line.starts_with("auth: could not");
-                if keep {
+                // Handshake diagnostics only; after connect keep session-exit
+                // lines and anything else the session itself reports.
+                if crate::session::keep_diagnostic(&line, connected) {
                     diag_entries.push((s.display_name.clone(), line));
                 }
             }

--- a/src/osc52.rs
+++ b/src/osc52.rs
@@ -1,0 +1,114 @@
+//! The single place OSC 52 ("set clipboard") sequences are framed.
+//!
+//! Two callers need it: `app::util` copies a stored secret out of SSHub itself,
+//! and the session relay forwards a clipboard write that an application inside
+//! the PTY emitted. Both go through here so the framing — and the selector
+//! decision below — exists exactly once.
+
+use std::io::Write;
+
+/// Frame an already-base64-encoded payload and write it to `out`.
+///
+/// The selector is pinned to `c` (host clipboard) instead of being forwarded.
+/// That is a deliberate normalisation: a payload vt100 handed us with selector
+/// `p` (the X11 *primary selection*) is relayed as `c`, i.e. it lands on the
+/// host clipboard rather than a primary selection of its own. Terminals differ
+/// wildly in which selectors they accept, and several drop the whole sequence
+/// when they meet one they don't know — a copy that silently does nothing is
+/// worse than a copy that lands one selection over.
+///
+/// `payload` is expected to be base64 already. For the relay path vt100 has
+/// validated the alphabet before handing it over, which is what rules out
+/// ESC/BEL injection; this helper deliberately adds no second validation.
+pub(crate) fn write_b64_to(out: &mut impl Write, payload: &str) -> std::io::Result<()> {
+    out.write_all(format!("\x1b]52;c;{payload}\x07").as_bytes())?;
+    out.flush()
+}
+
+/// Base64-encode plain `text` and write it through [`write_b64_to`].
+pub(crate) fn write_text_to(out: &mut impl Write, text: &str) -> std::io::Result<()> {
+    write_b64_to(out, &base64_encode(text.as_bytes()))
+}
+
+/// [`write_b64_to`] against the process's stdout — the terminal hosting SSHub.
+pub(crate) fn write_b64(payload: &str) -> std::io::Result<()> {
+    write_b64_to(&mut std::io::stdout().lock(), payload)
+}
+
+/// [`write_text_to`] against the process's stdout.
+pub(crate) fn write_text(text: &str) -> std::io::Result<()> {
+    write_text_to(&mut std::io::stdout().lock(), text)
+}
+
+/// Tiny base64 (standard alphabet, padded). Inlined so we don't pull in
+/// another crate for a single ~20 line helper.
+pub(crate) fn base64_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    let mut chunks = input.chunks_exact(3);
+    for chunk in chunks.by_ref() {
+        let b = ((chunk[0] as u32) << 16) | ((chunk[1] as u32) << 8) | (chunk[2] as u32);
+        out.push(ALPHABET[((b >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHABET[((b >> 12) & 0x3f) as usize] as char);
+        out.push(ALPHABET[((b >> 6) & 0x3f) as usize] as char);
+        out.push(ALPHABET[(b & 0x3f) as usize] as char);
+    }
+    let rem = chunks.remainder();
+    match rem.len() {
+        1 => {
+            let b = (rem[0] as u32) << 16;
+            out.push(ALPHABET[((b >> 18) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((b >> 12) & 0x3f) as usize] as char);
+            out.push('=');
+            out.push('=');
+        }
+        2 => {
+            let b = ((rem[0] as u32) << 16) | ((rem[1] as u32) << 8);
+            out.push(ALPHABET[((b >> 18) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((b >> 12) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((b >> 6) & 0x3f) as usize] as char);
+            out.push('=');
+        }
+        _ => {}
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn b64_payload_is_framed_with_the_c_selector() {
+        let mut out = Vec::new();
+        write_b64_to(&mut out, "R0VIRUlN").unwrap();
+        assert_eq!(out, b"\x1b]52;c;R0VIRUlN\x07");
+    }
+
+    #[test]
+    fn plain_text_is_encoded_then_framed() {
+        let mut out = Vec::new();
+        write_text_to(&mut out, "GEHEIM").unwrap();
+        assert_eq!(out, b"\x1b]52;c;R0VIRUlN\x07");
+    }
+
+    #[test]
+    fn both_entry_points_share_one_framing_path() {
+        // Guards the review point that OSC 52 must have a single production
+        // implementation: encoding "GEHEIM" and relaying its base64 must
+        // produce byte-identical output.
+        let mut from_text = Vec::new();
+        write_text_to(&mut from_text, "GEHEIM").unwrap();
+        let mut from_b64 = Vec::new();
+        write_b64_to(&mut from_b64, &base64_encode(b"GEHEIM")).unwrap();
+        assert_eq!(from_text, from_b64);
+    }
+
+    #[test]
+    fn base64_encode_pads() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"GEHEIM"), "R0VIRUlN");
+        assert_eq!(base64_encode(b"hello"), "aGVsbG8=");
+        assert_eq!(base64_encode(b"a"), "YQ==");
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -507,7 +507,6 @@ impl Session {
             }
         }
         if had_bytes {
-            self.relay_clipboard_writes();
             self.maybe_send_pending_secret();
             self.maybe_reveal();
         }
@@ -524,38 +523,56 @@ impl Session {
         self.maybe_detect_connected();
     }
 
+    /// Throw away whatever the PTY asked us to copy, including the drop
+    /// counters. Used for every session that is not the visible one this
+    /// frame, so a background tab can neither relay now nor replay later.
+    pub(crate) fn discard_clipboard_writes(&mut self) {
+        let _ = self.parser.take_clipboard_writes();
+        let _ = self.parser.take_clipboard_drops();
+    }
+
     /// Forward OSC 52 clipboard writes emitted by applications inside the PTY
     /// to the terminal hosting sshub. Without this the sequence dies in our
     /// vt100 parser: a nested multiplexer (herdr, tmux) or an editor with
     /// `clipboard=osc52` appears to copy — the selection even highlights —
     /// but nothing ever reaches the system clipboard.
     ///
-    /// Relaying means the remote side can write to the local clipboard, so
-    /// every relay raises a visible notice: a clipboard change the user didn't
-    /// ask for is worth noticing. The payload itself never lands in the notice,
-    /// the diagnostics or the session log.
-    fn relay_clipboard_writes(&mut self) {
-        self.relay_clipboard_writes_with(parser::emit_osc52_b64);
-    }
-
-    /// Relay with an injectable sink. Tests drive this directly: the real sink
-    /// writes to the process's stdout, which the test harness does *not*
-    /// capture (it only intercepts the `print!` macros), so exercising it under
-    /// `cargo test` would clobber the clipboard of whoever ran the suite.
-    fn relay_clipboard_writes_with(&mut self, mut emit: impl FnMut(&str) -> std::io::Result<()>) {
+    /// Only the session the user is actually looking at may relay; that
+    /// decision belongs to the frame, so this is driven from
+    /// [`crate::App::relay_visible_session_clipboard`] and every other session
+    /// discards instead. Relaying means the remote side can write to the local
+    /// clipboard, so the outcome is always visible: a clipboard change the user
+    /// didn't ask for is worth noticing, and so is one that was thrown away.
+    ///
+    /// The relay path itself never puts the payload into the notice, the
+    /// diagnostics or the session log — but the OSC 52 sequence travels in the
+    /// raw PTY stream, so an enabled session log can already contain it. This
+    /// neither adds it nor removes it.
+    ///
+    /// The sink is injectable because the real one writes to the process's
+    /// stdout, which the test harness does *not* capture (it only intercepts
+    /// the `print!` macros), so exercising it under `cargo test` would clobber
+    /// the clipboard of whoever ran the suite.
+    pub(crate) fn relay_clipboard_writes_with(
+        &mut self,
+        mut emit: impl FnMut(&str) -> std::io::Result<()>,
+    ) {
         let mut relayed = None;
         for payload in self.parser.take_clipboard_writes() {
             match emit(&payload) {
                 // Several writes in one tick collapse into one notice (the last
                 // one wins), so a copy loop can't flood the corner of the screen.
                 Ok(()) => relayed = Some(parser::decoded_len(payload.as_bytes())),
+                // Prefixed `session:` so the event loop's connected-session
+                // filter keeps it — see [`keep_diagnostic`].
                 Err(e) => self
                     .diagnostics
-                    .push(format!("clipboard relay failed: {e}")),
+                    .push(format!("session: clipboard relay failed: {e}")),
             }
         }
-        if let Some(bytes) = relayed {
-            self.set_copy_notice(format!("remote copied {bytes} bytes to clipboard"));
+        let drops = self.parser.take_clipboard_drops();
+        if let Some(msg) = clipboard_notice(relayed, drops) {
+            self.set_copy_notice(msg);
         }
     }
 
@@ -1072,6 +1089,70 @@ mod selection_tests {
     }
 }
 
+/// The one line shown after a batch of PTY clipboard writes, or `None` when
+/// nothing worth reporting happened.
+///
+/// A batch that both copied and dropped has to say both: reporting only the
+/// success would hide the loss behind good news.
+fn clipboard_notice(relayed_bytes: Option<usize>, drops: parser::ClipboardDrops) -> Option<String> {
+    let dropped = match (drops.oversize, drops.queue_full) {
+        (0, 0) => None,
+        (n, 0) => Some(format!("{n} oversized {}", plural_writes(n))),
+        (0, n) => Some(format!("{n} over the queue limit")),
+        (a, b) => Some(format!(
+            "{a} oversized {}, {b} over the queue limit",
+            plural_writes(a)
+        )),
+    };
+    match (relayed_bytes, dropped) {
+        (Some(bytes), None) => Some(format!("remote copied {bytes} bytes to clipboard")),
+        (Some(bytes), Some(d)) => Some(format!(
+            "remote copied {bytes} bytes to clipboard; dropped {d}"
+        )),
+        (None, Some(d)) => Some(format!("clipboard relay dropped {d}")),
+        (None, None) => None,
+    }
+}
+
+fn plural_writes(n: usize) -> &'static str {
+    if n == 1 {
+        "write"
+    } else {
+        "writes"
+    }
+}
+
+/// Should a session diagnostic reach the SSH log panel?
+///
+/// Before a session is connected everything is interesting — it is the record
+/// of a handshake that may be failing. Once connected the loop would otherwise
+/// bury the panel under routine chatter, so only lines that stay relevant are
+/// kept: anything the session itself reports (`session:` — exits, and the
+/// clipboard relay failing) plus unresolved auth problems.
+///
+/// The event loop calls exactly this function, so a diagnostic can be tested
+/// against the contract that actually governs it.
+pub(crate) fn keep_diagnostic(line: &str, connected: bool) -> bool {
+    !connected || line.starts_with("session:") || line.starts_with("auth: could not")
+}
+
+#[cfg(test)]
+mod diagnostic_filter_tests {
+    use super::keep_diagnostic;
+
+    #[test]
+    fn everything_survives_before_connect() {
+        assert!(keep_diagnostic("auth: trying key", false));
+    }
+
+    #[test]
+    fn connected_keeps_only_session_and_auth_failures() {
+        assert!(keep_diagnostic("session: ssh exited (code 1)", true));
+        assert!(keep_diagnostic("auth: could not read key", true));
+        assert!(!keep_diagnostic("auth: trying key", true));
+    }
+}
+
 #[cfg(test)]
 mod autoscroll_tests {
     use super::edge_autoscroll_dir;
@@ -1182,6 +1263,50 @@ mod prompt_tests {
         );
     }
 
+    #[test]
+    fn draining_the_pty_does_not_relay_by_itself() {
+        // Draining happens for every session, every frame — including the ones
+        // nobody is looking at. Deciding whether a write may reach the host
+        // clipboard is the frame's job (it knows which tab is on screen), so
+        // `drain` must leave the queue alone.
+        let config = SessionConfig {
+            argv: vec![
+                "sh".into(),
+                "-c".into(),
+                r"printf '\033]52;c;R0VIRUlN\007MARKER'".into(),
+            ],
+            display_name: "t".into(),
+            meta: SessionMeta::default(),
+            pending_secret: None,
+            key_push_identity: None,
+            host_name: "t".into(),
+        };
+        let mut s = Session::spawn(config, 24, 80, None).unwrap();
+
+        for _ in 0..200 {
+            s.drain();
+            if s.screen_tail_snippet().contains("MARKER") {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            s.screen_tail_snippet().contains("MARKER"),
+            "PTY output never arrived, tail: {:?}",
+            s.screen_tail_snippet()
+        );
+
+        assert!(
+            s.copy_notice.is_none(),
+            "drain must not announce a copy on its own"
+        );
+        assert_eq!(
+            s.parser.take_clipboard_writes(),
+            vec!["R0VIRUlN".to_string()],
+            "drain must leave the clipboard write for the frame to decide on"
+        );
+    }
+
     /// Build a throwaway session for tests that only need a live `Session`.
     fn scratch_session() -> Session {
         let config = SessionConfig {
@@ -1241,6 +1366,117 @@ mod prompt_tests {
                 .iter()
                 .any(|d| d.contains("clipboard relay failed")),
             "a failed relay must surface in diagnostics"
+        );
+    }
+
+    #[test]
+    fn a_mixed_batch_names_the_copy_and_the_drops() {
+        // A batch that both relayed something and dropped something must say
+        // so: the success message alone would hide the loss.
+        let mut s = scratch_session();
+        let mut stream = b"\x1b]52;c;R0VIRUlN\x07\x1b]52;c;".to_vec();
+        stream.extend(std::iter::repeat_n(b'A', 90_000));
+        stream.push(0x07);
+        s.parser.process(&stream);
+
+        s.relay_clipboard_writes_with(|_| Ok(()));
+
+        assert_eq!(
+            s.copy_notice.as_ref().map(|(m, _)| m.as_str()),
+            Some("remote copied 6 bytes to clipboard; dropped 1 oversized write"),
+        );
+    }
+
+    #[test]
+    fn drops_alone_are_still_announced() {
+        // Nothing was relayed, but the user must learn a copy was thrown away.
+        let mut s = scratch_session();
+        let mut stream = b"\x1b]52;c;".to_vec();
+        stream.extend(std::iter::repeat_n(b'A', 90_000));
+        stream.push(0x07);
+        for _ in 0..20 {
+            stream.extend_from_slice(b"\x1b]52;c;R0VIRUlN\x07");
+        }
+        s.parser.process(&stream);
+        // Take the queued writes away, so only the drops remain to report.
+        let _ = s.parser.take_clipboard_writes();
+
+        s.relay_clipboard_writes_with(|_| Ok(()));
+
+        assert_eq!(
+            s.copy_notice.as_ref().map(|(m, _)| m.as_str()),
+            Some("clipboard relay dropped 1 oversized write, 12 over the queue limit"),
+        );
+    }
+
+    #[test]
+    fn an_empty_payload_produces_no_notice_at_all() {
+        // `ESC]52;c;BEL` must not relay, must not clear, must not claim success.
+        let mut s = scratch_session();
+        s.parser.process(b"\x1b]52;c;\x07");
+
+        let mut sent = 0usize;
+        s.relay_clipboard_writes_with(|_| {
+            sent += 1;
+            Ok(())
+        });
+
+        assert_eq!(sent, 0);
+        assert!(s.copy_notice.is_none());
+    }
+
+    #[test]
+    fn discarded_clipboard_writes_are_never_resent() {
+        // A session that isn't the visible one drops what it saw. Bringing it
+        // to the front later must not replay the remote's old copy.
+        let mut s = scratch_session();
+        s.parser.process(b"\x1b]52;c;R0VIRUlN\x07");
+
+        s.discard_clipboard_writes();
+
+        let mut sent = Vec::new();
+        s.relay_clipboard_writes_with(|p| {
+            sent.push(p.to_string());
+            Ok(())
+        });
+        assert!(sent.is_empty(), "a discarded write must never be resent");
+        assert!(s.copy_notice.is_none(), "a discarded write must be silent");
+    }
+
+    #[test]
+    fn discarding_also_clears_drop_counters() {
+        // Otherwise the drops of an invisible session would surface the moment
+        // it becomes visible.
+        let mut s = scratch_session();
+        let mut stream = b"\x1b]52;c;".to_vec();
+        stream.extend(std::iter::repeat_n(b'A', 90_000));
+        stream.push(0x07);
+        s.parser.process(&stream);
+
+        s.discard_clipboard_writes();
+        s.relay_clipboard_writes_with(|_| Ok(()));
+
+        assert!(s.copy_notice.is_none());
+    }
+
+    #[test]
+    fn a_relay_failure_survives_the_connected_session_filter() {
+        // The event loop drops most diagnostics once a session is connected.
+        // A failed relay is exactly the case that must still reach the log, so
+        // it has to satisfy the real filter, not a look-alike.
+        let mut s = scratch_session();
+        s.parser.process(b"\x1b]52;c;R0VIRUlN\x07");
+        s.relay_clipboard_writes_with(|_| Err(std::io::Error::other("boom")));
+
+        let kept: Vec<String> = s
+            .take_diagnostics()
+            .into_iter()
+            .filter(|line| keep_diagnostic(line, true))
+            .collect();
+
+        assert!(
+            kept.iter().any(|d| d.contains("clipboard relay failed")),
+            "a failed relay must survive the connected-session filter, kept: {kept:?}"
         );
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -507,6 +507,7 @@ impl Session {
             }
         }
         if had_bytes {
+            self.relay_clipboard_writes();
             self.maybe_send_pending_secret();
             self.maybe_reveal();
         }
@@ -521,6 +522,41 @@ impl Session {
         self.reveal_on_timeout();
         // Re-check after reveal/timeout transitions (mosh has no ssh -v marker).
         self.maybe_detect_connected();
+    }
+
+    /// Forward OSC 52 clipboard writes emitted by applications inside the PTY
+    /// to the terminal hosting sshub. Without this the sequence dies in our
+    /// vt100 parser: a nested multiplexer (herdr, tmux) or an editor with
+    /// `clipboard=osc52` appears to copy — the selection even highlights —
+    /// but nothing ever reaches the system clipboard.
+    ///
+    /// Relaying means the remote side can write to the local clipboard, so
+    /// every relay raises a visible notice: a clipboard change the user didn't
+    /// ask for is worth noticing. The payload itself never lands in the notice,
+    /// the diagnostics or the session log.
+    fn relay_clipboard_writes(&mut self) {
+        self.relay_clipboard_writes_with(parser::emit_osc52_b64);
+    }
+
+    /// Relay with an injectable sink. Tests drive this directly: the real sink
+    /// writes to the process's stdout, which the test harness does *not*
+    /// capture (it only intercepts the `print!` macros), so exercising it under
+    /// `cargo test` would clobber the clipboard of whoever ran the suite.
+    fn relay_clipboard_writes_with(&mut self, mut emit: impl FnMut(&str) -> std::io::Result<()>) {
+        let mut relayed = None;
+        for payload in self.parser.take_clipboard_writes() {
+            match emit(&payload) {
+                // Several writes in one tick collapse into one notice (the last
+                // one wins), so a copy loop can't flood the corner of the screen.
+                Ok(()) => relayed = Some(parser::decoded_len(payload.as_bytes())),
+                Err(e) => self
+                    .diagnostics
+                    .push(format!("clipboard relay failed: {e}")),
+            }
+        }
+        if let Some(bytes) = relayed {
+            self.set_copy_notice(format!("remote copied {bytes} bytes to clipboard"));
+        }
     }
 
     /// Reveal the live terminal once the connect timeout elapses — but only if
@@ -1144,6 +1180,87 @@ mod prompt_tests {
             !s.screen_tail_snippet().contains("ERR_MARKER"),
             "stderr must not appear on the PTY grid"
         );
+    }
+
+    /// Build a throwaway session for tests that only need a live `Session`.
+    fn scratch_session() -> Session {
+        let config = SessionConfig {
+            argv: vec!["true".into()],
+            display_name: "t".into(),
+            meta: SessionMeta::default(),
+            pending_secret: None,
+            key_push_identity: None,
+            host_name: "t".into(),
+        };
+        Session::spawn(config, 24, 80, None).unwrap()
+    }
+
+    #[test]
+    fn clipboard_writes_from_the_pty_are_relayed_and_announced() {
+        // An app inside the PTY (herdr, tmux, an editor with clipboard=osc52)
+        // copies by writing OSC 52 to its stdout. vt100 hands that to the
+        // default no-op callback, where it used to vanish — the selection
+        // highlighted but the clipboard never changed.
+        let mut s = scratch_session();
+        // base64("GEHEIM") == "R0VIRUlN" → 6 bytes decoded.
+        s.parser.process(b"BEFORE\x1b]52;c;R0VIRUlN\x07AFTER");
+
+        let mut sent = Vec::new();
+        s.relay_clipboard_writes_with(|payload| {
+            sent.push(payload.to_string());
+            Ok(())
+        });
+
+        assert_eq!(sent, vec!["R0VIRUlN".to_string()]);
+        assert_eq!(
+            s.copy_notice.as_ref().map(|(m, _)| m.as_str()),
+            Some("remote copied 6 bytes to clipboard"),
+            "a relayed clipboard write must be visible to the user"
+        );
+
+        // The sequence itself must never become text on the grid.
+        let tail = s.screen_tail_snippet();
+        assert!(tail.contains("BEFOREAFTER"), "tail: {tail:?}");
+        assert!(!tail.contains("52;c;"), "escape sequence leaked: {tail:?}");
+    }
+
+    #[test]
+    fn failing_clipboard_relay_is_reported_not_swallowed() {
+        // A failed relay must not claim success: no notice, but a diagnostic.
+        let mut s = scratch_session();
+        s.parser.process(b"\x1b]52;c;R0VIRUlN\x07");
+
+        s.relay_clipboard_writes_with(|_| Err(std::io::Error::other("boom")));
+
+        assert!(
+            s.copy_notice.is_none(),
+            "a failed relay must not announce a copy"
+        );
+        assert!(
+            s.take_diagnostics()
+                .iter()
+                .any(|d| d.contains("clipboard relay failed")),
+            "a failed relay must surface in diagnostics"
+        );
+    }
+
+    #[test]
+    fn clipboard_queue_is_emptied_by_relaying() {
+        // Guards against re-sending the same payload on the next drain.
+        let mut s = scratch_session();
+        s.parser.process(b"\x1b]52;c;R0VIRUlN\x07");
+
+        let mut sent = 0usize;
+        s.relay_clipboard_writes_with(|_| {
+            sent += 1;
+            Ok(())
+        });
+        s.relay_clipboard_writes_with(|_| {
+            sent += 1;
+            Ok(())
+        });
+
+        assert_eq!(sent, 1, "each clipboard write must be relayed exactly once");
     }
 
     #[test]

--- a/src/session/parser.rs
+++ b/src/session/parser.rs
@@ -26,6 +26,17 @@ pub(crate) fn decoded_len(b64: &[u8]) -> usize {
     }
 }
 
+/// Why a clipboard write coming out of the PTY never made it to the queue.
+/// The two reasons are counted apart so the notice can name them: one is a
+/// single write past the size cap, the other a remote stuck in a copy loop.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ClipboardDrops {
+    /// Writes whose decoded payload exceeded [`CLIPBOARD_RELAY_MAX_BYTES`].
+    pub(crate) oversize: usize,
+    /// Writes that arrived with the queue already at [`CLIPBOARD_RELAY_MAX_QUEUED`].
+    pub(crate) queue_full: usize,
+}
+
 /// Collects OSC 52 clipboard writes coming out of the PTY so the session can
 /// re-emit them toward the real terminal.
 ///
@@ -34,16 +45,29 @@ pub(crate) fn decoded_len(b64: &[u8]) -> usize {
 /// copying inside the PTY (herdr, tmux, neovim, lazygit…) appears to work but
 /// never reaches the system clipboard.
 #[derive(Default)]
-pub struct ClipboardRelay {
+struct ClipboardRelay {
     /// Pending base64 payloads, in arrival order.
     pending: Vec<String>,
+    /// Writes rejected since the last drain, by reason.
+    drops: ClipboardDrops,
 }
 
 impl vt100::Callbacks for ClipboardRelay {
     fn copy_to_clipboard(&mut self, _: &mut vt100::Screen, _ty: &[u8], data: &[u8]) {
-        if self.pending.len() >= CLIPBOARD_RELAY_MAX_QUEUED
-            || decoded_len(data) > CLIPBOARD_RELAY_MAX_BYTES
-        {
+        // An empty payload is a clipboard *clear* on terminals that honour it.
+        // We neither forward it nor count it as a drop: a remote must not be
+        // able to wipe the local clipboard, and nothing was lost worth naming.
+        if data.is_empty() {
+            return;
+        }
+        // Order matters — a huge write is reported as oversize even when the
+        // queue happens to be full as well.
+        if decoded_len(data) > CLIPBOARD_RELAY_MAX_BYTES {
+            self.drops.oversize += 1;
+            return;
+        }
+        if self.pending.len() >= CLIPBOARD_RELAY_MAX_QUEUED {
+            self.drops.queue_full += 1;
             return;
         }
         // vt100 already guaranteed every byte is in the base64 alphabet
@@ -59,18 +83,6 @@ impl vt100::Callbacks for ClipboardRelay {
     // local clipboard, which is far worse than a write and buys us nothing.
 }
 
-/// Re-emit an already-base64-encoded payload as OSC 52 on our own stdout, so
-/// the terminal hosting SSHub puts it on the system clipboard.
-///
-/// The selector is pinned to `c` rather than forwarded: some terminals discard
-/// the whole sequence when they see a selector they don't know.
-pub fn emit_osc52_b64(payload: &str) -> std::io::Result<()> {
-    use std::io::Write;
-    let mut out = std::io::stdout().lock();
-    out.write_all(format!("\x1b]52;c;{payload}\x07").as_bytes())?;
-    out.flush()
-}
-
 pub struct ParserState {
     inner: vt100::Parser<ClipboardRelay>,
 }
@@ -82,9 +94,14 @@ impl ParserState {
         }
     }
 
+    /// Take the drops recorded since the last call, resetting the counters.
+    pub(crate) fn take_clipboard_drops(&mut self) -> ClipboardDrops {
+        std::mem::take(&mut self.inner.callbacks_mut().drops)
+    }
+
     /// Take the clipboard writes seen since the last call. Each entry is a
-    /// base64 payload ready to hand to [`emit_osc52_b64`].
-    pub fn take_clipboard_writes(&mut self) -> Vec<String> {
+    /// base64 payload ready to hand to [`crate::osc52::write_b64`].
+    pub(crate) fn take_clipboard_writes(&mut self) -> Vec<String> {
         std::mem::take(&mut self.inner.callbacks_mut().pending)
     }
 
@@ -132,6 +149,13 @@ impl ParserState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn drops(oversize: usize, queue_full: usize) -> ClipboardDrops {
+        ClipboardDrops {
+            oversize,
+            queue_full,
+        }
+    }
 
     fn parser_with(rows: u16, cols: u16, stream: &[u8]) -> ParserState {
         let mut p = ParserState::new(rows, cols);
@@ -208,11 +232,9 @@ mod tests {
     #[test]
     fn oversized_clipboard_write_is_dropped() {
         // 90_000 base64 chars ≈ 67.5 KiB decoded — past the 64 KiB cap.
-        let mut stream = b"\x1b]52;c;".to_vec();
-        stream.extend(std::iter::repeat_n(b'A', 90_000));
-        stream.push(0x07);
-        let mut p = parser_with(10, 80, &stream);
+        let mut p = parser_with(10, 80, &oversized_copy());
         assert!(p.take_clipboard_writes().is_empty());
+        assert_eq!(p.take_clipboard_drops(), drops(1, 0));
     }
 
     #[test]
@@ -223,6 +245,61 @@ mod tests {
         }
         let mut p = parser_with(10, 80, &stream);
         assert_eq!(p.take_clipboard_writes().len(), CLIPBOARD_RELAY_MAX_QUEUED);
+        assert_eq!(
+            p.take_clipboard_drops(),
+            drops(0, 20 - CLIPBOARD_RELAY_MAX_QUEUED)
+        );
+    }
+
+    /// An OSC 52 write whose decoded payload is past the size cap.
+    fn oversized_copy() -> Vec<u8> {
+        let mut stream = b"\x1b]52;c;".to_vec();
+        stream.extend(std::iter::repeat_n(b'A', 90_000));
+        stream.push(0x07);
+        stream
+    }
+
+    #[test]
+    fn empty_payload_is_ignored_entirely() {
+        // `ESC]52;c;BEL` clears the clipboard on terminals that honour it. We
+        // neither relay it nor treat it as a drop: an empty write must not
+        // wipe the user's clipboard and must not claim anything happened.
+        let mut p = parser_with(10, 80, b"\x1b]52;c;\x07");
+        assert!(p.take_clipboard_writes().is_empty());
+        assert_eq!(p.take_clipboard_drops(), ClipboardDrops::default());
+    }
+
+    #[test]
+    fn oversize_and_queue_full_are_counted_separately() {
+        // The two drop reasons are different failures — one is a single huge
+        // write, the other a remote in a copy loop — so the notice must be
+        // able to tell them apart.
+        let mut stream = oversized_copy();
+        for _ in 0..20 {
+            stream.extend_from_slice(b"\x1b]52;c;R0VIRUlN\x07");
+        }
+        let mut p = parser_with(10, 80, &stream);
+        assert_eq!(p.take_clipboard_writes().len(), CLIPBOARD_RELAY_MAX_QUEUED);
+        assert_eq!(
+            p.take_clipboard_drops(),
+            drops(1, 20 - CLIPBOARD_RELAY_MAX_QUEUED)
+        );
+    }
+
+    #[test]
+    fn taking_drops_resets_the_counters() {
+        let mut p = parser_with(10, 80, &oversized_copy());
+        assert_eq!(p.take_clipboard_drops(), drops(1, 0));
+        assert_eq!(p.take_clipboard_drops(), ClipboardDrops::default());
+    }
+
+    #[test]
+    fn primary_selection_is_relayed_as_clipboard() {
+        // vt100 hands us selector `p` (X11 primary selection) too. We
+        // deliberately normalise every selector to `c` in the shared helper,
+        // so the payload must reach the queue unchanged.
+        let mut p = parser_with(10, 80, b"\x1b]52;p;R0VIRUlN\x07");
+        assert_eq!(p.take_clipboard_writes(), vec!["R0VIRUlN".to_string()]);
     }
 
     #[test]

--- a/src/session/parser.rs
+++ b/src/session/parser.rs
@@ -1,15 +1,91 @@
 //! VT100 parser wrapper. Maintains an in-memory `vt100::Screen` that the
-//! renderer reads via `tui-term`.
+//! renderer reads via `tui-term`, and relays OSC 52 clipboard writes that
+//! applications inside the PTY emit.
+
+/// Largest decoded payload we'll relay from the PTY to the host clipboard
+/// (64 KiB). Keeps a remote from flooding the clipboard with a huge write.
+const CLIPBOARD_RELAY_MAX_BYTES: usize = 64 * 1024;
+
+/// How many clipboard writes we buffer between drains. A remote stuck in a
+/// copy loop can't grow the queue without bound; the excess is dropped.
+const CLIPBOARD_RELAY_MAX_QUEUED: usize = 8;
+
+/// Exact decoded byte length of a base64 payload, without decoding it. The
+/// payload is relayed verbatim, so a real decoder would be pure waste — this
+/// only exists to enforce the size cap and to size the "n bytes" notice.
+pub(crate) fn decoded_len(b64: &[u8]) -> usize {
+    let full = b64.len() / 4 * 3;
+    match b64.len() % 4 {
+        // Well-formed: subtract whatever padding is present.
+        0 => full.saturating_sub(b64.iter().rev().take_while(|&&c| c == b'=').count().min(2)),
+        // Unpadded tail: 2 chars carry 1 byte, 3 chars carry 2.
+        2 => full + 1,
+        3 => full + 2,
+        // len % 4 == 1 is not valid base64; treat the stray char as nothing.
+        _ => full,
+    }
+}
+
+/// Collects OSC 52 clipboard writes coming out of the PTY so the session can
+/// re-emit them toward the real terminal.
+///
+/// Without this, `vt100` parses `ESC ] 52 ; c ; <base64> BEL` and hands it to
+/// the default `Callbacks for ()` impl, which silently drops it — so anything
+/// copying inside the PTY (herdr, tmux, neovim, lazygit…) appears to work but
+/// never reaches the system clipboard.
+#[derive(Default)]
+pub struct ClipboardRelay {
+    /// Pending base64 payloads, in arrival order.
+    pending: Vec<String>,
+}
+
+impl vt100::Callbacks for ClipboardRelay {
+    fn copy_to_clipboard(&mut self, _: &mut vt100::Screen, _ty: &[u8], data: &[u8]) {
+        if self.pending.len() >= CLIPBOARD_RELAY_MAX_QUEUED
+            || decoded_len(data) > CLIPBOARD_RELAY_MAX_BYTES
+        {
+            return;
+        }
+        // vt100 already guaranteed every byte is in the base64 alphabet
+        // (including '='), so this is ASCII and the payload passes through
+        // unchanged — no decode, no re-encode.
+        if let Ok(payload) = std::str::from_utf8(data) {
+            self.pending.push(payload.to_string());
+        }
+    }
+
+    // `paste_from_clipboard` is deliberately left as the no-op default:
+    // answering `ESC]52;c;?BEL` would let any host we're SSH'd into *read* the
+    // local clipboard, which is far worse than a write and buys us nothing.
+}
+
+/// Re-emit an already-base64-encoded payload as OSC 52 on our own stdout, so
+/// the terminal hosting SSHub puts it on the system clipboard.
+///
+/// The selector is pinned to `c` rather than forwarded: some terminals discard
+/// the whole sequence when they see a selector they don't know.
+pub fn emit_osc52_b64(payload: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut out = std::io::stdout().lock();
+    out.write_all(format!("\x1b]52;c;{payload}\x07").as_bytes())?;
+    out.flush()
+}
 
 pub struct ParserState {
-    inner: vt100::Parser,
+    inner: vt100::Parser<ClipboardRelay>,
 }
 
 impl ParserState {
     pub fn new(rows: u16, cols: u16) -> Self {
         Self {
-            inner: vt100::Parser::new(rows, cols, 10_000),
+            inner: vt100::Parser::new_with_callbacks(rows, cols, 10_000, ClipboardRelay::default()),
         }
+    }
+
+    /// Take the clipboard writes seen since the last call. Each entry is a
+    /// base64 payload ready to hand to [`emit_osc52_b64`].
+    pub fn take_clipboard_writes(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.inner.callbacks_mut().pending)
     }
 
     pub fn process(&mut self, bytes: &[u8]) {
@@ -96,5 +172,101 @@ mod tests {
         p.set_scrollback(5);
         p.snap_to_bottom();
         assert_eq!(p.scrollback(), 0);
+    }
+
+    // ── OSC 52 clipboard relay ────────────────────────────────────
+    //
+    // An app running inside the PTY (herdr, tmux, neovim, lazygit…) copies by
+    // writing `ESC ] 52 ; c ; <base64> BEL` to its stdout — which is our PTY.
+    // vt100 parses that and hands it to `Callbacks::copy_to_clipboard`, whose
+    // default `()` impl silently drops it. We queue it instead so `drain()` can
+    // re-emit it toward the real terminal.
+
+    #[test]
+    fn osc52_copy_is_queued_for_relay() {
+        // base64("GEHEIM") == "R0VIRUlN"
+        let mut p = parser_with(10, 80, b"\x1b]52;c;R0VIRUlN\x07");
+        assert_eq!(p.take_clipboard_writes(), vec!["R0VIRUlN".to_string()]);
+    }
+
+    #[test]
+    fn padded_base64_is_relayed() {
+        // Guards the whole feature: vt100's BASE64 alphabet includes '=', so a
+        // padded payload (what herdr actually emits) must survive. If '=' ever
+        // stopped being accepted upstream, every short copy would break.
+        let mut p = parser_with(10, 80, b"\x1b]52;c;aGVsbG8=\x07");
+        assert_eq!(p.take_clipboard_writes(), vec!["aGVsbG8=".to_string()]);
+    }
+
+    #[test]
+    fn take_clipboard_writes_drains() {
+        let mut p = parser_with(10, 80, b"\x1b]52;c;R0VIRUlN\x07");
+        assert_eq!(p.take_clipboard_writes().len(), 1);
+        assert!(p.take_clipboard_writes().is_empty());
+    }
+
+    #[test]
+    fn oversized_clipboard_write_is_dropped() {
+        // 90_000 base64 chars ≈ 67.5 KiB decoded — past the 64 KiB cap.
+        let mut stream = b"\x1b]52;c;".to_vec();
+        stream.extend(std::iter::repeat_n(b'A', 90_000));
+        stream.push(0x07);
+        let mut p = parser_with(10, 80, &stream);
+        assert!(p.take_clipboard_writes().is_empty());
+    }
+
+    #[test]
+    fn queue_is_capped() {
+        let mut stream = Vec::new();
+        for _ in 0..20 {
+            stream.extend_from_slice(b"\x1b]52;c;R0VIRUlN\x07");
+        }
+        let mut p = parser_with(10, 80, &stream);
+        assert_eq!(p.take_clipboard_writes().len(), CLIPBOARD_RELAY_MAX_QUEUED);
+    }
+
+    #[test]
+    fn paste_query_is_not_answered() {
+        // `ESC]52;c;?BEL` asks us to hand the clipboard *back* to the remote.
+        // Answering would let any host we're SSH'd into read the local
+        // clipboard, so it must produce nothing at all.
+        let mut p = parser_with(10, 80, b"\x1b]52;c;?\x07");
+        assert!(p.take_clipboard_writes().is_empty());
+    }
+
+    #[test]
+    fn invalid_base64_is_ignored() {
+        // vt100 routes non-base64 payloads to `unhandled_osc`, never to us.
+        let mut p = parser_with(10, 80, b"\x1b]52;c;not base64!\x07");
+        assert!(p.take_clipboard_writes().is_empty());
+    }
+
+    #[test]
+    fn osc52_does_not_reach_the_grid() {
+        // Regression: the sequence must stay invisible. If it ever landed on a
+        // cell the user would see escape gibberish mid-session.
+        let mut p = parser_with(10, 80, b"before\x1b]52;c;R0VIRUlN\x07after");
+        assert_eq!(p.screen().contents().trim(), "beforeafter");
+        assert_eq!(p.take_clipboard_writes().len(), 1);
+    }
+
+    #[test]
+    fn decoded_len_matches_real_decode() {
+        // Exact decoded size without pulling in a base64 decoder — the payload
+        // is relayed verbatim, so decoding it would be pure waste.
+        assert_eq!(decoded_len(b""), 0);
+        assert_eq!(decoded_len(b"R0VIRUlN"), 6); // "GEHEIM"
+        assert_eq!(decoded_len(b"aGVsbG8="), 5); // "hello", 1 pad
+        assert_eq!(decoded_len(b"aGk="), 2); // "hi",    1 pad
+        assert_eq!(decoded_len(b"YQ=="), 1); // "a",     2 pads
+        assert_eq!(decoded_len(b"YWJjZA=="), 4); // "abcd",  2 pads
+    }
+
+    #[test]
+    fn decoded_len_handles_unpadded_input() {
+        // Some senders omit padding; vt100 accepts it, so we must size it right.
+        assert_eq!(decoded_len(b"aGVsbG8"), 5); // "hello" unpadded
+        assert_eq!(decoded_len(b"aGk"), 2); // "hi"    unpadded
+        assert_eq!(decoded_len(b"YQ"), 1); // "a"     unpadded
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -140,14 +140,13 @@ fn apply_panel_selection(frame: &mut Frame, app: &App) {
 }
 
 fn render_inner(frame: &mut Frame, app: &App) {
-    let session_behind_picker = app.mode == AppMode::SessionPicker
-        && app
-            .session_picker
-            .as_ref()
-            .is_some_and(|p| matches!(p.return_mode, AppMode::Connecting | AppMode::Session));
+    // Only governs the picker overlay's animation below; whether a session is
+    // drawn at all is `session_is_rendered`, which the clipboard relay gate
+    // reads too.
+    let session_behind_picker = app.session_picker_over_session();
 
     // Embedded session takes over the whole frame — no dashboard chrome.
-    if matches!(app.mode, AppMode::Connecting | AppMode::Session) || session_behind_picker {
+    if app.session_is_rendered() {
         crate::session::render::render(frame, app);
         // Slide the freshly-connected session in from the right (#35). Skipped
         // for the picker-over-session case (no fresh connect happening).


### PR DESCRIPTION
Closes #87

## What was broken

Copying from an application running **inside** a session PTY silently failed.
The selection highlighted, the inner app reported a copy, and the system
clipboard never changed.

Found with a nested [herdr](https://herdr.dev) under WSL2 / Windows Terminal,
but it is not specific to it: `tmux` with `set-clipboard on`, `neovim` with
`clipboard=osc52`, `lazygit` and `yazi` all copy the same way and were all
affected.

## Root cause

Those apps copy by writing `ESC ] 52 ; c ; <base64> BEL` to their stdout — our
PTY. `vt100` parses it and dispatches to `Callbacks::copy_to_clipboard`
(`vt100-0.16.2/src/perform.rs:210`). `ParserState` used
`vt100::Parser::new(...)`, i.e. `Parser<()>`, and `impl Callbacks for ()` is a
no-op. With no OSC passthrough to our own stdout either, the sequence was parsed
and dropped.

The mouse side was never the problem: the inner app enables mouse reporting, so
`src/app/session.rs` correctly forwards events to it. The inbound path worked;
only the outbound clipboard path was missing — hence a visible selection with no
copy.

## What this changes

`ParserState` now runs with a `ClipboardRelay` callbacks type
(`Parser::new_with_callbacks` + `callbacks_mut()`) that queues copy payloads.
The payload is relayed base64-encoded verbatim — no decode, no re-encode;
`decoded_len` sizes it for the cap and the notice without pulling in a decoder.

The relay itself is a per-frame pass in the event loop
(`App::relay_visible_session_clipboard`): only the session actually painted
this frame may relay — decided by the same `session_is_rendered()` predicate
the renderer draws from — and every other session **discards** its writes on
the spot, so a background tab can neither touch the clipboard now nor replay an
old write when it later comes to the front.

OSC 52 framing lives once in `src/osc52.rs`, shared between the relay and
SSHub's own copy shortcuts. The relay is on by default and can be switched off
with `relay_from_pty = false` under a new `[clipboard]` section in
`config.toml`; configs written before that section existed keep the default.

## Why SSHub's own selection can't substitute for it

Shift+drag is not a workaround. SSHub's selection is a stream selection over the
flat vt100 grid (`contents_between`), and intermediate lines are read out to the
full terminal width (`src/session/mod.rs`):

```rust
let ec = if r == end.0 { end_col } else { cols };
```

Across a split layout inside the PTY that drags in the neighbouring panes and
their borders. It is structural — SSHub sees one character grid and knows
nothing about the inner app's pane geometry, per-pane scrollback or line
wrapping. Only the inner app can select its own content.

## Security

Relaying means a remote host can write to the local clipboard — a known OSC 52
attack vector, and relevant here because foreign hosts sit on the PTY by
definition. Bounded and made visible:

| Measure | Effect |
|---|---|
| Only the visible session may relay | A background tab, the dashboard, SFTP or the tunnels view drop their PTY's writes immediately — and never replay them on tab switch |
| Notice on every relay **and every drop** | Oversize and queue-full drops are counted separately and named in the notice; a thrown-away copy is never hidden behind a success message |
| 64 KiB cap per write | No flooding the clipboard with a huge payload |
| Max 8 writes queued per frame | A copy loop can't grow the queue without bound |
| Empty payload ignored | A remote cannot clear the local clipboard |
| `paste_from_clipboard` left a no-op | `ESC]52;c;?BEL` is never answered — no host can *read* the clipboard |
| `[clipboard] relay_from_pty` opt-out | Default on; `false` drops every PTY clipboard write |
| Payload never logged by the relay | The raw PTY stream already carries the sequence, so an enabled session log can contain it — the relay neither adds nor removes it |

## Tests

~35 new tests: parser queueing, caps, padded/unpadded base64, drop counters,
grid invisibility; session relay/discard/notice semantics including mixed
success+drop batches and the connected-session diagnostic filter; app-level
visible-only gating (background tab, dashboard, SFTP, picker-over-session,
opt-out, no-replay); config defaults; shared OSC framing byte-identity.

`just test` green (630 unit + 73 e2e + 42 smoke + config_load, no failures),
`cargo fmt --check` and `cargo clippy --all-targets` clean, CI green on
Ubuntu + macOS.

One deliberate design note: the relay sink is injectable, and the tests use a
fake. The real sink writes to the process's stdout, which the test harness does
**not** capture — exercising it under `cargo test` would clobber the clipboard
of whoever ran the suite. The unexercised remainder is a three-line write with
no branching.

## Verification

Confirmed working by hand on the original setup: Windows 11 → WSL2 → herdr →
SSHub → PTY → herdr with three panes. Copying in the middle pane lands in the
Windows clipboard, and only that pane's content — no neighbouring panes, no
borders.

## Scope

12 files: the relay (`src/session/parser.rs`, `src/session/mod.rs`), the
per-frame visibility gate (`src/app/session.rs`, `src/lib.rs`,
`src/tui/mod.rs`), shared OSC 52 framing (`src/osc52.rs`, `src/app/util.rs`),
the config flag (`src/config.rs`), docs (`README.md`, `CHANGELOG.md`), and
tests.

_Written by Opus 5 (Claude Code) on behalf of the maintainer. Body updated
after the review round to match the final implementation._