### PR TITLE
fix(ssh): a leading-dash host target is no longer an ssh option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to SSHub are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A stored host address starting with `-` reached ssh as an option, not a
+  host** (issue #101) - `sshub connect evil` on a host whose address is
+  `-oProxyCommand=id` built `ssh … -oProxyCommand=id`, and ssh dutifully ran
+  `id` *locally*. Addresses are written verbatim from imported PuTTY, Termius
+  and mRemoteNG files, so a crafted export was local code execution on the
+  machine that imported it — no typo of the user's own required. Every target
+  sshub hands to ssh or mosh (connect, exec, tunnels, alias connects) now goes
+  through one guard that rewrites a leading-dash target into the `ssh://` URI
+  form, which OpenSSH refuses outright instead of parsing as a flag; ordinary
+  targets are untouched. Confirmed against the real `ssh -G`, which still
+  reports `proxycommand id` for the old form and refuses the new one.
+
 ## [0.14.0] - 2026-08-12
 
 ### Added

--- a/src/ssh/host.rs
+++ b/src/ssh/host.rs
@@ -67,7 +67,7 @@ pub fn build_ssh_argv(host: &SshHost) -> Vec<String> {
     } else {
         hostname.to_string()
     };
-    args.push(target);
+    args.push(safe_ssh_target(target));
 
     // Remote command runs on the SSH host (appended after target)
     if let Some(ref cmd) = host.remote_command {
@@ -82,7 +82,28 @@ pub fn build_ssh_argv(host: &SshHost) -> Vec<String> {
 
 /// Build argv for alias connect (`ssh name` via ssh_config).
 pub fn build_ssh_alias_argv(host: &SshHost) -> Vec<String> {
-    vec!["ssh".into(), host.name.clone()]
+    vec!["ssh".into(), safe_ssh_target(host.name.clone())]
+}
+
+/// Make a connection target one ssh cannot read as an **option**.
+///
+/// ssh takes the first non-flag argument as the host, but a stored target that
+/// begins with `-` is handed over verbatim and parsed as a flag instead: an
+/// address of `-oProxyCommand=id` becomes `ProxyCommand id`, which ssh runs
+/// *locally*. Addresses are written verbatim from imported PuTTY, Termius and
+/// mRemoteNG files (`src/import/`), so this is not the user's own typing — a
+/// crafted export would otherwise execute code on the machine that imported it.
+///
+/// The `ssh://` URI form is what OpenSSH refuses outright instead of treating as
+/// a flag, so a hostile row now fails loudly rather than running anything, while
+/// ordinary targets are untouched. `ssh -- <host>` is not an alternative: the
+/// words after `--` become the remote command.
+pub fn safe_ssh_target(target: String) -> String {
+    if target.starts_with('-') {
+        format!("ssh://{target}")
+    } else {
+        target
+    }
 }
 
 /// Build argv for `mosh` using explicit connection fields (managed / direct connect).
@@ -92,7 +113,7 @@ pub fn build_mosh_argv(host: &SshHost) -> Vec<String> {
 
 /// Build argv for alias connect (`mosh name` via ssh_config).
 pub fn build_mosh_alias_argv(host: &SshHost) -> Vec<String> {
-    vec!["mosh".into(), host.name.clone()]
+    vec!["mosh".into(), safe_ssh_target(host.name.clone())]
 }
 
 const ACCEPT_NEW_SSH_OPT: &str = "StrictHostKeyChecking=accept-new";
@@ -310,5 +331,83 @@ mod tests {
                 "htop".to_string(),
             ]
         );
+    }
+
+    /// A host stored with an option-like address must not reach ssh as an
+    /// option. Asked of the real ssh, because "does OpenSSH read this argument
+    /// as a flag or as a hostname" is OpenSSH's rule, not ours: `ssh -G`
+    /// resolves a command line and exits without connecting, so this needs no
+    /// network and no server.
+    ///
+    /// Both halves matter. Without the guard ssh reports `proxycommand id` and
+    /// would run `id` locally on the next connect; with it ssh refuses the
+    /// target outright. The unguarded half is the regression check — if
+    /// `safe_ssh_target` ever stops firing, the first assertion here is what
+    /// fails.
+    #[test]
+    fn an_option_like_address_is_not_read_as_an_ssh_option() {
+        use std::process::Command;
+        if Command::new("ssh").arg("-V").output().is_err() {
+            eprintln!("skipping: no ssh binary");
+            return;
+        }
+
+        let hostile = "-oProxyCommand=id";
+        // Shaped like a real exec/connect line so ssh has something left to
+        // treat as the hostname once it has eaten the target as a flag.
+        let resolve = |target: &str| {
+            let out = Command::new("ssh")
+                .args(["-F", "/dev/null", "-G", "-T", target, "--", "uptime"])
+                .output()
+                .unwrap();
+            (
+                out.status.success(),
+                String::from_utf8_lossy(&out.stdout).into_owned(),
+            )
+        };
+
+        // What sshub used to hand over verbatim.
+        let (ok, cfg) = resolve(hostile);
+        assert!(
+            ok && cfg.lines().any(|l| l == "proxycommand id"),
+            "OpenSSH no longer reads a leading-dash target as an option; this \
+             guard may be obsolete:\n{cfg}"
+        );
+
+        // What it hands over now.
+        let mut host = SshHost::new("evil");
+        host.hostname = Some(hostile.into());
+        let argv = build_ssh_argv(&host);
+        let target = argv.last().unwrap();
+        assert_eq!(target, "ssh://-oProxyCommand=id");
+
+        let (ok, cfg) = resolve(target);
+        assert!(
+            !ok,
+            "ssh accepted the guarded target instead of refusing it:\n{cfg}"
+        );
+        assert!(
+            !cfg.contains("proxycommand id"),
+            "ProxyCommand survived the guard:\n{cfg}"
+        );
+    }
+
+    #[test]
+    fn safe_ssh_target_leaves_ordinary_targets_alone() {
+        for target in ["10.0.0.5", "deploy@10.0.0.5", "web-01", "user@-weird"] {
+            assert_eq!(safe_ssh_target(target.to_string()), target);
+        }
+        // Only a *leading* dash can be read as a flag; `user@-weird` cannot.
+        assert_eq!(
+            safe_ssh_target("-weird".to_string()),
+            "ssh://-weird".to_string()
+        );
+    }
+
+    #[test]
+    fn alias_and_mosh_argv_guard_the_target_too() {
+        let host = SshHost::new("-oProxyCommand=id");
+        assert_eq!(build_ssh_alias_argv(&host)[1], "ssh://-oProxyCommand=id");
+        assert_eq!(build_mosh_alias_argv(&host)[1], "ssh://-oProxyCommand=id");
     }
 }

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -12,7 +12,7 @@ pub use export::{
 };
 pub use host::{
     build_mosh_alias_argv, build_mosh_argv, build_ssh_alias_argv, build_ssh_argv,
-    inject_mosh_ssh_accept_new, SshHost,
+    inject_mosh_ssh_accept_new, safe_ssh_target, SshHost,
 };
 pub use import::{
     compute_ssh_config_hash, import_ssh_config, materialize_ssh_config_host, sync_ssh_config_hosts,

--- a/src/tunnel/spawn.rs
+++ b/src/tunnel/spawn.rs
@@ -86,7 +86,9 @@ pub fn build_tunnel_argv(
     } else {
         host.address.clone()
     };
-    args.push(target);
+    // Same guard as the connect path: an address stored with a leading `-` would
+    // reach ssh as an option, not a host. See `ssh::safe_ssh_target`.
+    args.push(crate::ssh::safe_ssh_target(target));
     Ok(args)
 }
 


### PR DESCRIPTION
Closes #101.

## The bug

A host stored with an address like `-oProxyCommand=id` was pushed onto the argv verbatim, so ssh read it as a **flag** rather than a hostname:

```
$ sshub host add --name evil --address "-oProxyCommand=id"
$ sshub host resolve evil --format json
argv: ['ssh', '-o', 'ForwardAgent=no', '-oProxyCommand=id']

$ ssh -F /dev/null -G -T "-oProxyCommand=id" -- uptime
hostname uptime
proxycommand id          # ← runs locally, as the invoking user
```

Not a self-inflicted typo: `address` is written verbatim from imported PuTTY / Termius / mRemoteNG files (`src/import/`), so a crafted export was local code execution on the machine that imported it and connected to that entry. `username` shares the position (`user@host`), and the same target construction lived in `connect`, `exec` and the tunnel spawner.

Found while reviewing #85 — `sshub exec` adds an *unattended* path to it — but it predates that PR and is reachable today.

## The fix

One guard where every path converges, rather than a check per call site:

- `ssh::safe_ssh_target` rewrites a leading-dash target into the `ssh://` URI form, which OpenSSH refuses outright instead of parsing as a flag. Ordinary targets are returned untouched.
- Applied in `build_ssh_argv`, `build_ssh_alias_argv`, `build_mosh_alias_argv` and `tunnel::spawn` — connect, exec, alias connects, mosh and tunnels.

`ssh -- <host>` is deliberately *not* used: the words after `--` become the remote command, and OpenSSH ≥ 10 answers `hostname contains invalid characters` anyway.

After the fix the same host fails visibly instead of executing anything:

```
argv: ['ssh', '-o', 'ForwardAgent=no', 'ssh://-oProxyCommand=id']
$ sshub connect evil
usage: ssh [-46AaCfGgKkMNnqsTtVvXxYy] …
```

## How tested

- [x] **Oracle test** (`docs/oracle-tests.md`) asking real `ssh -G` both halves: that OpenSSH *still* reads the unguarded form as `proxycommand id` — so the guard cannot quietly become obsolete or silently stop firing — and that it refuses the guarded one. Degrades with a message when there is no `ssh` binary.
- [x] Unit tests: ordinary targets untouched (including `user@-weird`, where the dash is not leading and cannot be read as a flag), alias and mosh argv guarded.
- [x] `just test` green — 1156 unit, 68 smoke, 81 e2e, 1 config_load; `cargo fmt --check` and `cargo clippy --all-targets` clean.
- [x] Manual end-to-end: `sshub host add --address "-oProxyCommand=id"` then `sshub connect` — `id` does not run.

## Left for a follow-up (noted in #101)

Rejecting such a value at **write** time (`create_host` / `update_host`), so a hostile row never lands and an import fails with an error naming the field. This PR is the half that also protects rows already sitting in a database, and the error a user sees today is ssh's usage dump rather than a sentence from sshub.

_Written by Claude Opus 5 (Claude Code) on behalf of the maintainer._