### PR TITLE
docs(readme): name exec in the headless CLI intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,14 @@ the interactive picker.
 
 Beyond the TUI, `sshub` exposes a full command-line interface for scripting and
 automation: hosts, groups, identities, tunnels, SFTP, and the audit log, no
-terminal UI required. Add `--format json` to any listing or show command for
+terminal UI required. `sshub exec <host> -- <command>` runs a single command on
+a saved host and hands back its output and exit code, so a script gets the
+stored identity, credential and ProxyJump without rebuilding the ssh command
+line by hand. Add `--format json` to any listing or show command for
 machine-readable output (plain text is the default). Exit codes are stable:
-`0` success, `1` operational failure, `2` usage or bad flags. Destructive
-commands refuse to run without `--yes`.
+`0` success, `1` operational failure, `2` usage or bad flags, and `124` when
+`exec --timeout` kills the run (as `timeout(1)` does). Destructive commands
+refuse to run without `--yes`.
 
 ```bash
 # Hosts


### PR DESCRIPTION
The `## Headless CLI` examples block already shows `sshub exec` (it landed with #100), but the paragraph introducing the section did not: it listed the CLI as "hosts, groups, identities, tunnels, SFTP, and the audit log" and the exit codes as `0/1/2`. So the one command a script reaches for first was invisible to anyone reading the section instead of scanning the code block, and `124` was undocumented.

Adds one sentence naming `sshub exec <host> -- <command>` and what it buys over hand-assembling an ssh line, plus `124` to the exit-code list.

Noticed while here, **not** touched (pre-existing, separate change): the `## Features` list has two duplicated bullets — **Audit** appears at both `README.md:63` and `:65`, **Settings overlay** at `:64` and `:68` — and it has no bullet for the headless CLI at all.

_Written by Claude Opus 5 (Claude Code) on behalf of the maintainer._