### PR TITLE
fix(theme): save the picked theme to the config startup reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ All notable changes to SSHub are documented in this file.
 
 ### Fixed
 
+- **A theme picked in the picker was forgotten on the next start** - `Enter`
+  wrote `appearance.active_theme` to the global `~/.config/sshub/config.toml`,
+  but a profile-mode install reads its settings from
+  `~/.local/share/sshub/profiles/<name>/config.toml` — the file every *other*
+  setting is already written to. The theme therefore applied, looked saved, and
+  the next start silently served whatever the profile file still held. The
+  picker now persists through the same profile-aware writer as the rest of the
+  settings, and the regression test drives the real `Enter` rather than the
+  injectable writer the other picker tests use, which is why nothing caught it.
+
 - **A stored host address starting with `-` reached ssh as an option, not a
   host** (issue #101) - `sshub connect evil` on a host whose address is
   `-oProxyCommand=id` built `ssh … -oProxyCommand=id`, and ssh dutifully ran

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -1352,12 +1352,20 @@ impl App {
         Ok(())
     }
 
+    /// The `config.toml` this run reads and writes: the profile's own file when
+    /// a profile resolved startup, else the global one.
+    ///
+    /// Startup loads exactly this file (`lib.rs`), so a writer that picks a
+    /// different one saves where nothing will ever read: the setting appears to
+    /// take, and the next start silently serves the old value. Every persist
+    /// path goes through here for that reason.
+    pub(crate) fn config_target(&self) -> Option<std::path::PathBuf> {
+        self.profile.as_ref().map(|p| p.config_file.clone())
+    }
+
     /// Persist config, surfacing failures as a non-fatal host notice.
     pub(crate) fn save_config_quietly(&mut self) {
-        let result = match &self.profile {
-            Some(paths) => crate::config::save_config_at(&paths.config_file, &self.config),
-            None => crate::config::save_config(&self.config),
-        };
+        let result = save_config_to(self.config_target().as_deref(), &self.config);
         if let Err(e) = result {
             self.host_notice = Some(format!("Could not save config: {e}"));
         }
@@ -1387,5 +1395,18 @@ impl App {
     /// Whether `key` matches the configured "save" binding (default F2/Ctrl+S).
     pub fn is_save_key(&self, key: &KeyEvent) -> bool {
         self.is_action(KeyAction::Save, key)
+    }
+}
+
+/// Write `config` to the file this run owns: the profile's `config.toml`, or the
+/// global one in compatibility mode. The single place that chooses, so no call
+/// site can pick the file startup does not read.
+pub(crate) fn save_config_to(
+    target: Option<&std::path::Path>,
+    config: &AppConfig,
+) -> anyhow::Result<()> {
+    match target {
+        Some(path) => crate::config::save_config_at(path, config),
+        None => crate::config::save_config(config),
     }
 }

--- a/src/app/theme_picker.rs
+++ b/src/app/theme_picker.rs
@@ -460,8 +460,16 @@ impl App {
     }
 
     /// `Enter`: persist the previewed theme through the real config writer.
+    ///
+    /// Through [`App::config_target`], like every other setting: writing to the
+    /// global `config.toml` while a profile is active saves the theme where
+    /// startup never looks, so it survives until the app is closed and then
+    /// silently reverts to whatever the profile file still holds.
     pub(crate) fn commit_theme_picker(&mut self) {
-        self.commit_theme_picker_with(crate::config::save_config);
+        let target = self.config_target();
+        self.commit_theme_picker_with(move |config| {
+            super::keys::save_config_to(target.as_deref(), config)
+        });
     }
 
     /// `Enter` with an injectable writer.

--- a/tests/e2e/theme_picker.rs
+++ b/tests/e2e/theme_picker.rs
@@ -85,6 +85,33 @@ impl ThemeEnv {
         Self { root, app }
     }
 
+    /// Put this app in profile mode, exactly as a real start with a profile
+    /// does: `config.toml` lives inside the profile directory, and that is the
+    /// file startup reads back.
+    fn with_profile(mut self) -> Self {
+        let root = self.root.path().join("profile");
+        std::fs::create_dir_all(&root).unwrap();
+        self.app.profile = Some(sshub::profile::ProfilePaths {
+            data_root: self.root.path().to_path_buf(),
+            id: "p-test".into(),
+            name: "default".into(),
+            config_file: root.join("config.toml"),
+            root,
+            ssh_config: self.root.path().join("ssh_config"),
+            compat: false,
+        });
+        self
+    }
+
+    fn profile_config_path(&self) -> PathBuf {
+        self.app
+            .profile
+            .as_ref()
+            .expect("profile mode")
+            .config_file
+            .clone()
+    }
+
     fn themes_dir(&self) -> PathBuf {
         self.root.path().join("themes")
     }
@@ -469,4 +496,38 @@ fn browsing_the_picker_never_touches_the_disk() {
     assert!(!env.root.path().join("config.toml").exists());
     assert_eq!(env.app.saved_theme_id(), "default");
     assert_eq!(env.app.mode, AppMode::Settings);
+}
+
+/// Saving a theme has to write the file startup reads. With a profile active
+/// that is the profile's own `config.toml`; writing the global one instead
+/// looks like it worked and then serves the previous theme on the next start —
+/// the picked theme survives exactly until the app is closed.
+///
+/// Drives the real `Enter` (not the injectable writer every other test here
+/// uses), because the bug was the writer the real path picked.
+#[test]
+fn committing_a_theme_writes_the_profile_config_startup_reads() {
+    let mut env =
+        ThemeEnv::new(&[("aqua-ish", theme_with_accent("Aqua-ish", "#00b7c3"))]).with_profile();
+    let config_path = env.profile_config_path();
+
+    env.open_picker();
+    env.select("aqua-ish");
+    env.press(KeyCode::Enter);
+
+    assert_eq!(
+        env.app.mode,
+        AppMode::Settings,
+        "a successful commit closes the picker"
+    );
+    let saved = std::fs::read_to_string(&config_path)
+        .unwrap_or_else(|e| panic!("nothing was written to {}: {e}", config_path.display()));
+    assert!(
+        saved.contains("active_theme = \"aqua-ish\""),
+        "the profile config does not carry the picked theme:\n{saved}"
+    );
+
+    // And what a restart would load from that file is the same theme.
+    let reloaded = sshub::config::load_config_at(&config_path).unwrap();
+    assert_eq!(reloaded.appearance.active_theme, "aqua-ish");
 }


### PR DESCRIPTION
Reported by @Petyok: pick `aqua`, close SSHub, come back to `high-contrast`.

## Cause

`Enter` in the theme picker persisted through `config::save_config` (`src/app/theme_picker.rs`), which writes the **global** `~/.config/sshub/config.toml`. Startup reads `paths.config_file` (`src/lib.rs:155`) — in profile mode the profile's own `config.toml` — and every other setting already goes there via `save_config_quietly` (`src/app/keys.rs`).

So the theme applied, looked saved, and the next start served whatever the profile file still held. On the reporter's machine the two files disagreed exactly as the mechanism predicts:

```
~/.config/sshub/config.toml                        active_theme = "aqua"           mtime today 13:04
~/.local/share/sshub/profiles/default/config.toml  active_theme = "high-contrast"  mtime yesterday 23:50
```

`high-contrast` was not arbitrary: it is the last theme that was picked while a profile-aware writer happened to run, i.e. the last value ever written to the file startup actually reads.

## Fix

One `App::config_target` / `save_config_to` pair, used by both the picker and `save_config_quietly`, so no call site can choose a file startup does not read. Themes directory resolution was already profile-aware (`config_file.parent()/themes`), so nothing else moves.

## Why no test caught it

Every picker test — unit and e2e — injects its own writer through `commit_theme_picker_with`, which exists so persistence can be counted without touching a config dir. That is a good seam, but it means **no test ever pressed the real `Enter`**, and the bug was precisely the writer the real path picked. The new e2e test drives `Enter` for real against a profile-mode app and asserts the file a restart would load.

Verified red first: with the old call restored, it fails with `nothing was written to …/profile/config.toml`, and the theme is found in the other config directory instead.

## How tested

- [x] New e2e regression test, seen red on the old code.
- [x] `just test` green — 1167 unit, 79 smoke, 83 e2e, 1 config_load; `cargo fmt --check` and `cargo clippy --all-targets` clean.
- [x] Cause confirmed on the reporter's own machine before writing any code (the two config files above).

Note for @Petyok: your profile config still says `high-contrast`. With this build, picking `aqua` once writes it to the right file and it sticks.

_Written by Claude Opus 5 (Claude Code) on behalf of the maintainer._