### PR TITLE
chore: release v0.14.2 (fixes only, no exec)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to SSHub are documented in this file.
 
 ### Fixed
 
+- **A theme picked in the picker was forgotten on the next start** - `Enter`
+  wrote `appearance.active_theme` to the global `~/.config/sshub/config.toml`,
+  but a profile-mode install reads its settings from
+  `~/.local/share/sshub/profiles/<name>/config.toml` — the file every *other*
+  setting is already written to. The theme therefore applied, looked saved, and
+  the next start silently served whatever the profile file still held. The
+  picker now persists through the same profile-aware writer as the rest of the
+  settings, and the regression test drives the real `Enter` rather than the
+  injectable writer the other picker tests use, which is why nothing caught it.
+
 - **A stored host address starting with `-` reached ssh as an option, not a
   host** (issue #101) - `sshub connect evil` on a host whose address is
   `-oProxyCommand=id` built `ssh … -oProxyCommand=id`, and ssh dutifully ran

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to SSHub are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A stored host address starting with `-` reached ssh as an option, not a
+  host** (issue #101) - `sshub connect evil` on a host whose address is
+  `-oProxyCommand=id` built `ssh … -oProxyCommand=id`, and ssh dutifully ran
+  `id` *locally*. Addresses are written verbatim from imported PuTTY, Termius
+  and mRemoteNG files, so a crafted export was local code execution on the
+  machine that imported it — no typo of the user's own required. Every target
+  sshub hands to ssh or mosh (connect, exec, tunnels, alias connects) now goes
+  through one guard that rewrites a leading-dash target into the `ssh://` URI
+  form, which OpenSSH refuses outright instead of parsing as a flag; ordinary
+  targets are untouched. Confirmed against the real `ssh -G`, which still
+  reports `proxycommand id` for the old form and refuses the new one.
+
 ## [0.14.0] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to SSHub are documented in this file.
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-08-12
+
 ### Fixed
 
 - **A theme picked in the picker was forgotten on the next start** - `Enter`
@@ -22,7 +24,7 @@ All notable changes to SSHub are documented in this file.
   `id` *locally*. Addresses are written verbatim from imported PuTTY, Termius
   and mRemoteNG files, so a crafted export was local code execution on the
   machine that imported it — no typo of the user's own required. Every target
-  sshub hands to ssh or mosh (connect, exec, tunnels, alias connects) now goes
+  sshub hands to ssh or mosh (connect, tunnels, alias connects) now goes
   through one guard that rewrites a leading-dash target into the `ssh://` URI
   form, which OpenSSH refuses outright instead of parsing as a flag; ordinary
   targets are untouched. Confirmed against the real `ssh -G`, which still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ All notable changes to SSHub are documented in this file.
   through one guard that rewrites a leading-dash target into the `ssh://` URI
   form, which OpenSSH refuses outright instead of parsing as a flag; ordinary
   targets are untouched. Confirmed against the real `ssh -G`, which still
-  reports `proxycommand id` for the old form and refuses the new one.
+  reports `proxycommand id` for the old form and refuses the new one. Such a
+  value is now also refused at the write: `host add`, the TUI form and every
+  importer reject a `name`, `address` or `username` starting with `-`, so the
+  row never lands. An import drops only the poisoned entry — the rest of the
+  file still lands, and the summary counts what was refused.
 
 ## [0.14.0] - 2026-08-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "sshub"
-version = "0.14.0"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sshub"
-version = "0.14.0"
+version = "0.14.2"
 edition = "2021"
 description = "SSHub — TUI launcher for SSH hosts"
 license = "AGPL-3.0-or-later"

--- a/src/app/host_form.rs
+++ b/src/app/host_form.rs
@@ -226,6 +226,23 @@ impl App {
             self.host_form = Some(form);
             return Ok(());
         }
+        // The store refuses these outright (issue #101); say so with the form
+        // still open rather than letting a write error unwind the TUI.
+        let option_like_field = [
+            ("Name", name),
+            ("Address", address),
+            ("Username", form.username.trim()),
+        ]
+        .into_iter()
+        .find(|(_, value)| crate::store::is_option_like(value))
+        .map(|(field, _)| field);
+        if let Some(field) = option_like_field {
+            self.host_notice = Some(format!(
+                "{field} cannot start with '-' — ssh would read it as an option, not a host"
+            ));
+            self.host_form = Some(form);
+            return Ok(());
+        }
 
         let port: u16 = match form.port.trim().parse() {
             Ok(p) if p > 0 => p,

--- a/src/app/keys.rs
+++ b/src/app/keys.rs
@@ -1352,12 +1352,20 @@ impl App {
         Ok(())
     }
 
+    /// The `config.toml` this run reads and writes: the profile's own file when
+    /// a profile resolved startup, else the global one.
+    ///
+    /// Startup loads exactly this file (`lib.rs`), so a writer that picks a
+    /// different one saves where nothing will ever read: the setting appears to
+    /// take, and the next start silently serves the old value. Every persist
+    /// path goes through here for that reason.
+    pub(crate) fn config_target(&self) -> Option<std::path::PathBuf> {
+        self.profile.as_ref().map(|p| p.config_file.clone())
+    }
+
     /// Persist config, surfacing failures as a non-fatal host notice.
     pub(crate) fn save_config_quietly(&mut self) {
-        let result = match &self.profile {
-            Some(paths) => crate::config::save_config_at(&paths.config_file, &self.config),
-            None => crate::config::save_config(&self.config),
-        };
+        let result = save_config_to(self.config_target().as_deref(), &self.config);
         if let Err(e) = result {
             self.host_notice = Some(format!("Could not save config: {e}"));
         }
@@ -1387,5 +1395,18 @@ impl App {
     /// Whether `key` matches the configured "save" binding (default F2/Ctrl+S).
     pub fn is_save_key(&self, key: &KeyEvent) -> bool {
         self.is_action(KeyAction::Save, key)
+    }
+}
+
+/// Write `config` to the file this run owns: the profile's `config.toml`, or the
+/// global one in compatibility mode. The single place that chooses, so no call
+/// site can pick the file startup does not read.
+pub(crate) fn save_config_to(
+    target: Option<&std::path::Path>,
+    config: &AppConfig,
+) -> anyhow::Result<()> {
+    match target {
+        Some(path) => crate::config::save_config_at(path, config),
+        None => crate::config::save_config(config),
     }
 }

--- a/src/app/theme_picker.rs
+++ b/src/app/theme_picker.rs
@@ -460,8 +460,16 @@ impl App {
     }
 
     /// `Enter`: persist the previewed theme through the real config writer.
+    ///
+    /// Through [`App::config_target`], like every other setting: writing to the
+    /// global `config.toml` while a profile is active saves the theme where
+    /// startup never looks, so it survives until the app is closed and then
+    /// silently reverts to whatever the profile file still holds.
     pub(crate) fn commit_theme_picker(&mut self) {
-        self.commit_theme_picker_with(crate::config::save_config);
+        let target = self.config_target();
+        self.commit_theme_picker_with(move |config| {
+            super::keys::save_config_to(target.as_deref(), config)
+        });
     }
 
     /// `Enter` with an injectable writer.

--- a/src/cli/inventory.rs
+++ b/src/cli/inventory.rs
@@ -221,6 +221,12 @@ fn print_host_import_report(r: &crate::import::HostImportReport) {
         "imported: {} host(s), {} skipped (already exist), {} skipped (non-ssh)",
         r.imported, r.skipped_existing, r.skipped_non_ssh
     );
+    if r.skipped_invalid > 0 {
+        println!(
+            "           {} skipped (refused: a field ssh would read as an option)",
+            r.skipped_invalid
+        );
+    }
 }
 
 /// Summary line for a Termius CSV export import.
@@ -229,6 +235,12 @@ fn print_csv_import_report(r: &crate::import::termius_csv::CsvImportReport) {
         "imported: {} host(s), {} identity(ies) created, {} skipped (already exist)",
         r.hosts_imported, r.identities_created, r.skipped
     );
+    if r.skipped_invalid > 0 {
+        println!(
+            "           {} skipped (refused: a field ssh would read as an option)",
+            r.skipped_invalid
+        );
+    }
 }
 
 /// Preview printer for `--dry-run`: one `  name  user@host:port` line per host
@@ -270,6 +282,7 @@ mod tests {
             imported: 3,
             skipped_existing: 1,
             skipped_non_ssh: 2,
+            skipped_invalid: 1,
         };
         print_host_import_report(&report);
     }

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -13,4 +13,8 @@ pub struct HostImportReport {
     pub skipped_existing: usize,
     /// Entries skipped because they are not SSH connections (RDP/VNC/telnet/…).
     pub skipped_non_ssh: usize,
+    /// Entries the store refused: a name, address or username starting with
+    /// `-`, which ssh would read as an option rather than a host (issue #101).
+    /// One poisoned row does not cost the rest of the file.
+    pub skipped_invalid: usize,
 }

--- a/src/import/mremoteng.rs
+++ b/src/import/mremoteng.rs
@@ -446,8 +446,15 @@ pub fn import_mremoteng(path: &Path, store: &LauncherStore) -> Result<HostImport
             source: HostSource::Launcher,
             ..Default::default()
         };
-        store.create_host(&new_host)?;
-        report.imported += 1;
+        // A rejected row is skipped, not fatal: the rest of the file is still
+        // worth importing, and the count says something was dropped.
+        match store.create_host(&new_host) {
+            Ok(_) => report.imported += 1,
+            Err(e) => {
+                eprintln!("sshub: skipping host '{}': {e:#}", host.name);
+                report.skipped_invalid += 1;
+            }
+        }
     }
 
     Ok(report)

--- a/src/import/putty.rs
+++ b/src/import/putty.rs
@@ -380,7 +380,7 @@ pub fn import_putty(path: &Path, store: &LauncherStore) -> Result<HostImportRepo
             continue;
         }
         let username = (!host.username.is_empty()).then(|| host.username.clone());
-        store.create_host(&NewHost {
+        let created = store.create_host(&NewHost {
             name: host.name.clone(),
             address: host.hostname.clone(),
             port: host.port,
@@ -388,8 +388,15 @@ pub fn import_putty(path: &Path, store: &LauncherStore) -> Result<HostImportRepo
             notes: Some("Imported from PuTTY".into()),
             source: HostSource::Launcher,
             ..Default::default()
-        })?;
-        report.imported += 1;
+        });
+        // Same as the mRemoteNG importer: one refused row does not cost the file.
+        match created {
+            Ok(_) => report.imported += 1,
+            Err(e) => {
+                eprintln!("sshub: skipping host '{}': {e:#}", host.name);
+                report.skipped_invalid += 1;
+            }
+        }
     }
 
     Ok(report)

--- a/src/import/termius_csv.rs
+++ b/src/import/termius_csv.rs
@@ -46,6 +46,9 @@ pub struct CsvKeyFile {
 #[derive(Debug, Default)]
 pub struct CsvImportReport {
     pub hosts_imported: usize,
+    /// Rows the store refused: a name, address or username starting with `-`,
+    /// which ssh would read as an option rather than a host (issue #101).
+    pub skipped_invalid: usize,
     pub identities_created: usize,
     /// Hosts that already existed by name. We do NOT touch their other
     /// fields, but we always refresh their stored credentials from the CSV
@@ -310,7 +313,7 @@ pub fn import_csv_export(
             None => {
                 let identity_id = resolve_key_hint(&row.ssh_key, &key_by_hint);
                 let username = (!row.username.is_empty()).then(|| row.username.clone());
-                let host = store.create_host(&NewHost {
+                let created = store.create_host(&NewHost {
                     name: name.clone(),
                     address: row.host.clone(),
                     port: row.port,
@@ -320,7 +323,17 @@ pub fn import_csv_export(
                     source: HostSource::Launcher,
                     has_password,
                     ..Default::default()
-                })?;
+                });
+                // A row the store refuses (a field ssh would read as an option,
+                // issue #101) is dropped on its own; the rest of the CSV lands.
+                let host = match created {
+                    Ok(host) => host,
+                    Err(e) => {
+                        eprintln!("sshub: skipping host '{name}': {e:#}");
+                        report.skipped_invalid += 1;
+                        continue;
+                    }
+                };
                 report.hosts_imported += 1;
                 host.id
             }

--- a/src/ssh/host.rs
+++ b/src/ssh/host.rs
@@ -67,7 +67,7 @@ pub fn build_ssh_argv(host: &SshHost) -> Vec<String> {
     } else {
         hostname.to_string()
     };
-    args.push(target);
+    args.push(safe_ssh_target(target));
 
     // Remote command runs on the SSH host (appended after target)
     if let Some(ref cmd) = host.remote_command {
@@ -82,7 +82,28 @@ pub fn build_ssh_argv(host: &SshHost) -> Vec<String> {
 
 /// Build argv for alias connect (`ssh name` via ssh_config).
 pub fn build_ssh_alias_argv(host: &SshHost) -> Vec<String> {
-    vec!["ssh".into(), host.name.clone()]
+    vec!["ssh".into(), safe_ssh_target(host.name.clone())]
+}
+
+/// Make a connection target one ssh cannot read as an **option**.
+///
+/// ssh takes the first non-flag argument as the host, but a stored target that
+/// begins with `-` is handed over verbatim and parsed as a flag instead: an
+/// address of `-oProxyCommand=id` becomes `ProxyCommand id`, which ssh runs
+/// *locally*. Addresses are written verbatim from imported PuTTY, Termius and
+/// mRemoteNG files (`src/import/`), so this is not the user's own typing — a
+/// crafted export would otherwise execute code on the machine that imported it.
+///
+/// The `ssh://` URI form is what OpenSSH refuses outright instead of treating as
+/// a flag, so a hostile row now fails loudly rather than running anything, while
+/// ordinary targets are untouched. `ssh -- <host>` is not an alternative: the
+/// words after `--` become the remote command.
+pub fn safe_ssh_target(target: String) -> String {
+    if target.starts_with('-') {
+        format!("ssh://{target}")
+    } else {
+        target
+    }
 }
 
 /// Build argv for `mosh` using explicit connection fields (managed / direct connect).
@@ -92,7 +113,7 @@ pub fn build_mosh_argv(host: &SshHost) -> Vec<String> {
 
 /// Build argv for alias connect (`mosh name` via ssh_config).
 pub fn build_mosh_alias_argv(host: &SshHost) -> Vec<String> {
-    vec!["mosh".into(), host.name.clone()]
+    vec!["mosh".into(), safe_ssh_target(host.name.clone())]
 }
 
 const ACCEPT_NEW_SSH_OPT: &str = "StrictHostKeyChecking=accept-new";
@@ -310,5 +331,83 @@ mod tests {
                 "htop".to_string(),
             ]
         );
+    }
+
+    /// A host stored with an option-like address must not reach ssh as an
+    /// option. Asked of the real ssh, because "does OpenSSH read this argument
+    /// as a flag or as a hostname" is OpenSSH's rule, not ours: `ssh -G`
+    /// resolves a command line and exits without connecting, so this needs no
+    /// network and no server.
+    ///
+    /// Both halves matter. Without the guard ssh reports `proxycommand id` and
+    /// would run `id` locally on the next connect; with it ssh refuses the
+    /// target outright. The unguarded half is the regression check — if
+    /// `safe_ssh_target` ever stops firing, the first assertion here is what
+    /// fails.
+    #[test]
+    fn an_option_like_address_is_not_read_as_an_ssh_option() {
+        use std::process::Command;
+        if Command::new("ssh").arg("-V").output().is_err() {
+            eprintln!("skipping: no ssh binary");
+            return;
+        }
+
+        let hostile = "-oProxyCommand=id";
+        // Shaped like a real exec/connect line so ssh has something left to
+        // treat as the hostname once it has eaten the target as a flag.
+        let resolve = |target: &str| {
+            let out = Command::new("ssh")
+                .args(["-F", "/dev/null", "-G", "-T", target, "--", "uptime"])
+                .output()
+                .unwrap();
+            (
+                out.status.success(),
+                String::from_utf8_lossy(&out.stdout).into_owned(),
+            )
+        };
+
+        // What sshub used to hand over verbatim.
+        let (ok, cfg) = resolve(hostile);
+        assert!(
+            ok && cfg.lines().any(|l| l == "proxycommand id"),
+            "OpenSSH no longer reads a leading-dash target as an option; this \
+             guard may be obsolete:\n{cfg}"
+        );
+
+        // What it hands over now.
+        let mut host = SshHost::new("evil");
+        host.hostname = Some(hostile.into());
+        let argv = build_ssh_argv(&host);
+        let target = argv.last().unwrap();
+        assert_eq!(target, "ssh://-oProxyCommand=id");
+
+        let (ok, cfg) = resolve(target);
+        assert!(
+            !ok,
+            "ssh accepted the guarded target instead of refusing it:\n{cfg}"
+        );
+        assert!(
+            !cfg.contains("proxycommand id"),
+            "ProxyCommand survived the guard:\n{cfg}"
+        );
+    }
+
+    #[test]
+    fn safe_ssh_target_leaves_ordinary_targets_alone() {
+        for target in ["10.0.0.5", "deploy@10.0.0.5", "web-01", "user@-weird"] {
+            assert_eq!(safe_ssh_target(target.to_string()), target);
+        }
+        // Only a *leading* dash can be read as a flag; `user@-weird` cannot.
+        assert_eq!(
+            safe_ssh_target("-weird".to_string()),
+            "ssh://-weird".to_string()
+        );
+    }
+
+    #[test]
+    fn alias_and_mosh_argv_guard_the_target_too() {
+        let host = SshHost::new("-oProxyCommand=id");
+        assert_eq!(build_ssh_alias_argv(&host)[1], "ssh://-oProxyCommand=id");
+        assert_eq!(build_mosh_alias_argv(&host)[1], "ssh://-oProxyCommand=id");
     }
 }

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -12,7 +12,7 @@ pub use export::{
 };
 pub use host::{
     build_mosh_alias_argv, build_mosh_argv, build_ssh_alias_argv, build_ssh_argv,
-    inject_mosh_ssh_accept_new, SshHost,
+    inject_mosh_ssh_accept_new, safe_ssh_target, SshHost,
 };
 pub use import::{
     compute_ssh_config_hash, import_ssh_config, materialize_ssh_config_host, sync_ssh_config_hosts,

--- a/src/store/hosts.rs
+++ b/src/store/hosts.rs
@@ -202,6 +202,11 @@ impl LauncherStore {
     // --- hosts ---
 
     pub fn create_host(&self, host: &NewHost) -> Result<ManagedHost> {
+        reject_option_like("name", &host.name)?;
+        reject_option_like("address", &host.address)?;
+        if let Some(user) = &host.username {
+            reject_option_like("username", user)?;
+        }
         let now = now_ts();
         let tags_json = tags_to_json(&host.tags)?;
         let source = host.source.as_str();
@@ -304,6 +309,15 @@ impl LauncherStore {
     }
 
     pub fn update_host(&self, id: i64, update: &HostUpdate) -> Result<Option<ManagedHost>> {
+        if let Some(name) = &update.name {
+            reject_option_like("name", name)?;
+        }
+        if let Some(address) = &update.address {
+            reject_option_like("address", address)?;
+        }
+        if let Some(Some(user)) = &update.username {
+            reject_option_like("username", user)?;
+        }
         // Read-merge-write under one transaction on one connection: a
         // concurrent writer (watcher reimport, second instance) can no longer
         // slip between the read and the write and get its change overwritten.
@@ -867,6 +881,31 @@ fn status_sql(status: &str) -> String {
         "retry" => "status = 'retry'".into(),
         other => format!("status = '{other}'"),
     }
+}
+
+/// True when a value would be read by ssh as an option rather than a host.
+/// Exposed so the host form can say so while the form is still open, instead of
+/// surfacing a store error through a TUI key handler.
+pub fn is_option_like(value: &str) -> bool {
+    value.starts_with('-')
+}
+
+/// Refuse a host field that ssh would read as an *option* instead of a value.
+///
+/// `name`, `address` and `username` all end up in the connection target
+/// (`user@host`, or the bare alias for an ssh_config host), and a value starting
+/// with `-` is parsed by ssh as a flag: an address of `-oProxyCommand=id` runs
+/// `id` locally. `ssh::safe_ssh_target` neutralises such a row at connect time,
+/// but nothing legitimate looks like this, and refusing the write is where the
+/// user (or an import of a file someone else wrote) finds out. See issue #101.
+fn reject_option_like(field: &str, value: &str) -> Result<()> {
+    if is_option_like(value) {
+        anyhow::bail!(
+            "host {field} '{value}' starts with '-', which ssh reads as an option rather than \
+             a host — refusing to store it"
+        );
+    }
+    Ok(())
 }
 
 fn via_filter_sql(via: Option<&str>) -> String {
@@ -1435,6 +1474,67 @@ mod tests {
 
         // An edit may keep its own current name (exclude_id).
         assert_eq!(store.unique_host_name("web", Some(web.id)).unwrap(), "web");
+    }
+
+    /// Issue #101: a value ssh would read as an option never reaches the
+    /// database, so no later code path has to remember to defend against it.
+    #[test]
+    fn option_like_fields_are_refused_on_write() {
+        let store = LauncherStore::open_in_memory().unwrap();
+
+        let err = store
+            .create_host(&NewHost {
+                name: "evil".into(),
+                address: "-oProxyCommand=id".into(),
+                port: 22,
+                ..Default::default()
+            })
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("address"), "{err}");
+        assert!(err.contains("option"), "{err}");
+
+        assert!(store
+            .create_host(&NewHost {
+                name: "-oProxyCommand=id".into(),
+                address: "10.0.0.1".into(),
+                port: 22,
+                ..Default::default()
+            })
+            .is_err());
+        assert!(store
+            .create_host(&NewHost {
+                name: "user-flag".into(),
+                address: "10.0.0.1".into(),
+                port: 22,
+                username: Some("-oProxyCommand=id".into()),
+                ..Default::default()
+            })
+            .is_err());
+
+        // An ordinary host is untouched, and editing it into a hostile one is
+        // refused on the same terms.
+        let ok = store
+            .create_host(&NewHost {
+                name: "web".into(),
+                address: "10.0.0.1".into(),
+                port: 22,
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(store
+            .update_host(
+                ok.id,
+                &HostUpdate {
+                    address: Some("-oProxyCommand=id".into()),
+                    ..Default::default()
+                },
+            )
+            .is_err());
+        assert_eq!(
+            store.get_host_by_name("web").unwrap().unwrap().address,
+            "10.0.0.1"
+        );
     }
 
     #[test]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -4,6 +4,7 @@ mod migrate;
 mod tunnels;
 mod types;
 
+pub use hosts::is_option_like;
 pub use types::{
     AuthEvent, DeleteHostOutcome, DeleteIdentityOutcome, HostGroup, HostGroupUpdate, HostSource,
     HostUpdate, Identity, IdentityUpdate, ManagedHost, NewHost, NewHostGroup, NewIdentity,

--- a/src/tunnel/spawn.rs
+++ b/src/tunnel/spawn.rs
@@ -86,7 +86,9 @@ pub fn build_tunnel_argv(
     } else {
         host.address.clone()
     };
-    args.push(target);
+    // Same guard as the connect path: an address stored with a leading `-` would
+    // reach ssh as an option, not a host. See `ssh::safe_ssh_target`.
+    args.push(crate::ssh::safe_ssh_target(target));
     Ok(args)
 }
 

--- a/tests/e2e/host_crud.rs
+++ b/tests/e2e/host_crud.rs
@@ -303,3 +303,32 @@ fn delete_ssh_config_host_shows_notice() {
         .contains("launcher"));
     assert_eq!(app.hosts.len(), 1);
 }
+
+/// Issue #101: the store refuses an address ssh would read as an option. The
+/// form has to say so and stay open — the write error would otherwise travel
+/// out through `handle_key` and end the TUI run loop.
+#[test]
+fn form_refuses_an_option_like_address_without_unwinding() {
+    let file = NamedTempFile::new().unwrap();
+    let path = file.path();
+    let mut app = app_with_store(path);
+
+    app.handle_key(key_char('a')).unwrap();
+    assert_eq!(app.mode, AppMode::HostForm);
+    edit_field(&mut app, "-oProxyCommand=id"); // Address
+    app.handle_key(key(KeyCode::Down)).unwrap(); // → Password
+    app.handle_key(key(KeyCode::Down)).unwrap(); // → Username
+    app.handle_key(key(KeyCode::Down)).unwrap(); // → Label
+    app.handle_key(key(KeyCode::Down)).unwrap(); // → Name
+    edit_field(&mut app, "evil");
+
+    app.handle_key(key(KeyCode::F(2))).unwrap();
+
+    assert_eq!(app.mode, AppMode::HostForm, "the form stays open");
+    let notice = app.host_notice.clone().expect("a notice explaining why");
+    assert!(notice.contains("Address"), "{notice}");
+    assert!(notice.contains("option"), "{notice}");
+
+    let store = LauncherStore::open(path).unwrap();
+    assert!(store.get_host_by_name("evil").unwrap().is_none());
+}

--- a/tests/e2e/theme_picker.rs
+++ b/tests/e2e/theme_picker.rs
@@ -85,6 +85,33 @@ impl ThemeEnv {
         Self { root, app }
     }
 
+    /// Put this app in profile mode, exactly as a real start with a profile
+    /// does: `config.toml` lives inside the profile directory, and that is the
+    /// file startup reads back.
+    fn with_profile(mut self) -> Self {
+        let root = self.root.path().join("profile");
+        std::fs::create_dir_all(&root).unwrap();
+        self.app.profile = Some(sshub::profile::ProfilePaths {
+            data_root: self.root.path().to_path_buf(),
+            id: "p-test".into(),
+            name: "default".into(),
+            config_file: root.join("config.toml"),
+            root,
+            ssh_config: self.root.path().join("ssh_config"),
+            compat: false,
+        });
+        self
+    }
+
+    fn profile_config_path(&self) -> PathBuf {
+        self.app
+            .profile
+            .as_ref()
+            .expect("profile mode")
+            .config_file
+            .clone()
+    }
+
     fn themes_dir(&self) -> PathBuf {
         self.root.path().join("themes")
     }
@@ -469,4 +496,38 @@ fn browsing_the_picker_never_touches_the_disk() {
     assert!(!env.root.path().join("config.toml").exists());
     assert_eq!(env.app.saved_theme_id(), "default");
     assert_eq!(env.app.mode, AppMode::Settings);
+}
+
+/// Saving a theme has to write the file startup reads. With a profile active
+/// that is the profile's own `config.toml`; writing the global one instead
+/// looks like it worked and then serves the previous theme on the next start —
+/// the picked theme survives exactly until the app is closed.
+///
+/// Drives the real `Enter` (not the injectable writer every other test here
+/// uses), because the bug was the writer the real path picked.
+#[test]
+fn committing_a_theme_writes_the_profile_config_startup_reads() {
+    let mut env =
+        ThemeEnv::new(&[("aqua-ish", theme_with_accent("Aqua-ish", "#00b7c3"))]).with_profile();
+    let config_path = env.profile_config_path();
+
+    env.open_picker();
+    env.select("aqua-ish");
+    env.press(KeyCode::Enter);
+
+    assert_eq!(
+        env.app.mode,
+        AppMode::Settings,
+        "a successful commit closes the picker"
+    );
+    let saved = std::fs::read_to_string(&config_path)
+        .unwrap_or_else(|e| panic!("nothing was written to {}: {e}", config_path.display()));
+    assert!(
+        saved.contains("active_theme = \"aqua-ish\""),
+        "the profile config does not carry the picked theme:\n{saved}"
+    );
+
+    // And what a restart would load from that file is the same theme.
+    let reloaded = sshub::config::load_config_at(&config_path).unwrap();
+    assert_eq!(reloaded.appearance.active_theme, "aqua-ish");
 }

--- a/tests/smoke/cli_commands.rs
+++ b/tests/smoke/cli_commands.rs
@@ -791,3 +791,54 @@ fn theme_check_unlistable_directory_exits_one() {
     std::fs::set_permissions(&closed, std::fs::Permissions::from_mode(0o755)).unwrap();
     assertion.code(1);
 }
+
+/// Issue #101: a host field ssh would read as an option is refused at the
+/// write, and an import file carrying one loses that row only — not the file.
+#[test]
+fn import_refuses_an_option_like_address_and_keeps_the_rest() {
+    let d = dir();
+    let xml = d.path().join("confCons.xml");
+    std::fs::write(
+        &xml,
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<mrng:Connections xmlns:mrng="http://mremoteng.org" Name="Connections" ConfVersion="2.6">
+  <Node Name="good" Type="Connection" Hostname="10.0.0.1" Username="admin" Protocol="SSH2" />
+  <Node Name="evil" Type="Connection" Hostname="-oProxyCommand=id" Protocol="SSH2" />
+</mrng:Connections>
+"#,
+    )
+    .unwrap();
+
+    sshub(d.path())
+        .args(["import", "--from", "mremoteng"])
+        .arg(&xml)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 host(s)"))
+        .stdout(predicate::str::contains("refused"))
+        .stderr(predicate::str::contains("skipping host 'evil'"));
+
+    sshub(d.path())
+        .args(["host", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("good"))
+        .stdout(predicate::str::contains("evil").not());
+}
+
+#[test]
+fn host_add_refuses_an_option_like_address() {
+    let d = dir();
+    sshub(d.path())
+        .args([
+            "host",
+            "add",
+            "--name",
+            "evil",
+            "--address",
+            "-oProxyCommand=id",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("ssh reads as an option"));
+}


### PR DESCRIPTION
Hotfix release cut from `v0.14.0`, deliberately **not** from `development`: `sshub exec` and the README text that describes it stay on `development` until they ship in their own release.

Opened against `main` so CI validates the exact tree that would be released. **Not for merging by button** — the release wants `main`'s first-parent line to read one `chore: release vX.Y.Z` per release, so the merge is a local `--no-ff` with that message once you say go. No tag is pushed yet; the tag is what triggers binaries + crates.io + npm.

## What ships

Three fixes, cherry-picked onto v0.14.0:

- **`fix(ssh)`** — a stored host address starting with `-` reached ssh as an *option*, so an imported PuTTY/Termius/mRemoteNG entry could make `sshub connect` run `ProxyCommand` locally (#101, PR #102).
- **`fix(store)`** — the same value is now refused at the write, in `host add`, the TUI form and every importer; an import drops only the poisoned row (#101, PR #103).
- **`fix(theme)`** — a theme picked in the picker was saved to the global `config.toml` while startup reads the profile's, so it reverted on the next start (PR #107).

## What does not ship

- `sshub exec` (#85, PR #100) and its docs.
- The README changes from #104 and #105 — both describe `exec`.

Verified the tree carries no trace of it: no `src/cli/exec.rs`, no `exec` in `is_subcommand`, help, completions, man page or README; `sshub exec` exits 2 with `unknown command 'exec'`, and `sshub --help` mentions it zero times.

The CHANGELOG entry for the address guard also lost its `exec` mention from the list of covered call sites, since that command does not exist in this version.

## Verification

- [x] `cargo fmt --check`, `cargo clippy --all-targets` clean
- [x] 1157 unit, 70 smoke, 83 e2e, 1 config_load — all green
- [x] Release binary built and checked: `sshub 0.14.2`, `exec` absent, `theme list` fine

## After the tag (for the record)

`main` will carry a commit `development` does not have, so the merge-back is required before the next release (`CLAUDE.md`: "if `main` ever gets a direct commit anyway, merge `main` into `development`"). That merge also has to keep `development`'s `[Unreleased]` from duplicating the three entries now sitting under `[0.14.2]`.

_Written by Claude Opus 5 (Claude Code) on behalf of the maintainer._