### PR TITLE
fix(store): refuse a host field ssh would read as an option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,11 @@ All notable changes to SSHub are documented in this file.
   through one guard that rewrites a leading-dash target into the `ssh://` URI
   form, which OpenSSH refuses outright instead of parsing as a flag; ordinary
   targets are untouched. Confirmed against the real `ssh -G`, which still
-  reports `proxycommand id` for the old form and refuses the new one.
+  reports `proxycommand id` for the old form and refuses the new one. Such a
+  value is now also refused at the write: `host add`, the TUI form and every
+  importer reject a `name`, `address` or `username` starting with `-`, so the
+  row never lands. An import drops only the poisoned entry — the rest of the
+  file still lands, and the summary counts what was refused.
 
 ## [0.14.0] - 2026-08-12
 

--- a/src/app/host_form.rs
+++ b/src/app/host_form.rs
@@ -226,6 +226,23 @@ impl App {
             self.host_form = Some(form);
             return Ok(());
         }
+        // The store refuses these outright (issue #101); say so with the form
+        // still open rather than letting a write error unwind the TUI.
+        let option_like_field = [
+            ("Name", name),
+            ("Address", address),
+            ("Username", form.username.trim()),
+        ]
+        .into_iter()
+        .find(|(_, value)| crate::store::is_option_like(value))
+        .map(|(field, _)| field);
+        if let Some(field) = option_like_field {
+            self.host_notice = Some(format!(
+                "{field} cannot start with '-' — ssh would read it as an option, not a host"
+            ));
+            self.host_form = Some(form);
+            return Ok(());
+        }
 
         let port: u16 = match form.port.trim().parse() {
             Ok(p) if p > 0 => p,

--- a/src/cli/inventory.rs
+++ b/src/cli/inventory.rs
@@ -221,6 +221,12 @@ fn print_host_import_report(r: &crate::import::HostImportReport) {
         "imported: {} host(s), {} skipped (already exist), {} skipped (non-ssh)",
         r.imported, r.skipped_existing, r.skipped_non_ssh
     );
+    if r.skipped_invalid > 0 {
+        println!(
+            "           {} skipped (refused: a field ssh would read as an option)",
+            r.skipped_invalid
+        );
+    }
 }
 
 /// Summary line for a Termius CSV export import.
@@ -229,6 +235,12 @@ fn print_csv_import_report(r: &crate::import::termius_csv::CsvImportReport) {
         "imported: {} host(s), {} identity(ies) created, {} skipped (already exist)",
         r.hosts_imported, r.identities_created, r.skipped
     );
+    if r.skipped_invalid > 0 {
+        println!(
+            "           {} skipped (refused: a field ssh would read as an option)",
+            r.skipped_invalid
+        );
+    }
 }
 
 /// Preview printer for `--dry-run`: one `  name  user@host:port` line per host
@@ -270,6 +282,7 @@ mod tests {
             imported: 3,
             skipped_existing: 1,
             skipped_non_ssh: 2,
+            skipped_invalid: 1,
         };
         print_host_import_report(&report);
     }

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -13,4 +13,8 @@ pub struct HostImportReport {
     pub skipped_existing: usize,
     /// Entries skipped because they are not SSH connections (RDP/VNC/telnet/…).
     pub skipped_non_ssh: usize,
+    /// Entries the store refused: a name, address or username starting with
+    /// `-`, which ssh would read as an option rather than a host (issue #101).
+    /// One poisoned row does not cost the rest of the file.
+    pub skipped_invalid: usize,
 }

--- a/src/import/mremoteng.rs
+++ b/src/import/mremoteng.rs
@@ -446,8 +446,15 @@ pub fn import_mremoteng(path: &Path, store: &LauncherStore) -> Result<HostImport
             source: HostSource::Launcher,
             ..Default::default()
         };
-        store.create_host(&new_host)?;
-        report.imported += 1;
+        // A rejected row is skipped, not fatal: the rest of the file is still
+        // worth importing, and the count says something was dropped.
+        match store.create_host(&new_host) {
+            Ok(_) => report.imported += 1,
+            Err(e) => {
+                eprintln!("sshub: skipping host '{}': {e:#}", host.name);
+                report.skipped_invalid += 1;
+            }
+        }
     }
 
     Ok(report)

--- a/src/import/putty.rs
+++ b/src/import/putty.rs
@@ -380,7 +380,7 @@ pub fn import_putty(path: &Path, store: &LauncherStore) -> Result<HostImportRepo
             continue;
         }
         let username = (!host.username.is_empty()).then(|| host.username.clone());
-        store.create_host(&NewHost {
+        let created = store.create_host(&NewHost {
             name: host.name.clone(),
             address: host.hostname.clone(),
             port: host.port,
@@ -388,8 +388,15 @@ pub fn import_putty(path: &Path, store: &LauncherStore) -> Result<HostImportRepo
             notes: Some("Imported from PuTTY".into()),
             source: HostSource::Launcher,
             ..Default::default()
-        })?;
-        report.imported += 1;
+        });
+        // Same as the mRemoteNG importer: one refused row does not cost the file.
+        match created {
+            Ok(_) => report.imported += 1,
+            Err(e) => {
+                eprintln!("sshub: skipping host '{}': {e:#}", host.name);
+                report.skipped_invalid += 1;
+            }
+        }
     }
 
     Ok(report)

--- a/src/import/termius_csv.rs
+++ b/src/import/termius_csv.rs
@@ -46,6 +46,9 @@ pub struct CsvKeyFile {
 #[derive(Debug, Default)]
 pub struct CsvImportReport {
     pub hosts_imported: usize,
+    /// Rows the store refused: a name, address or username starting with `-`,
+    /// which ssh would read as an option rather than a host (issue #101).
+    pub skipped_invalid: usize,
     pub identities_created: usize,
     /// Hosts that already existed by name. We do NOT touch their other
     /// fields, but we always refresh their stored credentials from the CSV
@@ -310,7 +313,7 @@ pub fn import_csv_export(
             None => {
                 let identity_id = resolve_key_hint(&row.ssh_key, &key_by_hint);
                 let username = (!row.username.is_empty()).then(|| row.username.clone());
-                let host = store.create_host(&NewHost {
+                let created = store.create_host(&NewHost {
                     name: name.clone(),
                     address: row.host.clone(),
                     port: row.port,
@@ -320,7 +323,17 @@ pub fn import_csv_export(
                     source: HostSource::Launcher,
                     has_password,
                     ..Default::default()
-                })?;
+                });
+                // A row the store refuses (a field ssh would read as an option,
+                // issue #101) is dropped on its own; the rest of the CSV lands.
+                let host = match created {
+                    Ok(host) => host,
+                    Err(e) => {
+                        eprintln!("sshub: skipping host '{name}': {e:#}");
+                        report.skipped_invalid += 1;
+                        continue;
+                    }
+                };
                 report.hosts_imported += 1;
                 host.id
             }

--- a/src/store/hosts.rs
+++ b/src/store/hosts.rs
@@ -202,6 +202,11 @@ impl LauncherStore {
     // --- hosts ---
 
     pub fn create_host(&self, host: &NewHost) -> Result<ManagedHost> {
+        reject_option_like("name", &host.name)?;
+        reject_option_like("address", &host.address)?;
+        if let Some(user) = &host.username {
+            reject_option_like("username", user)?;
+        }
         let now = now_ts();
         let tags_json = tags_to_json(&host.tags)?;
         let source = host.source.as_str();
@@ -304,6 +309,15 @@ impl LauncherStore {
     }
 
     pub fn update_host(&self, id: i64, update: &HostUpdate) -> Result<Option<ManagedHost>> {
+        if let Some(name) = &update.name {
+            reject_option_like("name", name)?;
+        }
+        if let Some(address) = &update.address {
+            reject_option_like("address", address)?;
+        }
+        if let Some(Some(user)) = &update.username {
+            reject_option_like("username", user)?;
+        }
         // Read-merge-write under one transaction on one connection: a
         // concurrent writer (watcher reimport, second instance) can no longer
         // slip between the read and the write and get its change overwritten.
@@ -868,6 +882,31 @@ fn status_sql(status: &str) -> String {
         "retry" => "status = 'retry'".into(),
         other => format!("status = '{other}'"),
     }
+}
+
+/// True when a value would be read by ssh as an option rather than a host.
+/// Exposed so the host form can say so while the form is still open, instead of
+/// surfacing a store error through a TUI key handler.
+pub fn is_option_like(value: &str) -> bool {
+    value.starts_with('-')
+}
+
+/// Refuse a host field that ssh would read as an *option* instead of a value.
+///
+/// `name`, `address` and `username` all end up in the connection target
+/// (`user@host`, or the bare alias for an ssh_config host), and a value starting
+/// with `-` is parsed by ssh as a flag: an address of `-oProxyCommand=id` runs
+/// `id` locally. `ssh::safe_ssh_target` neutralises such a row at connect time,
+/// but nothing legitimate looks like this, and refusing the write is where the
+/// user (or an import of a file someone else wrote) finds out. See issue #101.
+fn reject_option_like(field: &str, value: &str) -> Result<()> {
+    if is_option_like(value) {
+        anyhow::bail!(
+            "host {field} '{value}' starts with '-', which ssh reads as an option rather than \
+             a host — refusing to store it"
+        );
+    }
+    Ok(())
 }
 
 fn via_filter_sql(via: Option<&str>) -> String {
@@ -1437,6 +1476,67 @@ mod tests {
 
         // An edit may keep its own current name (exclude_id).
         assert_eq!(store.unique_host_name("web", Some(web.id)).unwrap(), "web");
+    }
+
+    /// Issue #101: a value ssh would read as an option never reaches the
+    /// database, so no later code path has to remember to defend against it.
+    #[test]
+    fn option_like_fields_are_refused_on_write() {
+        let store = LauncherStore::open_in_memory().unwrap();
+
+        let err = store
+            .create_host(&NewHost {
+                name: "evil".into(),
+                address: "-oProxyCommand=id".into(),
+                port: 22,
+                ..Default::default()
+            })
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("address"), "{err}");
+        assert!(err.contains("option"), "{err}");
+
+        assert!(store
+            .create_host(&NewHost {
+                name: "-oProxyCommand=id".into(),
+                address: "10.0.0.1".into(),
+                port: 22,
+                ..Default::default()
+            })
+            .is_err());
+        assert!(store
+            .create_host(&NewHost {
+                name: "user-flag".into(),
+                address: "10.0.0.1".into(),
+                port: 22,
+                username: Some("-oProxyCommand=id".into()),
+                ..Default::default()
+            })
+            .is_err());
+
+        // An ordinary host is untouched, and editing it into a hostile one is
+        // refused on the same terms.
+        let ok = store
+            .create_host(&NewHost {
+                name: "web".into(),
+                address: "10.0.0.1".into(),
+                port: 22,
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(store
+            .update_host(
+                ok.id,
+                &HostUpdate {
+                    address: Some("-oProxyCommand=id".into()),
+                    ..Default::default()
+                },
+            )
+            .is_err());
+        assert_eq!(
+            store.get_host_by_name("web").unwrap().unwrap().address,
+            "10.0.0.1"
+        );
     }
 
     #[test]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -4,6 +4,7 @@ mod migrate;
 mod tunnels;
 mod types;
 
+pub use hosts::is_option_like;
 pub use types::{
     AuthEvent, DeleteHostOutcome, DeleteIdentityOutcome, HostGroup, HostGroupUpdate, HostSource,
     HostUpdate, Identity, IdentityUpdate, ManagedHost, NewHost, NewHostGroup, NewIdentity,

--- a/tests/e2e/host_crud.rs
+++ b/tests/e2e/host_crud.rs
@@ -303,3 +303,32 @@ fn delete_ssh_config_host_shows_notice() {
         .contains("launcher"));
     assert_eq!(app.hosts.len(), 1);
 }
+
+/// Issue #101: the store refuses an address ssh would read as an option. The
+/// form has to say so and stay open — the write error would otherwise travel
+/// out through `handle_key` and end the TUI run loop.
+#[test]
+fn form_refuses_an_option_like_address_without_unwinding() {
+    let file = NamedTempFile::new().unwrap();
+    let path = file.path();
+    let mut app = app_with_store(path);
+
+    app.handle_key(key_char('a')).unwrap();
+    assert_eq!(app.mode, AppMode::HostForm);
+    edit_field(&mut app, "-oProxyCommand=id"); // Address
+    app.handle_key(key(KeyCode::Down)).unwrap(); // → Password
+    app.handle_key(key(KeyCode::Down)).unwrap(); // → Username
+    app.handle_key(key(KeyCode::Down)).unwrap(); // → Label
+    app.handle_key(key(KeyCode::Down)).unwrap(); // → Name
+    edit_field(&mut app, "evil");
+
+    app.handle_key(key(KeyCode::F(2))).unwrap();
+
+    assert_eq!(app.mode, AppMode::HostForm, "the form stays open");
+    let notice = app.host_notice.clone().expect("a notice explaining why");
+    assert!(notice.contains("Address"), "{notice}");
+    assert!(notice.contains("option"), "{notice}");
+
+    let store = LauncherStore::open(path).unwrap();
+    assert!(store.get_host_by_name("evil").unwrap().is_none());
+}

--- a/tests/smoke/cli_commands.rs
+++ b/tests/smoke/cli_commands.rs
@@ -922,3 +922,54 @@ fn global_help_lists_the_exec_command() {
         .success()
         .stdout(predicate::str::contains("sshub exec"));
 }
+
+/// Issue #101: a host field ssh would read as an option is refused at the
+/// write, and an import file carrying one loses that row only — not the file.
+#[test]
+fn import_refuses_an_option_like_address_and_keeps_the_rest() {
+    let d = dir();
+    let xml = d.path().join("confCons.xml");
+    std::fs::write(
+        &xml,
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<mrng:Connections xmlns:mrng="http://mremoteng.org" Name="Connections" ConfVersion="2.6">
+  <Node Name="good" Type="Connection" Hostname="10.0.0.1" Username="admin" Protocol="SSH2" />
+  <Node Name="evil" Type="Connection" Hostname="-oProxyCommand=id" Protocol="SSH2" />
+</mrng:Connections>
+"#,
+    )
+    .unwrap();
+
+    sshub(d.path())
+        .args(["import", "--from", "mremoteng"])
+        .arg(&xml)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 host(s)"))
+        .stdout(predicate::str::contains("refused"))
+        .stderr(predicate::str::contains("skipping host 'evil'"));
+
+    sshub(d.path())
+        .args(["host", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("good"))
+        .stdout(predicate::str::contains("evil").not());
+}
+
+#[test]
+fn host_add_refuses_an_option_like_address() {
+    let d = dir();
+    sshub(d.path())
+        .args([
+            "host",
+            "add",
+            "--name",
+            "evil",
+            "--address",
+            "-oProxyCommand=id",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("ssh reads as an option"));
+}


### PR DESCRIPTION
Closes #101 — the write-side half. #102 stopped such a value from being *executed* at connect time; this stops it from being **stored** at all, which is where the user (or an import of a file someone else wrote) finds out.

## What changed

- `LauncherStore::create_host` / `update_host` reject a `name`, `address` or `username` starting with `-`. Those three make up the connection target (`user@host`, or the bare alias for an ssh_config host), and ssh reads a leading dash as a flag. Nothing legitimate looks like this.
- The mRemoteNG, PuTTY and Termius importers **skip** a refused row and count it, instead of aborting the whole import on `?`. One poisoned entry must not cost the rest of the file; the summary says how many were dropped:
  ```
  imported: 1 host(s), 0 skipped (already exist), 0 skipped (non-ssh)
             1 skipped (refused: a field ssh would read as an option)
  ```
- The TUI host form checks the same rule *before* writing and keeps the form open with a notice. This one is not cosmetic: a store error travelling out of `save_host_form` leaves `handle_key`, and `src/lib.rs:462` does `app.handle_key(key)?` — it would end the run loop, i.e. a typo in the Address field would drop the user out of the TUI.

One rule, one definition (`store::is_option_like`), enforced at the write and reported early by the form.

## Deliberately not covered

`upsert_ssh_config_host` (the `~/.ssh/config` sync) still accepts whatever the user's own config holds. Refusing there would silently drop a host they can see in their own file, and the connect-time guard from #102 already neutralises it. Worth a `sshub sync` warning later, not a refusal.

## How tested

- [x] Store unit test: address, name and username all refused on create; an ordinary host still writes; editing one *into* a hostile value is refused and the stored row is unchanged.
- [x] Smoke test, end to end through the real binary: a crafted `confCons.xml` with one good and one hostile node imports the good one, reports the refusal, and `sshub host list` shows only the good host. Plus `host add --address "-oProxyCommand=id"` failing with the explanation.
- [x] e2e test for the TUI form: typing the hostile address and pressing save leaves the form open with a notice and writes nothing. **Seen red** — with the form check removed it fails by panicking out of `handle_key`, which is the run-loop unwind this exists to prevent.
- [x] `just test` green — 1167 unit, 79 smoke, 82 e2e, 1 config_load; `cargo fmt --check` and `cargo clippy --all-targets` clean.

_Written by Claude Opus 5 (Claude Code) on behalf of the maintainer._