### PR TITLE
feat(cli): sshub exec runs one command on a saved host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@ All notable changes to SSHub are documented in this file.
   reassembling the ssh command line by hand and losing the stored identity,
   askpass wiring and ProxyJump the launcher already knows. stdout/stderr pass
   through, stdin is inherited so pipes work, and the exit code is the remote
-  command's (ssh's own failures keep ssh's 255). No PTY by default; `--tty`
-  forces one for commands that insist (`sudo` without NOPASSWD). `--timeout
-  SECS` kills the command and exits 124 like `timeout(1)`; `--format json`
-  buffers the run as `{host, command, exit_code, stdout, stderr, duration_ms}`.
-  A command given here overrides the host's stored remote command. Runs are
+  command's (ssh's own failures keep ssh's 255). Nothing prompts: without a
+  stored credential the run is `BatchMode`, so an unknown host key fails a
+  script instead of parking it on a question no one will answer. No PTY by
+  default; `--tty` forces one for commands that insist (`sudo` without
+  NOPASSWD). `--timeout SECS` kills the run and exits 124 like `timeout(1)` —
+  into its own process group, so a `ProxyJump` helper cannot outlive the
+  deadline holding the output pipes open; `--format json` buffers the run as
+  `{host, command, exit_code, stdout, stderr, duration_ms}`. A command given
+  here overrides one stored on the host *or* in `~/.ssh/config`, where ssh
+  would otherwise refuse the run outright. Runs are
   audited (`sshub audit list --via exec`) without recording the command itself,
   which can carry a secret in an argument. Session transcripts are skipped —
   `script(1)` wrapping fights the redirection exec exists for — and mosh hosts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to SSHub are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`sshub exec <host> -- <command>`** (issue #85) - run one command on a saved
+  host from a script and get its output and exit code back, instead of
+  reassembling the ssh command line by hand and losing the stored identity,
+  askpass wiring and ProxyJump the launcher already knows. stdout/stderr pass
+  through, stdin is inherited so pipes work, and the exit code is the remote
+  command's (ssh's own failures keep ssh's 255). No PTY by default; `--tty`
+  forces one for commands that insist (`sudo` without NOPASSWD). `--timeout
+  SECS` kills the command and exits 124 like `timeout(1)`; `--format json`
+  buffers the run as `{host, command, exit_code, stdout, stderr, duration_ms}`.
+  A command given here overrides the host's stored remote command. Runs are
+  audited (`sshub audit list --via exec`) without recording the command itself,
+  which can carry a secret in an argument. Session transcripts are skipped —
+  `script(1)` wrapping fights the redirection exec exists for — and mosh hosts
+  are refused, having no one-shot command mode.
+
 ## [0.14.0] - 2026-08-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ sshub host add --name prod-web --address 10.0.0.5 --port 22 \
     --username deploy --group prod --tags web,prod
 sshub host delete --name prod-web --yes      # destructive: needs --yes
 
+# Run a command on a host (scripted; exit code is the remote command's)
+sshub exec prod-web -- systemctl is-active nginx
+sshub exec prod-web -- 'tail -n 200 /var/log/nginx/error.log' > errors.log
+echo "$payload" | sshub exec db-01 -- 'psql -f -'
+sshub exec prod-web --timeout 30 --format json -- uptime
+
 # Groups and identities
 sshub groups                                 # list host groups
 sshub group add --name prod

--- a/man/sshub.1
+++ b/man/sshub.1
@@ -93,6 +93,36 @@ Delete a launcher host. Requires
 .TP
 .B sshub host duplicate \fINAME\fR
 Duplicate a host (legacy ssh_config hosts are copied into the launcher).
+.SS Exec (scripted)
+.TP
+.B sshub exec \fIHOST\fR \fR[\fB\-\-tty\fR] [\fB\-\-timeout\fR \fISECS\fR] [\fB\-\-format\fR \fIF\fR] [\fB\-v\fR] \fB\-\-\fR \fICOMMAND\fR \fR[\fIARGS\fR...]
+Run one command on a saved host and exit with the remote command's exit code
+(ssh's own failures keep ssh's 255). stdout and stderr pass through, stdin is
+inherited so pipes work, and nothing ever prompts. Everything after
+.B \-\-
+is the command; a single quoted string
+.RB ( "sshub exec web-01 \(dquptime\(dq" )
+works too.
+.B \-\-tty
+forces a PTY
+.RB ( "ssh \-tt" )
+for commands that insist on one; without it exec runs
+.BR "ssh \-T" .
+.B \-\-timeout
+kills the command after
+.I SECS
+and exits 124, like
+.BR timeout (1).
+.B \-\-format
+.B json
+buffers the run as
+.IR {host, " " command, " " exit_code, " " stdout, " " stderr, " " duration_ms} ;
+plain (the default) streams. A per-host stored remote command is overridden by
+the command given here. Session transcripts are skipped for exec \(em
+.BR script (1)
+wrapping fights output redirection. Mosh hosts are refused: mosh has no one-shot
+command mode. Runs are audited as
+.BR "via exec" .
 .SS Aliases
 .TP
 .B sshub connect \fINAME\fR
@@ -178,7 +208,7 @@ is
 .BR all ", " ok ", " fail ", or " retry ;
 .I V
 is
-.BR all ", " connect ", " tunnel ", or " agent .
+.BR all ", " connect ", " tunnel ", " agent ", or " exec .
 .SS Themes
 .TP
 .B sshub theme list \fR[\fB\-\-format\fR \fBplain\fR|\fBjson\fR]
@@ -304,6 +334,10 @@ Success.
 Operational failure (not found, a destructive command refused without
 .BR \-\-yes ,
 spawn error, non-zero ssh exit, hard import error).
+.TP
+.B 124
+.B sshub exec \-\-timeout
+killed the remote command.
 .TP
 .B 2
 Usage error, bad flags, deleting a non-launcher host, or deleting an identity

--- a/man/sshub.1
+++ b/man/sshub.1
@@ -98,7 +98,10 @@ Duplicate a host (legacy ssh_config hosts are copied into the launcher).
 .B sshub exec \fIHOST\fR \fR[\fB\-\-tty\fR] [\fB\-\-timeout\fR \fISECS\fR] [\fB\-\-format\fR \fIF\fR] [\fB\-v\fR] \fB\-\-\fR \fICOMMAND\fR \fR[\fIARGS\fR...]
 Run one command on a saved host and exit with the remote command's exit code
 (ssh's own failures keep ssh's 255). stdout and stderr pass through, stdin is
-inherited so pipes work, and nothing ever prompts. Everything after
+inherited so pipes work, and nothing ever prompts \(em with no stored credential
+exec runs ssh in
+.BR BatchMode ,
+so an unknown host key fails instead of waiting for a human. Everything after
 .B \-\-
 is the command; a single quoted string
 .RB ( "sshub exec web-01 \(dquptime\(dq" )
@@ -112,13 +115,19 @@ for commands that insist on one; without it exec runs
 kills the command after
 .I SECS
 and exits 124, like
-.BR timeout (1).
+.BR timeout (1);
+the run is spawned into its own process group and the group is killed, so a
+.B ProxyJump
+helper cannot outlive it (with a timeout,
+.B Ctrl-C
+therefore no longer reaches ssh).
 .B \-\-format
 .B json
 buffers the run as
 .IR {host, " " command, " " exit_code, " " stdout, " " stderr, " " duration_ms} ;
-plain (the default) streams. A per-host stored remote command is overridden by
-the command given here. Session transcripts are skipped for exec \(em
+plain (the default) streams. A remote command stored on the host or in
+.I ~/.ssh/config
+is overridden by the command given here. Session transcripts are skipped for exec \(em
 .BR script (1)
 wrapping fights output redirection. Mosh hosts are refused: mosh has no one-shot
 command mode. Runs are audited as

--- a/openwiki/workflows/cli.md
+++ b/openwiki/workflows/cli.md
@@ -1,7 +1,7 @@
 ---
 type: API Reference
 title: Headless CLI — full command tree, JSON output, and exit codes
-description: SSHub's scriptable command-line interface (src/cli) covering hosts, groups, identities, tunnels, SFTP, audit, import/export/sync, and completions, with --format json support and stable exit codes 0/1/2.
+description: SSHub's scriptable command-line interface (src/cli) covering hosts, exec, groups, identities, tunnels, SFTP, audit, import/export/sync, and completions, with --format json support and stable exit codes 0/1/2 (plus 124 for `exec --timeout`).
 resource: src/cli/mod.rs
 tags: [cli, automation, json, reference, workflow]
 ---
@@ -13,7 +13,7 @@ Beyond the TUI, `sshub` exposes a full scriptable CLI. `src/main.rs` dispatches 
 Parsing is hand-rolled (`src/cli/parse.rs`), output DTOs in `src/cli/output.rs`. Conventions:
 
 - `--format plain|json` on listing/show commands (plain default).
-- Exit codes: `0` success, `1` operational failure, `2` usage/bad flags. `host connect` propagates the child ssh exit code.
+- Exit codes: `0` success, `1` operational failure, `2` usage/bad flags, `124` when `exec --timeout` kills the run. `host connect` and `exec` propagate the child ssh exit code.
 - Destructive commands refuse without `--yes`; `sshub db purge` requires `--yes-i-am-stupid`.
 - Unknown positional first arg exits 2 with a hint (avoids launching a full-screen TUI on a typo).
 
@@ -22,11 +22,12 @@ Parsing is hand-rolled (`src/cli/parse.rs`), output DTOs in `src/cli/output.rs`.
 | Command | Subcommands | Notes |
 |---|---|---|
 | `host` (alias `list`, `connect`) | `list show connect resolve search add edit rename delete duplicate` | `add` takes `--name --address --port --username --group --tags`; `connect` runs ssh/mosh as a foreground child process with inherited stdio (Command::spawn + wait), propagating its exit code; it does not use the TUI embedded-PTY session module or the (dead-code) external TerminalLauncher |
+| `exec` | — | `sshub exec <host> [--tty] [--timeout SECS] [--format plain\|json] -- <command>`: one non-interactive command on a saved host (`src/cli/exec.rs`). Reuses the connect argv (`session_argv_for_entry` + `prepare_cli_connect_argv`), then adds `-T`/`-tt`, `-o RemoteCommand=none` (a per-host stored remote command must not win, and a config-level one makes ssh refuse the run) and `-o BatchMode=yes` when no stored secret is staged, so a script can never sit on a prompt. stdio passes through, stdin inherited; `--timeout` spawns into its own process group and SIGKILLs the group (a ProxyJump helper would otherwise hold the pipes open). Audited as `via exec`, without the command string. No session transcript; mosh refused |
 | `group` (alias `groups`) | `list show add edit delete` | Nested groups via parent |
 | `identity` | `list show add edit delete agent-remove` | `add --private-key`, `--password-stdin` for secrets; `agent-remove` = `ssh-add -d` |
 | `tunnel` | `list show create start stop delete` | `start` is detached by default (PID files), `--foreground` runs with keep-alive ([tunnels](tunnels.md)) |
 | `sftp` | `ls get put rm mkdir rename chmod` | One-shot over a direct host; no ProxyJump ([sessions & SFTP](sessions-sftp.md#sftp)) |
-| `audit` | `list stats` | `--status ok|fail`, `--days N` |
+| `audit` | `list stats` | `--status ok|fail`, `--days N`, `--via all|connect|tunnel|agent|exec` (`connect` means interactive connects only) |
 | `tags` | — | List all tags |
 | `import` / `sync` / `export` | — | ssh config import, row refresh, `export --stdout|-o` |
 | `completions` | `bash zsh fish` | Installed by `just install-completions` |
@@ -38,6 +39,7 @@ Examples (from `README.md`):
 sshub host add --name prod-web --address 10.0.0.5 --port 22 --username deploy --group prod --tags web,prod
 sshub tunnel create --host prod-web --type local --local-port 8080 --remote-host localhost --remote-port 80
 sshub sftp get prod-web /var/log/app.log ./app.log
+sshub exec prod-web --timeout 30 -- systemctl is-active nginx
 sshub audit list --status fail --days 7
 ```
 
@@ -45,6 +47,6 @@ Per-command help: `sshub <command> --help`; the man page (`man/sshub.1`, preview
 
 ## Change guidance
 
-- New subcommand: register in `src/cli/mod.rs` (`is_subcommand` + `run_subcommand`), add a module under `src/cli/`, extend the man page and README table.
+- New subcommand: register in `src/cli/mod.rs` (`is_subcommand` + `run_subcommand`), add a module under `src/cli/`, add its help block in `src/cli/help.rs` and the section in `main.rs::print_help`, list it in `src/cli/completions.rs` (`TOP_LEVEL` plus the bash/zsh/fish bodies), extend the man page, the README table and this page.
 - CLI smoke coverage lives in `tests/smoke/cli_commands.rs` (drives the real binary via `assert_cmd`) — see [testing](../testing/strategy.md).
 - Keep exit codes stable; scripts depend on them.

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -36,7 +36,7 @@ fn cmd_list(ctx: &CliContext, args: &[String]) -> Result<i32> {
         usage("audit list --status must be one of: all, ok, fail, retry");
     }
     if !valid_via(&via) {
-        usage("audit list --via must be one of: all, connect, tunnel, agent");
+        usage("audit list --via must be one of: all, connect, tunnel, agent, exec");
     }
 
     let since = match days {
@@ -81,7 +81,7 @@ fn cmd_stats(ctx: &CliContext, args: &[String]) -> Result<i32> {
     let include_retry = take_flag(&mut a, "--include-retry");
 
     if !valid_via(&via) {
-        usage("audit stats --via must be one of: all, connect, tunnel, agent");
+        usage("audit stats --via must be one of: all, connect, tunnel, agent, exec");
     }
 
     let via_opt = (via != "all").then_some(via.as_str());
@@ -123,7 +123,7 @@ fn valid_status(s: &str) -> bool {
 }
 
 fn valid_via(s: &str) -> bool {
-    matches!(s, "all" | "connect" | "tunnel" | "agent")
+    matches!(s, "all" | "connect" | "tunnel" | "agent" | "exec")
 }
 
 #[cfg(test)]
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn via_values_are_validated() {
-        for s in ["all", "connect", "tunnel", "agent"] {
+        for s in ["all", "connect", "tunnel", "agent", "exec"] {
             assert!(valid_via(s));
         }
         for s in ["", "bogus", "local", "remote"] {

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -17,6 +17,7 @@ const CACHE_HEADER: &str = "# sshub-completion-cache v1";
 const TOP_LEVEL: &[&str] = &[
     "host",
     "connect",
+    "exec",
     "list",
     "groups",
     "group",
@@ -248,7 +249,7 @@ _sshub_completions() {{
                 COMPREPLY=( $(compgen -W "$hosts" -- "$cur") )
             fi
             ;;
-        connect)
+        connect|exec)
             if (( COMP_CWORD == 2 )); then
                 COMPREPLY=( $(compgen -W "$hosts" -- "$cur") )
             fi
@@ -359,7 +360,7 @@ _sshub() {{
                         _describe 'host' hosts
                     fi
                     ;;
-                connect)
+                connect|exec)
                     (( CURRENT == 3 )) && _describe 'host' hosts
                     ;;
                 groups|group)
@@ -477,6 +478,9 @@ fn render_fish(host_names: &[String]) -> String {
         let q = fish_sq(name);
         out.push_str(&format!(
             "complete -c sshub -n '__fish_seen_subcommand_from host connect; and __fish_seen_subcommand_from connect show resolve delete duplicate' -a {q}\n"
+        ));
+        out.push_str(&format!(
+            "complete -c sshub -n '__fish_seen_subcommand_from exec' -a {q}\n"
         ));
         out.push_str(&format!(
             "complete -c sshub -n '__fish_seen_subcommand_from sftp; and not __fish_seen_subcommand_from ls get put rm mkdir rename chmod' -a {q}\n"

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,0 +1,397 @@
+//! `sshub exec <host> -- <command>`: run one command on a saved host.
+//!
+//! `sshub connect` hands the terminal to ssh for a human; this is the scripted
+//! counterpart. stdio passes through, the remote exit code becomes ours, and
+//! nothing here ever prompts. Session logging is deliberately skipped — the
+//! `script(1)` wrapper `connect` uses fights output redirection, which is the
+//! whole point of exec.
+
+use std::io::Read;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::app::{prepare_cli_connect_argv, resolve_pending_secret, session_argv_for_entry};
+use crate::cli::context::CliContext;
+use crate::cli::parse::{self, OutputFormat};
+use crate::session::askpass::AskpassSecret;
+use crate::session_transport::SessionTransport;
+
+/// What `timeout(1)` exits with when it kills the child; mirrored so a script
+/// can treat `sshub exec --timeout` the same way it treats `timeout`.
+const EXIT_TIMEOUT: i32 = 124;
+
+/// How often the timeout path checks on the child. std has no timed wait, and
+/// 50ms is noise next to the round-trip of any real remote command.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Serialize)]
+struct ExecRecord<'a> {
+    host: &'a str,
+    command: &'a str,
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+    duration_ms: u128,
+}
+
+pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
+    let (mut head, after_dashes) = split_at_dashes(args);
+
+    let verbose = parse::take_flag(&mut head, "--verbose") || parse::take_flag(&mut head, "-v");
+    let tty = parse::take_flag(&mut head, "--tty");
+    let fmt = parse::parse_format(&head).map_err(anyhow::Error::msg)?;
+    parse::take_opt(&mut head, "--format");
+    let timeout = match parse::take_opt(&mut head, "--timeout") {
+        Some(v) => Some(Duration::from_secs(v.parse().map_err(|_| {
+            anyhow::anyhow!("invalid --timeout '{v}' (whole seconds)")
+        })?)),
+        None => None,
+    };
+
+    let pos = parse::positional(&head);
+    let Some(name) = pos.first().map(|s| s.to_string()) else {
+        parse::usage("exec requires a host: sshub exec <host> -- <command>");
+    };
+    let command = after_dashes.unwrap_or_else(|| pos[1..].join(" "));
+    if command.trim().is_empty() {
+        parse::usage("exec requires a command: sshub exec <host> -- <command>");
+    }
+
+    let entry = ctx.host_by_name(&name)?.clone();
+    // mosh has no one-shot command mode: `mosh host -- cmd` opens an interactive
+    // session anyway, which for a script means a hang, not an error.
+    if matches!(entry.session_transport(), SessionTransport::Mosh) {
+        anyhow::bail!(
+            "host '{name}' uses the mosh transport, which cannot run a one-shot command — \
+             use `sshub connect {name}`, or switch the host to the ssh transport"
+        );
+    }
+
+    let host_name = entry.name().to_string();
+    let (pending_secret, _) = resolve_pending_secret(&entry, ctx.password_store.as_ref());
+    let argv = exec_argv(
+        prepare_cli_connect_argv(
+            session_argv_for_entry(&entry),
+            pending_secret.is_some(),
+            verbose,
+        ),
+        entry.ssh_host().remote_command.as_deref(),
+        &command,
+        tty,
+    );
+
+    let mut askpass_guard = None;
+    let mut extra_env: Vec<(String, String)> = Vec::new();
+    if let Some(secret) = pending_secret.as_ref() {
+        if let Ok(exe) = crate::session::askpass::helper_exe() {
+            if let Ok(guard) = AskpassSecret::new(secret.value()) {
+                extra_env = guard.env(&exe);
+                askpass_guard = Some(guard);
+            }
+        }
+    }
+
+    let json = matches!(fmt, OutputFormat::Json);
+    let program = argv.first().context("empty exec argv")?;
+    let mut cmd = Command::new(program);
+    cmd.args(&argv[1..]);
+    // stdin is inherited in both modes so `echo … | sshub exec db -- 'psql -f -'`
+    // works; only the output side is buffered, and only for JSON.
+    cmd.stdin(Stdio::inherit());
+    cmd.stdout(if json {
+        Stdio::piped()
+    } else {
+        Stdio::inherit()
+    });
+    cmd.stderr(if json {
+        Stdio::piped()
+    } else {
+        Stdio::inherit()
+    });
+    for (k, v) in &extra_env {
+        cmd.env(k, v);
+    }
+
+    // Legacy ssh_config hosts have no managed record, so fall back to the
+    // resolved SshHost rather than logging username=None.
+    let ssh = entry.ssh_host();
+    let username = entry
+        .managed()
+        .and_then(|m| {
+            m.username
+                .clone()
+                .or_else(|| m.identity.as_ref().and_then(|i| i.username.clone()))
+        })
+        .or(ssh.user);
+
+    let started = Instant::now();
+    let mut child = match cmd.spawn() {
+        Ok(child) => {
+            // The command itself is never logged: it can carry a password in an
+            // argument, and the audit log is not the place to keep one.
+            let _ = ctx.store.log_auth_event(
+                &host_name,
+                username.as_deref(),
+                "exec",
+                "launched",
+                "cli exec",
+                None,
+            );
+            child
+        }
+        Err(e) => {
+            let msg = format!("spawn failed: {e:#}");
+            let _ = ctx.store.log_auth_event(
+                &host_name,
+                username.as_deref(),
+                "exec",
+                "fail",
+                &msg,
+                None,
+            );
+            eprintln!("sshub: {msg}");
+            return Ok(1);
+        }
+    };
+
+    // Drain the pipes on their own threads: a command that outfills the pipe
+    // buffer would otherwise block forever while we poll for the timeout.
+    let readers = json.then(|| (drain(child.stdout.take()), drain(child.stderr.take())));
+    let (status, timed_out) = wait_or_kill(&mut child, timeout)?;
+    let (stdout, stderr) = match readers {
+        Some((out, err)) => (
+            out.join().unwrap_or_default(),
+            err.join().unwrap_or_default(),
+        ),
+        None => (String::new(), String::new()),
+    };
+
+    let exit_code = if timed_out {
+        eprintln!("sshub: exec timed out, killed the remote command");
+        EXIT_TIMEOUT
+    } else {
+        status.code().unwrap_or(1)
+    };
+
+    if json {
+        let record = ExecRecord {
+            host: &host_name,
+            command: &command,
+            exit_code,
+            stdout,
+            stderr,
+            duration_ms: started.elapsed().as_millis(),
+        };
+        println!("{}", serde_json::to_string_pretty(&record)?);
+    }
+
+    drop(askpass_guard);
+    Ok(exit_code)
+}
+
+/// Split argv at the first `--`: everything before it is ours, everything after
+/// is the remote command, joined with spaces exactly the way ssh joins its own
+/// trailing arguments. `None` when there is no `--` at all.
+pub(crate) fn split_at_dashes(args: &[String]) -> (Vec<String>, Option<String>) {
+    match args.iter().position(|a| a == "--") {
+        Some(i) => (args[..i].to_vec(), Some(args[i + 1..].join(" "))),
+        None => (args.to_vec(), None),
+    }
+}
+
+/// The part of `rest` that may carry sshub's own `--help` / `-h`. Anything after
+/// `--` belongs to the remote command: `sshub exec web -- ls -h` lists a remote
+/// directory, it does not print our help.
+pub(crate) fn help_scan(rest: &[String]) -> &[String] {
+    match rest.iter().position(|a| a == "--") {
+        Some(i) => &rest[..i],
+        None => rest,
+    }
+}
+
+/// Turn a connect argv into an exec argv: no PTY unless asked for, and the
+/// ad-hoc command appended after the target.
+///
+/// A host with a stored `remote_command` already carries it as a trailing
+/// `-- <cmd>` (see `build_ssh_argv`); that one is dropped, because the command
+/// typed on the exec line has to win.
+pub(crate) fn exec_argv(
+    mut argv: Vec<String>,
+    stored_remote_command: Option<&str>,
+    command: &str,
+    tty: bool,
+) -> Vec<String> {
+    if let Some(stored) = stored_remote_command.filter(|s| !s.is_empty()) {
+        let n = argv.len();
+        if n >= 2 && argv[n - 1] == stored && argv[n - 2] == "--" {
+            argv.truncate(n - 2);
+        }
+    }
+    // `-T` keeps this batch-friendly; `-tt` forces a PTY for the commands that
+    // insist on one (sudo without NOPASSWD, top).
+    argv.insert(1, if tty { "-tt" } else { "-T" }.to_string());
+    argv.push("--".into());
+    argv.push(command.to_string());
+    argv
+}
+
+/// Read a child pipe to the end on its own thread.
+fn drain<R: Read + Send + 'static>(pipe: Option<R>) -> JoinHandle<String> {
+    std::thread::spawn(move || {
+        let mut buf = String::new();
+        if let Some(mut pipe) = pipe {
+            // Lossy on purpose: a remote command may emit anything, and exec
+            // still has to report its exit code.
+            let mut bytes = Vec::new();
+            let _ = pipe.read_to_end(&mut bytes);
+            buf = String::from_utf8_lossy(&bytes).into_owned();
+        }
+        buf
+    })
+}
+
+/// Wait for `child`, killing it once `timeout` has passed. The bool is true when
+/// it was killed rather than having exited on its own.
+fn wait_or_kill(child: &mut Child, timeout: Option<Duration>) -> Result<(ExitStatus, bool)> {
+    let Some(limit) = timeout else {
+        return Ok((child.wait().context("wait exec child")?, false));
+    };
+    let deadline = Instant::now() + limit;
+    loop {
+        if let Some(status) = child.try_wait().context("poll exec child")? {
+            return Ok((status, false));
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            return Ok((child.wait().context("reap timed-out exec child")?, true));
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn exec_argv_appends_the_command_after_the_target() {
+        let argv = exec_argv(
+            s(&["ssh", "-p", "2222", "root@10.0.0.1"]),
+            None,
+            "uptime",
+            false,
+        );
+        assert_eq!(
+            argv,
+            s(&["ssh", "-T", "-p", "2222", "root@10.0.0.1", "--", "uptime"])
+        );
+    }
+
+    #[test]
+    fn exec_argv_tty_flag_forces_a_pty() {
+        let argv = exec_argv(s(&["ssh", "web"]), None, "sudo reboot", true);
+        assert_eq!(argv, s(&["ssh", "-tt", "web", "--", "sudo reboot"]));
+    }
+
+    #[test]
+    fn exec_argv_ad_hoc_command_replaces_a_stored_remote_command() {
+        // What `build_ssh_argv` produces for a host with remote_command set.
+        let stored = s(&["ssh", "web", "--", "tmux attach"]);
+        let argv = exec_argv(stored, Some("tmux attach"), "uptime", false);
+        assert_eq!(argv, s(&["ssh", "-T", "web", "--", "uptime"]));
+        assert_eq!(argv.iter().filter(|a| *a == "--").count(), 1);
+    }
+
+    #[test]
+    fn exec_argv_keeps_a_trailing_word_that_only_looks_like_a_stored_command() {
+        // No `--` before it, so it is the target, not a stored remote command.
+        let argv = exec_argv(s(&["ssh", "web"]), Some("web"), "uptime", false);
+        assert_eq!(argv, s(&["ssh", "-T", "web", "--", "uptime"]));
+    }
+
+    #[test]
+    fn split_at_dashes_takes_everything_after_the_separator_as_the_command() {
+        let (head, cmd) = split_at_dashes(&s(&["web", "--tty", "--", "tail", "-n", "5", "log"]));
+        assert_eq!(head, s(&["web", "--tty"]));
+        assert_eq!(cmd.as_deref(), Some("tail -n 5 log"));
+    }
+
+    #[test]
+    fn split_at_dashes_without_a_separator_leaves_the_command_to_the_positionals() {
+        let (head, cmd) = split_at_dashes(&s(&["web", "uptime"]));
+        assert_eq!(head, s(&["web", "uptime"]));
+        assert_eq!(cmd, None);
+    }
+
+    /// Differential test against OpenSSH: the argv `exec_argv` builds has to be
+    /// one real ssh parses as *this* host, with the PTY policy we asked for.
+    /// `ssh -G` resolves a command line and exits without connecting, so this
+    /// needs neither network nor server. `-F /dev/null` keeps the developer's
+    /// own `~/.ssh/config` out of the answer.
+    ///
+    /// What it does not prove: `-G` never echoes a remote command given on the
+    /// command line, so nothing here checks how ssh joins the words after `--`.
+    /// That claim is only covered by the unit tests above.
+    #[test]
+    fn argv_is_understood_by_real_ssh() {
+        if Command::new("ssh").arg("-V").output().is_err() {
+            eprintln!("skipping: no ssh binary");
+            return;
+        }
+
+        // `-T` is spelled "no" by OpenSSH < 10 and "false" by newer ones.
+        for (tty, want_tty) in [(false, ["no", "false"]), (true, ["force", "force"])] {
+            let argv = exec_argv(
+                s(&["ssh", "-p", "2222", "deploy@10.0.0.5"]),
+                None,
+                "tail -n 5 /var/log/app.log",
+                tty,
+            );
+            let out = Command::new("ssh")
+                .args(["-F", "/dev/null", "-G"])
+                .args(&argv[1..])
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "ssh rejected the argv we build: {argv:?}\n{}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+
+            let cfg = String::from_utf8_lossy(&out.stdout);
+            let field = |key: &str| {
+                cfg.lines()
+                    .find_map(|l| l.strip_prefix(&format!("{key} ")))
+                    .map(str::trim)
+            };
+            // The target still resolves the way we meant it to: a command
+            // appended in the wrong place would land ssh on another host.
+            assert_eq!(field("hostname"), Some("10.0.0.5"), "argv {argv:?}");
+            assert_eq!(field("user"), Some("deploy"), "argv {argv:?}");
+            assert_eq!(field("port"), Some("2222"), "argv {argv:?}");
+            let requesttty = field("requesttty").unwrap_or("<missing>");
+            assert!(
+                want_tty.contains(&requesttty),
+                "ssh read {requesttty:?} out of {argv:?}, expected one of {want_tty:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn help_scan_ignores_flags_meant_for_the_remote_command() {
+        assert!(help_scan(&s(&["web", "--", "ls", "-h"]))
+            .iter()
+            .all(|a| a != "-h"));
+        assert!(help_scan(&s(&["web", "--help"]))
+            .iter()
+            .any(|a| a == "--help"));
+    }
+}

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -45,10 +45,21 @@ pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
     let tty = parse::take_flag(&mut head, "--tty");
     let fmt = parse::parse_format(&head).map_err(anyhow::Error::msg)?;
     parse::take_opt(&mut head, "--format");
-    let timeout = match parse::take_opt(&mut head, "--timeout") {
-        Some(v) => Some(Duration::from_secs(v.parse().map_err(|_| {
-            anyhow::anyhow!("invalid --timeout '{v}' (whole seconds)")
-        })?)),
+    // `take_opt` cannot tell "flag absent" from "flag without a value", and for
+    // the flag that is the whole safety net of a scripted run, silently having
+    // no timeout is the wrong way to fail.
+    let timeout = match head.iter().position(|a| a == "--timeout") {
+        Some(_) => {
+            let raw = parse::take_opt(&mut head, "--timeout")
+                .unwrap_or_else(|| parse::usage("--timeout requires a value in whole seconds"));
+            let secs: u64 = raw
+                .parse()
+                .map_err(|_| anyhow::anyhow!("invalid --timeout '{raw}' (whole seconds)"))?;
+            if secs == 0 {
+                parse::usage("--timeout must be at least 1 second");
+            }
+            Some(Duration::from_secs(secs))
+        }
         None => None,
     };
 
@@ -56,7 +67,21 @@ pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
     let Some(name) = pos.first().map(|s| s.to_string()) else {
         parse::usage("exec requires a host: sshub exec <host> -- <command>");
     };
-    let command = after_dashes.unwrap_or_else(|| pos[1..].join(" "));
+    let command = match after_dashes {
+        Some(cmd) => cmd,
+        None => {
+            // Every flag exec knows has been taken out of `head` by now, and
+            // `positional` drops what is left over, so an unknown exec flag or a
+            // flag meant for the remote command would vanish without a word.
+            if let Some(flag) = head.iter().find(|a| a.starts_with('-')) {
+                parse::usage(&format!(
+                    "'{flag}' is not an exec flag; put the remote command after `--`: \
+                     sshub exec {name} -- <command>"
+                ));
+            }
+            pos[1..].join(" ")
+        }
+    };
     if command.trim().is_empty() {
         parse::usage("exec requires a command: sshub exec <host> -- <command>");
     }
@@ -82,6 +107,11 @@ pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
         entry.ssh_host().remote_command.as_deref(),
         &command,
         tty,
+        // BatchMode also switches off the askpass helper, so it can only go in
+        // when there is no staged secret to hand over. Without a secret exec
+        // must never sit on a prompt: ssh reads those from /dev/tty, so
+        // redirecting stdin does not save a script from hanging forever.
+        pending_secret.is_none(),
     );
 
     let mut askpass_guard = None;
@@ -114,6 +144,9 @@ pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
     });
     for (k, v) in &extra_env {
         cmd.env(k, v);
+    }
+    if timeout.is_some() {
+        spawn_group(&mut cmd);
     }
 
     // Legacy ssh_config hosts have no managed record, so fall back to the
@@ -154,6 +187,19 @@ pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
                 None,
             );
             eprintln!("sshub: {msg}");
+            // A JSON caller gets a record even here: an empty stdout is not
+            // something a parser on the other end can act on.
+            if matches!(fmt, OutputFormat::Json) {
+                let record = ExecRecord {
+                    host: &host_name,
+                    command: &command,
+                    exit_code: 1,
+                    stdout: String::new(),
+                    stderr: format!("sshub: {msg}\n"),
+                    duration_ms: started.elapsed().as_millis(),
+                };
+                println!("{}", serde_json::to_string_pretty(&record)?);
+            }
             return Ok(1);
         }
     };
@@ -171,7 +217,12 @@ pub fn run(ctx: &mut CliContext, args: &[String]) -> Result<i32> {
     };
 
     let exit_code = if timed_out {
-        eprintln!("sshub: exec timed out, killed the remote command");
+        // The local ssh is what gets killed. A remote command started without a
+        // PTY can outlive the connection, so promising more than this would be
+        // a lie.
+        eprintln!("sshub: exec timed out after {}s, killed ssh", {
+            timeout.map(|t| t.as_secs()).unwrap_or(0)
+        });
         EXIT_TIMEOUT
     } else {
         status.code().unwrap_or(1)
@@ -213,17 +264,26 @@ pub(crate) fn help_scan(rest: &[String]) -> &[String] {
     }
 }
 
-/// Turn a connect argv into an exec argv: no PTY unless asked for, and the
-/// ad-hoc command appended after the target.
+/// Turn a connect argv into an exec argv: no PTY unless asked for, no prompts,
+/// no inherited remote command, and the ad-hoc command appended after the
+/// target.
 ///
-/// A host with a stored `remote_command` already carries it as a trailing
-/// `-- <cmd>` (see `build_ssh_argv`); that one is dropped, because the command
-/// typed on the exec line has to win.
+/// A stored per-host remote command reaches ssh two different ways, and the
+/// command typed on the exec line has to beat both:
+///
+/// - launcher-managed hosts carry it as a trailing `-- <cmd>` in the argv
+///   (see `build_ssh_argv`), which is truncated off here;
+/// - `ssh_config` hosts connect by alias, so the argv has nothing to strip and
+///   ssh reads `RemoteCommand` from the config itself — where it does not merely
+///   lose, it makes ssh refuse the run outright with "Cannot execute
+///   command-line and remote command" (exit 255). `RemoteCommand=none` is what
+///   clears it.
 pub(crate) fn exec_argv(
     mut argv: Vec<String>,
     stored_remote_command: Option<&str>,
     command: &str,
     tty: bool,
+    batch: bool,
 ) -> Vec<String> {
     if let Some(stored) = stored_remote_command.filter(|s| !s.is_empty()) {
         let n = argv.len();
@@ -234,6 +294,10 @@ pub(crate) fn exec_argv(
     // `-T` keeps this batch-friendly; `-tt` forces a PTY for the commands that
     // insist on one (sudo without NOPASSWD, top).
     argv.insert(1, if tty { "-tt" } else { "-T" }.to_string());
+    argv.splice(1..1, ["-o".to_string(), "RemoteCommand=none".to_string()]);
+    if batch {
+        argv.splice(1..1, ["-o".to_string(), "BatchMode=yes".to_string()]);
+    }
     argv.push("--".into());
     argv.push(command.to_string());
     argv
@@ -256,6 +320,12 @@ fn drain<R: Read + Send + 'static>(pipe: Option<R>) -> JoinHandle<String> {
 
 /// Wait for `child`, killing it once `timeout` has passed. The bool is true when
 /// it was killed rather than having exited on its own.
+///
+/// Killing takes the whole process group, not just ssh: with `ProxyJump` ssh
+/// spawns an `ssh -W` helper that inherits our pipes, and killing only the
+/// parent leaves that helper holding them open — the drain threads below then
+/// never see EOF and `--timeout` never returns. See `spawn_group` for why the
+/// group only exists when a timeout was asked for.
 fn wait_or_kill(child: &mut Child, timeout: Option<Duration>) -> Result<(ExitStatus, bool)> {
     let Some(limit) = timeout else {
         return Ok((child.wait().context("wait exec child")?, false));
@@ -266,11 +336,41 @@ fn wait_or_kill(child: &mut Child, timeout: Option<Duration>) -> Result<(ExitSta
             return Ok((status, false));
         }
         if Instant::now() >= deadline {
-            let _ = child.kill();
+            kill_group(child);
             return Ok((child.wait().context("reap timed-out exec child")?, true));
         }
         std::thread::sleep(POLL_INTERVAL);
     }
+}
+
+/// Put the child in its own process group so the timeout can kill everything it
+/// spawned. Only done when a timeout was given: a process group of its own also
+/// takes the child out of the terminal's foreground group, so `Ctrl-C` would
+/// stop reaching ssh — an acceptable trade for a run that already declared a
+/// deadline, but not for one that did not.
+#[cfg(unix)]
+fn spawn_group(cmd: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    cmd.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn spawn_group(_cmd: &mut Command) {}
+
+#[cfg(unix)]
+fn kill_group(child: &Child) {
+    // SIGKILL the group; the child is its own group leader (`process_group(0)`),
+    // so its pid is the group id. Falls back to the single child if the group
+    // call fails, which is all a non-group spawn could have killed anyway.
+    let pid = child.id() as i32;
+    if unsafe { libc::killpg(pid, libc::SIGKILL) } != 0 {
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_group(child: &mut Child) {
+    let _ = child.kill();
 }
 
 #[cfg(test)]
@@ -288,33 +388,65 @@ mod tests {
             None,
             "uptime",
             false,
+            false,
         );
         assert_eq!(
             argv,
-            s(&["ssh", "-T", "-p", "2222", "root@10.0.0.1", "--", "uptime"])
+            s(&[
+                "ssh",
+                "-o",
+                "RemoteCommand=none",
+                "-T",
+                "-p",
+                "2222",
+                "root@10.0.0.1",
+                "--",
+                "uptime"
+            ])
         );
     }
 
     #[test]
     fn exec_argv_tty_flag_forces_a_pty() {
-        let argv = exec_argv(s(&["ssh", "web"]), None, "sudo reboot", true);
-        assert_eq!(argv, s(&["ssh", "-tt", "web", "--", "sudo reboot"]));
+        let argv = exec_argv(s(&["ssh", "web"]), None, "sudo reboot", true, false);
+        assert!(argv.contains(&"-tt".to_string()) && !argv.contains(&"-T".to_string()));
+        assert_eq!(&argv[argv.len() - 3..], s(&["web", "--", "sudo reboot"]));
+    }
+
+    /// Without a stored secret nothing can answer a prompt, and ssh reads its
+    /// prompts from `/dev/tty` — a script with redirected stdin still hangs.
+    #[test]
+    fn exec_argv_without_a_staged_secret_runs_in_batch_mode() {
+        let batch = exec_argv(s(&["ssh", "web"]), None, "uptime", false, true);
+        assert!(batch.windows(2).any(|w| w == s(&["-o", "BatchMode=yes"])));
+
+        // With a secret staged, BatchMode would switch the askpass helper off.
+        let staged = exec_argv(s(&["ssh", "web"]), None, "uptime", false, false);
+        assert!(!staged.iter().any(|a| a == "BatchMode=yes"));
     }
 
     #[test]
     fn exec_argv_ad_hoc_command_replaces_a_stored_remote_command() {
-        // What `build_ssh_argv` produces for a host with remote_command set.
-        let stored = s(&["ssh", "web", "--", "tmux attach"]);
-        let argv = exec_argv(stored, Some("tmux attach"), "uptime", false);
-        assert_eq!(argv, s(&["ssh", "-T", "web", "--", "uptime"]));
+        // Built by the real thing rather than hand-written, so a change to how
+        // `build_ssh_argv` emits the stored command fails this test instead of
+        // silently making the truncation below a no-op.
+        let mut host = crate::ssh::SshHost::new("web");
+        host.hostname = Some("10.0.0.7".into());
+        host.remote_command = Some("tmux attach".into());
+        let stored = crate::ssh::build_ssh_argv(&host);
+        assert_eq!(&stored[stored.len() - 2..], s(&["--", "tmux attach"]));
+
+        let argv = exec_argv(stored, Some("tmux attach"), "uptime", false, false);
+        assert_eq!(&argv[argv.len() - 3..], s(&["10.0.0.7", "--", "uptime"]));
         assert_eq!(argv.iter().filter(|a| *a == "--").count(), 1);
+        assert!(!argv.iter().any(|a| a == "tmux attach"));
     }
 
     #[test]
     fn exec_argv_keeps_a_trailing_word_that_only_looks_like_a_stored_command() {
         // No `--` before it, so it is the target, not a stored remote command.
-        let argv = exec_argv(s(&["ssh", "web"]), Some("web"), "uptime", false);
-        assert_eq!(argv, s(&["ssh", "-T", "web", "--", "uptime"]));
+        let argv = exec_argv(s(&["ssh", "web"]), Some("web"), "uptime", false, false);
+        assert_eq!(&argv[argv.len() - 3..], s(&["web", "--", "uptime"]));
     }
 
     #[test]
@@ -354,6 +486,7 @@ mod tests {
                 None,
                 "tail -n 5 /var/log/app.log",
                 tty,
+                true,
             );
             let out = Command::new("ssh")
                 .args(["-F", "/dev/null", "-G"])
@@ -383,6 +516,76 @@ mod tests {
                 "ssh read {requesttty:?} out of {argv:?}, expected one of {want_tty:?}"
             );
         }
+    }
+
+    /// The other half of the OpenSSH oracle, and the one `-F /dev/null` above
+    /// cannot see: a host whose `~/.ssh/config` sets `RemoteCommand` makes ssh
+    /// refuse a command line outright — "Cannot execute command-line and remote
+    /// command", exit 255 — rather than letting the ad-hoc command win. Asked of
+    /// the real ssh, with a real config, because that refusal is ssh's rule and
+    /// no test we write ourselves would know it.
+    #[test]
+    fn a_config_remote_command_does_not_defeat_the_ad_hoc_command() {
+        use std::io::Write;
+        if Command::new("ssh").arg("-V").output().is_err() {
+            eprintln!("skipping: no ssh binary");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = dir.path().join("config");
+        let mut f = std::fs::File::create(&cfg).unwrap();
+        writeln!(
+            f,
+            "Host rc-host\n    HostName 10.0.0.8\n    RemoteCommand tmux attach"
+        )
+        .unwrap();
+        drop(f);
+
+        // Alias-form argv, the shape `ssh_argv_for_entry` builds for an
+        // ssh_config-sourced host: nothing to truncate, the stored command
+        // lives in the config file.
+        let argv = exec_argv(s(&["ssh", "rc-host"]), None, "uptime", false, true);
+        let out = Command::new("ssh")
+            .arg("-F")
+            .arg(&cfg)
+            .arg("-G")
+            .args(&argv[1..])
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "ssh refused the argv we build for a host with a config RemoteCommand: {argv:?}\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        // And the same argv without our `RemoteCommand=none` is what ssh
+        // refuses — so the option above is load-bearing, not decoration. This
+        // is the failure the feature would ship with if it were dropped.
+        let stripped: Vec<String> = argv[1..]
+            .iter()
+            .enumerate()
+            .filter(|(i, a)| {
+                a.as_str() != "RemoteCommand=none"
+                    && argv[1..].get(i + 1).map(String::as_str) != Some("RemoteCommand=none")
+            })
+            .map(|(_, a)| a.clone())
+            .collect();
+        let refused = Command::new("ssh")
+            .arg("-F")
+            .arg(&cfg)
+            .arg("-G")
+            .args(&stripped)
+            .output()
+            .unwrap();
+        assert!(
+            !refused.status.success(),
+            "expected ssh to refuse {stripped:?} against a config RemoteCommand"
+        );
+        assert!(
+            String::from_utf8_lossy(&refused.stderr).contains("remote command"),
+            "unexpected refusal: {}",
+            String::from_utf8_lossy(&refused.stderr)
+        );
     }
 
     #[test]

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -10,6 +10,7 @@ pub fn print_command_help(cmd: &str) {
     match cmd {
         "host" => print_host(),
         "connect" => print_connect(),
+        "exec" => print_exec(),
         "list" => print_list(),
         "groups" => print_groups(),
         "group" => print_group(),
@@ -59,6 +60,29 @@ fn print_connect() {
 
 USAGE:
     sshub connect <name> [-v|--verbose]"#
+    );
+}
+
+fn print_exec() {
+    println!(
+        r#"sshub exec - run one command on a saved host and return its exit code
+
+USAGE:
+    sshub exec <host> [OPTIONS] -- <command> [args...]
+    sshub exec <host> [OPTIONS] "<command>"
+
+OPTIONS:
+    --tty                 Force a PTY (-tt) for commands that insist on one
+    --timeout SECS        Kill the command after SECS and exit 124, like timeout(1)
+    --format plain|json   json buffers the run as {{host, command, exit_code,
+                          stdout, stderr, duration_ms}}; plain (default) streams
+    -v, --verbose         Verbose ssh logging on stderr
+
+stdout/stderr pass through, stdin is inherited so pipes work, and the exit code
+is the remote command's (ssh's own failures keep ssh's 255). Never prompts.
+Session transcripts are skipped for exec — script(1) wrapping fights redirection;
+use `sshub connect` when you want one. Mosh hosts are refused: mosh has no
+one-shot command mode. Runs show up in `sshub audit list --via exec`."#
     );
 }
 
@@ -153,9 +177,9 @@ fn print_audit() {
         r#"sshub audit - inspect the connection audit log
 
 USAGE:
-    sshub audit list  [--status all|ok|fail|retry] [--via all|connect|tunnel|agent]
+    sshub audit list  [--status all|ok|fail|retry] [--via all|connect|tunnel|agent|exec]
                       [--host NAME] [--limit N] [--days N] [--format plain|json]
-    sshub audit stats [--days N] [--via all|connect|tunnel|agent] [--include-retry]
+    sshub audit stats [--days N] [--via all|connect|tunnel|agent|exec] [--include-retry]
                       [--format plain|json]"#
     );
 }

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -79,10 +79,13 @@ OPTIONS:
     -v, --verbose         Verbose ssh logging on stderr
 
 stdout/stderr pass through, stdin is inherited so pipes work, and the exit code
-is the remote command's (ssh's own failures keep ssh's 255). Never prompts.
-Session transcripts are skipped for exec — script(1) wrapping fights redirection;
-use `sshub connect` when you want one. Mosh hosts are refused: mosh has no
-one-shot command mode. Runs show up in `sshub audit list --via exec`."#
+is the remote command's (ssh's own failures keep ssh's 255). Never prompts: with
+no stored credential exec runs ssh in BatchMode, so an unknown host key fails
+instead of waiting for a human. A per-host or ssh_config remote command is
+overridden by the command given here. Session transcripts are skipped for exec —
+script(1) wrapping fights redirection; use `sshub connect` when you want one.
+Mosh hosts are refused: mosh has no one-shot command mode. Runs show up in
+`sshub audit list --via exec`."#
     );
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod audit;
 pub mod completions;
 pub mod context;
+pub mod exec;
 pub mod filter;
 pub mod group;
 pub mod help;
@@ -24,6 +25,7 @@ pub fn is_subcommand(cmd: &str) -> bool {
         cmd,
         "host"
             | "connect"
+            | "exec"
             | "list"
             | "tunnel"
             | "group"
@@ -42,12 +44,20 @@ pub fn is_subcommand(cmd: &str) -> bool {
 /// Dispatch a subcommand. `rest` is argv AFTER the subcommand token. main.rs
 /// owns bootstrap and passes `ctx` in; this fn must NOT call CliContext::bootstrap.
 pub fn run_subcommand(ctx: &mut CliContext, cmd: &str, rest: &[String]) -> Result<i32> {
-    if rest.iter().any(|a| a == "--help" || a == "-h") {
+    // `exec` passes everything after `--` to the remote shell, so a `-h` in
+    // there is the remote command's flag, not a request for our help.
+    let help_args = if cmd == "exec" {
+        exec::help_scan(rest)
+    } else {
+        rest
+    };
+    if help_args.iter().any(|a| a == "--help" || a == "-h") {
         help::print_command_help(cmd);
         return Ok(0);
     }
     match cmd {
         "host" => host::run_host(ctx, rest),
+        "exec" => exec::run(ctx, rest),
         // aliases:
         "connect" => host::run_host(ctx, &prepend("connect", rest)),
         "list" => host::run_host(ctx, &prepend("list", rest)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,9 @@ HOST (read/write):
     sshub host search <query> [--format plain|json]
     sshub host add|edit|rename|delete|duplicate …
 
+EXEC (scripted, non-interactive):
+    sshub exec <host> [--tty] [--timeout SECS] [--format plain|json] -- <command> [args…]
+
 ALIASES:
     sshub connect <name>                    Same as `host connect`
     sshub list …                            Same as `host list`

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,16 @@ fn main() -> Result<()> {
 
     // Global profile flags (`--profile NAME`, `--manage-profiles`) apply to
     // both the TUI and headless subcommands, so parse them before dispatch.
-    let (startup, args) = profile::extract_startup_flags(args)?;
+    // Everything after a `--` belongs to a remote command (`sshub exec web --
+    // aws --profile prod s3 ls`) and is held back from that scan: otherwise the
+    // launcher would swallow the remote tool's flags and either fail with
+    // "unknown profile" or silently run the command with a flag missing.
+    let (head, tail) = match args.iter().position(|a| a == "--") {
+        Some(i) => (args[..i].to_vec(), args[i..].to_vec()),
+        None => (args, Vec::new()),
+    };
+    let (startup, mut args) = profile::extract_startup_flags(head)?;
+    args.extend(tail);
 
     // Subcommands must be handled before the global flags and the TUI launch
     // path, so that `sshub <cmd> --help` reaches the subcommand's own help

--- a/src/store/hosts.rs
+++ b/src/store/hosts.rs
@@ -816,9 +816,10 @@ impl LauncherStore {
             }
             if let Some(v) = via.filter(|v| *v != "all") {
                 match v {
-                    "connect" => conds.push("via NOT IN ('tunnel', 'agent')".into()),
+                    "connect" => conds.push("via NOT IN ('tunnel', 'agent', 'exec')".into()),
                     "tunnel" => conds.push("via = 'tunnel'".into()),
                     "agent" => conds.push("via = 'agent'".into()),
+                    "exec" => conds.push("via = 'exec'".into()),
                     other => conds.push(format!("via = '{other}'")),
                 }
             }
@@ -872,9 +873,10 @@ fn status_sql(status: &str) -> String {
 fn via_filter_sql(via: Option<&str>) -> String {
     match via {
         None | Some("all") => String::new(),
-        Some("connect") => " AND via NOT IN ('tunnel', 'agent')".into(),
+        Some("connect") => " AND via NOT IN ('tunnel', 'agent', 'exec')".into(),
         Some("tunnel") => " AND via = 'tunnel'".into(),
         Some("agent") => " AND via = 'agent'".into(),
+        Some("exec") => " AND via = 'exec'".into(),
         Some(v) => format!(" AND via = '{v}'"),
     }
 }

--- a/tests/smoke/cli_commands.rs
+++ b/tests/smoke/cli_commands.rs
@@ -791,3 +791,84 @@ fn theme_check_unlistable_directory_exits_one() {
     std::fs::set_permissions(&closed, std::fs::Permissions::from_mode(0o755)).unwrap();
     assertion.code(1);
 }
+
+// ── exec ────────────────────────────────────────────────────────────────────
+// Every case here stops before a child is spawned: argument parsing, the
+// unknown-host lookup and the mosh refusal all fail first, so nothing reaches
+// the network. A real round-trip needs a live host and is not smoke-testable.
+
+#[test]
+fn exec_help_lists_the_flags_and_exits_zero() {
+    let d = dir();
+    sshub(d.path())
+        .args(["exec", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sshub exec"))
+        .stdout(predicate::str::contains("--tty"))
+        .stdout(predicate::str::contains("--timeout"));
+}
+
+#[test]
+fn exec_without_a_host_exits_two() {
+    let d = dir();
+    sshub(d.path())
+        .arg("exec")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("exec requires a host"));
+}
+
+#[test]
+fn exec_without_a_command_exits_two() {
+    let d = dir();
+    sshub(d.path())
+        .args(["exec", "some-host"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("exec requires a command"));
+}
+
+#[test]
+fn exec_on_an_unknown_host_fails_before_spawning() {
+    let d = dir();
+    sshub(d.path())
+        .args(["exec", "no-such-host", "--", "uptime"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+}
+
+#[test]
+fn exec_refuses_a_mosh_host() {
+    let d = dir();
+    sshub(d.path())
+        .args([
+            "host",
+            "add",
+            "--name",
+            "mosh-box",
+            "--address",
+            "10.0.0.9",
+            "--transport",
+            "mosh",
+        ])
+        .assert()
+        .success();
+
+    sshub(d.path())
+        .args(["exec", "mosh-box", "--", "uptime"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("mosh"));
+}
+
+#[test]
+fn global_help_lists_the_exec_command() {
+    let d = dir();
+    sshub(d.path())
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sshub exec"));
+}

--- a/tests/smoke/cli_commands.rs
+++ b/tests/smoke/cli_commands.rs
@@ -864,6 +864,56 @@ fn exec_refuses_a_mosh_host() {
 }
 
 #[test]
+fn exec_rejects_a_command_flag_that_is_not_behind_the_separator() {
+    let d = dir();
+    // `-l` would otherwise be dropped by positional parsing and the remote
+    // command would silently run as plain `ls`.
+    sshub(d.path())
+        .args(["exec", "some-host", "ls", "-l"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("after `--`"));
+}
+
+#[test]
+fn exec_timeout_without_a_value_is_a_usage_error() {
+    let d = dir();
+    sshub(d.path())
+        .args(["exec", "some-host", "--timeout", "--", "uptime"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("--timeout requires a value"));
+
+    sshub(d.path())
+        .args(["exec", "some-host", "--timeout", "0", "--", "uptime"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("at least 1 second"));
+}
+
+/// A remote command's own flags must not be read as sshub's: the profile
+/// parser in `main.rs` runs before dispatch and used to swallow them.
+#[test]
+fn exec_does_not_let_the_profile_parser_eat_the_remote_commands_flags() {
+    let d = dir();
+    sshub(d.path())
+        .args([
+            "exec",
+            "no-such-host",
+            "--",
+            "aws",
+            "--profile",
+            "prod",
+            "s3",
+            "ls",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"))
+        .stderr(predicate::str::contains("profile").not());
+}
+
+#[test]
 fn global_help_lists_the_exec_command() {
     let d = dir();
     sshub(d.path())


### PR DESCRIPTION
Closes #85 (Phase 1, single host — fan-out, `--script`, and any interactive prompting stay deferred as the issue asks).

## What changed

`sshub exec <host> [--tty] [--timeout SECS] [--format plain|json] [-v] -- <command>`. It reuses the connect path (`session_argv_for_entry` + `prepare_cli_connect_argv`, askpass guard, audit), so a script gets the stored identity, the password wiring and ProxyJump that hand-assembling an ssh line throws away.

- stdout/stderr pass through, stdin inherited (`echo … | sshub exec db -- 'psql -f -'`), exit code is the remote command's; ssh's own failures keep 255.
- `-T` by default, `-tt` behind `--tty`.
- `--timeout SECS` → exit 124 like `timeout(1)`.
- `--format json` → `{host, command, exit_code, stdout, stderr, duration_ms}`.
- Audited as `via exec`; `--via connect` now means interactive connects only.
- Mosh refused (no one-shot command mode). No session transcript — `script(1)` fights the redirection exec exists for.

## Deviations from the issue, on purpose

- **The command string is not logged.** The issue only asked for the run to be audited. A command can carry a password in an argument, so the audit row records `via exec` / note `cli exec` and nothing else.
- **`--via connect` excludes exec** (`src/store/hosts.rs`). The issue wanted exec visible "next to interactive connects" — it is, under the default `--via all`; giving `connect` its literal meaning seemed better than a category that quietly includes two things.

## Review findings, fixed in the second commit

The first commit passed local tests and would still have shipped three real bugs. All reproduced before fixing:

1. **`--timeout` never fired with `--format json` over ProxyJump.** Killing only ssh leaves the `ssh -W` helper holding the output pipes, so the drain threads never saw EOF and the run hung indefinitely. Fixed with a process group + group kill; also stops the helper surviving as an orphan (which held the *caller's* pipe open and stalled shell pipelines). The group is only created when a timeout was given — it takes the child out of the terminal's foreground group, so without a deadline `Ctrl-C` must keep reaching ssh.
2. **exec could sit on an ssh prompt forever** — the thing issue #85 explicitly forbids, while the help text claimed "never prompts". ssh reads prompts from `/dev/tty`, so redirected stdin does not save a script. `BatchMode=yes` now goes in whenever no secret is staged (with one it cannot: BatchMode disables the askpass helper too).
3. **A host with `RemoteCommand` in `~/.ssh/config` made ssh refuse the run** with `Cannot execute command-line and remote command` (exit 255). The argv-tail truncation only covered launcher-managed hosts. `-o RemoteCommand=none` covers both shapes.

Plus: a remote command's flags no longer reach the global profile parser (`sshub exec web -- aws --profile prod s3 ls` used to die with `unknown profile 'prod'`), a `-flag` without `--` is a usage error instead of being silently dropped, `--timeout` with no value is an error rather than a silently disabled timeout, and a spawn failure emits a JSON record instead of empty stdout.

## Security notes

Reviewed per the flow's §5 (this touches auth, env, and process spawning). Verified: the stored secret never reaches argv, the child's env beyond the askpass handoff, a log line, an error, or the JSON; the askpass guard outlives the child on every path including the timeout kill; `sshub exec <host> -- -oProxyCommand=id` is **not** exploitable — the `--` separator is always present and load-bearing (options *after* the hostname otherwise are parsed).

**Pre-existing issue found during review, filed separately, not fixed here** (per AGENTS.md): a host whose stored `address` starts with `-` becomes an ssh *option*, so `sshub connect`/`sftp`/`exec` build `ssh … -oProxyCommand=id` and run it locally. `address` comes verbatim from imported mRemoteNG/Termius/PuTTY files. Reachable today without this PR; the guard belongs in `build_ssh_argv`/host creation, not in exec.

## How tested

- [x] `just test` green — 1163 unit, 77 smoke, 81 e2e, 1 config_load
- [x] `cargo fmt --check` / `cargo clippy --all-targets` clean
- [x] **Oracle tests** (`docs/oracle-tests.md`): the argv we build is handed to real `ssh -G`, which confirms the target still resolves to the intended host/user/port and that `requesttty` matches `-T`/`-tt`; a second case asks ssh about the `RemoteCommand` conflict — our argv is accepted, and the same argv *without* `RemoteCommand=none` is refused, so the option cannot be dropped unnoticed. Both were seen red first: moving the command before the target makes OpenSSH answer `hostname contains invalid characters`. What they do **not** prove is written into the test docstring — `-G` never echoes a command-line remote command, so the word-joining after `--` rests on unit tests alone.
- [x] Manual: `--timeout` over a ProxyJump returns in 2s with exit 124 in both plain and JSON mode, leaving no orphaned ssh; the parse errors above checked against the built binary.
- [x] Adversarial review (§7) run on the diff; every finding reproduced against the code before acting on it.

`openwiki/workflows/cli.md` documents the command, the wire-up checklist and exit code 124. `openwiki/.last-update.json` is deliberately untouched: it records the last full generation run, and this is a hand edit of one page, not a validation pass over the wiki.

_Written by Claude Opus 5 (Claude Code) on behalf of the maintainer._