### PR TITLE
chore(build): halve target/ and stop the shared cache from splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # VHS intermediates (mp4 masters + palettes) produced by demo/record.sh
 /demo/build/
 npm/dist/
+.cargo/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,22 +13,36 @@ The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do
 Main agent checkout stays in this folder (`ssh-tui/`). Extra agents use git
 worktrees so they do not fight over the same working tree.
 
-Rust `target/` is **shared** across the main checkout and all worktrees to
-save disk (one ~12G artifact dir, not one per agent):
+Rust build output is **shared** across the main checkout and all worktrees to
+save disk (~1.2G per full dev+test+release cycle, not one such dir per agent):
 
 ```text
 sshub-dev/
-  .cargo-target/          ← real cargo artifacts
+  .cargo-target/          ← real cargo artifacts (build.target-dir)
   .worktrees/<agent>/     ← isolated checkouts
   ssh-tui/                ← main checkout (this repo)
-    target -> ../.cargo-target
+    .cargo/config.toml    ← untracked, points at ../.cargo-target
 ```
 
+Each checkout carries its own untracked `.cargo/config.toml` with an absolute
+`build.target-dir`. There is **no `target` symlink** — `cargo clean` deletes a
+symlink, after which cargo silently builds into a private `./target` and the
+shared dir quietly becomes one copy per agent. If you find a `target` symlink,
+do not repair it: run `just setup-shared-target`, which migrates it.
+
 ```bash
-just setup-shared-target          # one-time / repair symlink on main checkout
-just worktree-add agent-foo       # ../.worktrees/agent-foo on feature/agent-foo
-just worktree-rm agent-foo        # remove worktree; keeps shared target
+just setup-shared-target          # once per checkout/worktree (writes .cargo/config.toml)
+just worktree-add agent-foo       # ../.worktrees/agent-foo on feature/agent-foo (runs the above)
+just worktree-rm agent-foo        # remove worktree; sweeps its stale artifacts
+just sweep                        # prune shared target back under 4GB (cargo never does)
 ```
+
+The `vendored` feature (OpenSSL compiled from source) is **on by default**,
+because `cargo install sshub` and the release tarballs must build with no system
+OpenSSL present. Local work opts out with `--no-default-features` to link the
+system libs instead — ~120 MB less target/ per profile and most of a cold
+build's wall clock. `just test` already does. Never pass that flag on anything
+that ships: `just build`, CI, and the release workflow stay on the default.
 
 Do **not** run two `cargo`/`just test` builds at once against the shared
 target — fingerprint races. Serialize builds (one agent compiling at a time).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Multi-agent worktrees
 
 Stay in `ssh-tui/` for the primary checkout. For parallel agents, use
-`just worktree-add <name>` (creates `../.worktrees/<name>` and points its
-`target/` at shared `../.cargo-target`). Repair main symlink with
-`just setup-shared-target`. Never run concurrent cargo builds on the shared
-target. See [AGENTS.md](AGENTS.md).
+`just worktree-add <name>` (creates `../.worktrees/<name>` and points its build
+output at shared `../.cargo-target`). Every checkout needs `just
+setup-shared-target` once — it writes an untracked `.cargo/config.toml`; there
+is no `target` symlink to repair (`cargo clean` used to delete it and split the
+shared dir into per-agent copies). Never run concurrent cargo builds on the
+shared target. Vendored OpenSSL is a default feature (shipped builds need it);
+local builds opt out with `--no-default-features` for speed and disk. See
+[AGENTS.md](AGENTS.md).
 
 ## Workflow rules
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,16 @@ path = "demo/seed_demo.rs"
 name = "sshub"
 path = "src/lib.rs"
 
+[features]
+# Vendored OpenSSL is what makes `cargo install sshub` and the release tarballs
+# self-contained, so it stays ON by default -- anything published must build
+# without a system OpenSSL present. It is a feature only so local development
+# can opt OUT with `--no-default-features` (see the `test` recipe in the
+# Justfile): linking the system libs saves ~120 MB of target/ per profile and
+# most of a cold build's wall clock. Nothing that ships may pass that flag.
+default = ["vendored"]
+vendored = ["ssh2/vendored-openssl"]
+
 [dependencies]
 anyhow = "1"
 crossterm = "0.29"
@@ -55,10 +65,10 @@ nucleo = "0.3"
 portable-pty = "0.9"
 ratatui = "0.30"
 rusqlite = { version = "0.32", features = ["bundled"] }
-# Native SFTP transport (libssh2). vendored-openssl compiles OpenSSL from source
-# so `cargo install sshub` stays self-contained (same tradeoff as rusqlite
-# "bundled" above — no system OpenSSL/libssh2 needed).
-ssh2 = { version = "0.9", features = ["vendored-openssl"] }
+# Native SFTP transport (libssh2). OpenSSL comes from the `vendored` feature
+# above (on by default), which compiles it from source so `cargo install sshub`
+# stays self-contained — same tradeoff as rusqlite "bundled" above.
+ssh2 = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Levenshtein suggestions for misspelled theme role/field names in diagnostics.
@@ -103,3 +113,11 @@ path = "tests/smoke/config_load.rs"
 lto = "thin"
 codegen-units = 1
 strip = "symbols"
+
+[profile.dev]
+# Full DWARF for every dependency is ~40% of target/. Line tables keep
+# backtraces readable for our own code; nobody steps through libc with a debugger.
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false

--- a/Justfile
+++ b/Justfile
@@ -5,10 +5,10 @@ default:
 
 # Run all test targets (unit + integration). CI-friendly; no TTY required.
 test:
-    cargo test
-    cargo test --test smoke
-    cargo test --test e2e
-    cargo test --test config_load
+    cargo test --no-default-features
+    cargo test --no-default-features --test smoke
+    cargo test --no-default-features --test e2e
+    cargo test --no-default-features --test config_load
 
 # Coverage, plus the functions no test executes even once (docs/coverage-map.md).
 coverage:
@@ -136,39 +136,59 @@ setup-hooks:
     git config core.hooksPath .githooks
     @echo "git hooks enabled (core.hooksPath = .githooks)"
 
-# Point ./target at ../.cargo-target (sibling of the git root). Keeps one Rust
-# artifact dir for the main checkout + all agent worktrees. Safe to re-run.
-# If ./target is a real directory and ../.cargo-target is empty/missing, moves
-# the existing artifacts into the shared dir first (preserves the cache).
+# Point this checkout's build output at the shared ../.cargo-target (sibling of
+# the main checkout). One Rust artifact dir for the main checkout + every agent
+# worktree. Safe to re-run; run it once per checkout/worktree.
+#
+# Uses .cargo/config.toml (untracked) rather than a `target` symlink: `cargo
+# clean` DELETES the symlink, after which cargo silently starts building into a
+# private ./target again — that is how one shared 1 GB dir turns into N copies.
+# The path written is absolute because worktrees sit one level deeper than the
+# main checkout, so no single relative path is correct for both.
 setup-shared-target:
     #!/usr/bin/env bash
     set -euo pipefail
-    repo="$(git rev-parse --show-toplevel)"
-    parent="$(dirname "$repo")"
-    shared="$parent/.cargo-target"
-    cd "$repo"
-    if [ -L target ]; then
-      cur="$(readlink target)"
-      want="../.cargo-target"
-      if [ "$cur" = "$want" ] || [ "$(readlink -f target)" = "$(readlink -f "$shared")" ]; then
-        echo "target already -> $shared"
-        exit 0
-      fi
-      echo "target is a symlink to '$cur', expected '$want' or $shared" >&2
+    root="$(git rev-parse --show-toplevel)"
+    cd "$root"
+    # --git-common-dir points at the MAIN checkout's .git from any worktree.
+    common="$(realpath "$(git rev-parse --git-common-dir)")"
+    shared="$(dirname "$(dirname "$common")")/.cargo-target"
+    mkdir -p "$shared" .cargo
+    cfg=.cargo/config.toml
+    if [ -f "$cfg" ] && ! grep -q '^target-dir' "$cfg"; then
+      echo "$cfg exists without a target-dir — add [build] target-dir by hand" >&2
       exit 1
     fi
-    if [ -d target ]; then
-      if [ -e "$shared" ]; then
-        echo "both ./target and $shared exist — move/merge by hand, then re-run" >&2
-        exit 1
-      fi
-      echo "moving ./target -> $shared"
-      mv target "$shared"
-    else
-      mkdir -p "$shared"
+    # Migrate whatever ./target is today, then get it out of the way.
+    if [ -L target ]; then
+      rm -f target
+    elif [ -d target ]; then
+      echo "moving ./target into $shared"
+      cp -a target/. "$shared"/ && rm -rf target
     fi
-    ln -sfn ../.cargo-target target
-    echo "target -> $shared ($(du -sh "$shared" | cut -f1))"
+    printf '[build]\ntarget-dir = "%s"\n' "$shared" > "$cfg"
+    echo "target-dir -> $shared ($(du -sh "$shared" | cut -f1))"
+
+# Prune the shared target dir. Cargo NEVER deletes artifacts of branches you
+# moved off, so the dir only grows: a full dev+test+release cycle is ~1.2 GB and
+# every stale fingerprint stays forever. Keeps it under a size cap, dropping the
+# oldest artifacts first.
+#
+#   just sweep           # cap at 4GB
+#   just sweep 2GB
+#
+# By age instead of size: cargo sweep --time 7 ../.cargo-target
+sweep size="4GB":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v cargo-sweep >/dev/null || { echo "needs: cargo install cargo-sweep" >&2; exit 1; }
+    common="$(realpath "$(git rev-parse --git-common-dir)")"
+    shared="$(dirname "$(dirname "$common")")/.cargo-target"
+    before="$(du -sh "$shared" | cut -f1)"
+    # cargo-sweep wants the PROJECT path (it resolves target-dir itself), not the
+    # target dir — pointed at the latter it looks for a Cargo.toml inside it.
+    cargo sweep --maxsize {{size}} "$(git rev-parse --show-toplevel)"
+    echo "$shared: $before -> $(du -sh "$shared" | cut -f1)"
 
 # Add an isolated worktree under ../.worktrees/<name> on branch <branch>
 # (default: feature/<name>), then link its target/ at the shared cargo dir.
@@ -199,10 +219,10 @@ worktree-add name branch="":
     else
       git worktree add -b "$branch" "$dest"
     fi
-    ln -sfn "$shared" "$dest/target"
+    (cd "$dest" && just setup-shared-target)
     echo "worktree: $dest"
     echo "branch:   $branch"
-    echo "target:   $dest/target -> $shared"
+    echo "target:   $shared (shared)"
     echo "cd $dest"
 
 # Remove a worktree created by worktree-add. Does NOT delete the shared
@@ -230,6 +250,8 @@ worktree-rm name mode="":
     fi
     rmdir "$parent/.worktrees" 2>/dev/null || true
     echo "removed $dest"
+    # That branch's artifacts are now unreachable but still in the shared dir.
+    command -v cargo-sweep >/dev/null && just sweep || true
 
 # Cut a release: merge development -> main with a --no-ff merge commit, tag,
 # and push. The tag triggers the release workflow (binaries + crates.io


### PR DESCRIPTION
## Measured, on a clean target dir

A full `dev + test --no-run + release` cycle:

| | before | after |
|---|---|---|
| **total** | **2188 MB / 40 min** | **1175 MB / 15 min** |
| `debug/deps` | 1204 MB | 507 MB |
| the 5 linked test/bin artifacts | 569 MB | 100 MB |
| `openssl-sys` out dirs (both profiles) | 79 MB | 2 MB |
| `release/` | 398 MB | 356 MB |

## What changed

**1. Vendored OpenSSL behind a default-on feature.** It stays ON by default — `cargo install sshub` and the release tarballs must build with no system OpenSSL present, and `cargo publish` means users get whatever `default` says. Only `just test` passes `--no-default-features`. CI and the release workflow are untouched, so what ships is what CI tested.

**2. Dev debuginfo trimmed** — `line-tables-only` for our own code, none for dependencies. Backtraces keep file and line. This is what takes the five linked artifacts from 569 MB to 100 MB.

**3. The shared target dir moves from a symlink to `.cargo/config.toml`.** This is the actual reason it reached 22 GB: `cargo clean` *deletes* the `target` symlink, and cargo then silently builds into a private `./target`. One shared dir became one copy per agent worktree, and nothing about it looked broken. The config file is untracked with an absolute `build.target-dir` (worktrees sit one level deeper, so no single relative path works for both); `just setup-shared-target` writes it and migrates an existing symlink or directory.

**Plus `just sweep`** (`cargo-sweep`, 4 GB cap by default): cargo never deletes artifacts of branches you have moved off, so the dir only grows. `just worktree-rm` now runs it.

`AGENTS.md` / `CLAUDE.md` updated — they documented the symlink, so an agent finding no `target` would have "repaired" it straight back.

## Verification

- `just test` on this branch: 1167 + 83 + 79 + … all passed, exit 0
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- feature resolution checked both ways: default pulls `openssl-src`, `--no-default-features` does not
- release binary links `libssl.so.3` and runs; the symlink regression reproduced and confirmed fixed (`cargo clean` → `cargo build` returns to the shared dir, no private `./target`)

_Written by Claude Opus 5 (Claude Code) on behalf of the maintainer._