### PR TITLE
fix(push-key): open the picker on the first Shift+P, and let notices be seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,23 @@ All notable changes to SSHub are documented in this file.
   `script(1)` wrapping fights the redirection exec exists for — and mosh hosts
   are refused, having no one-shot command mode.
 
+### Fixed
+
+- **Shift+P on the hosts tab did nothing until Identities had been visited
+  once** - `App::identities` is filled lazily, only by the Keys tab, the host
+  form and the group form. Before any of those, push-key read an empty cache,
+  concluded there were no key identities and returned; a trip to Identities and
+  back "fixed" it, which reads as a haunted keybind. It now reloads the
+  identities itself, so the picker opens on the first press of a fresh start.
+
+- **Dashboard notices were invisible unless a panel was zoomed** - `host_notice`
+  had exactly one surface left after the status bar was removed (#58), and that
+  toast was gated on `panel_zoomed`. Push-key errors, import/export results and
+  SFTP failures were all set and then never drawn, so every refused action
+  looked like a dead key. The toast now renders zoomed or not. Two silent
+  push-key bail-outs also gained a message: a group header has no key target,
+  and an empty Keys selection has no identity to push.
+
 ## [0.14.2] - 2026-08-12
 
 ### Fixed

--- a/src/app/push_key.rs
+++ b/src/app/push_key.rs
@@ -9,9 +9,17 @@ use crate::store::Identity;
 impl App {
     pub(crate) fn trigger_push_key_from_hosts(&mut self) -> Result<()> {
         let Some(_entry) = self.selected_entry().cloned() else {
+            // A group header (or an empty list) has nothing to push to. Silence
+            // here reads as "the key is broken", so say what's wrong.
+            self.host_notice =
+                Some("Select a host row first — a group header has no key target.".into());
             return Ok(());
         };
 
+        // `self.identities` is lazily filled (Keys tab, host form, group form),
+        // so before the first visit to those it is empty and push-key bailed out
+        // with "no key identities" on the hosts tab.
+        self.reload_identities()?;
         let key_identities = self.push_key_identities();
         if key_identities.is_empty() {
             self.host_notice =
@@ -26,6 +34,7 @@ impl App {
 
     pub(crate) fn trigger_push_key_from_keys(&mut self) -> Result<()> {
         let Some(identity) = self.selected_identity().cloned() else {
+            self.identity_notice = Some("No identity selected.".into());
             return Ok(());
         };
 

--- a/src/app/tests/misc.rs
+++ b/src/app/tests/misc.rs
@@ -795,3 +795,30 @@ fn fresh_ping_sample_grows_into_the_sparkline() {
     );
     assert_eq!(app.ping_grow("a"), 1.0);
 }
+
+/// Regression: Shift+P on the hosts tab used to do nothing until the Keys tab
+/// had been visited once, because `App::identities` is lazily loaded.
+#[test]
+fn push_key_from_hosts_opens_picker_without_visiting_keys_tab() {
+    let mut app = test_app(vec![("web", host("web"))]);
+    app.store
+        .create_identity(&crate::store::NewIdentity {
+            name: "with-key".into(),
+            username: None,
+            private_key: Some(std::path::PathBuf::from("~/.ssh/id_ed25519")),
+            certificate: None,
+            sort_order: 1,
+            has_password: false,
+        })
+        .unwrap();
+    assert!(app.identities.is_empty(), "cache starts cold");
+
+    app.trigger_push_key_from_hosts().unwrap();
+
+    assert_eq!(
+        app.mode,
+        AppMode::PushKeyIdentityPicker,
+        "{:?}",
+        app.host_notice
+    );
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -801,13 +801,12 @@ fn render_inner(frame: &mut Frame, app: &App, composition: &FrameComposition) {
     let (keybinds, pinned) = footer_keybinds(app);
     widgets::footer::render_footer(frame, areas.footer, &keybinds, pinned, theme);
 
-    // Issue #18: a zoomed panel hides the normal notice surface (status bar),
-    // so surface transient feedback (e.g. "copied N chars") as a toast pinned
-    // to the right of the footer until the next key press clears it.
-    if app.panel_zoomed {
-        if let Some(notice) = &app.host_notice {
-            render_zoom_toast(frame, areas.footer, notice, app);
-        }
+    // The status bar that used to print `host_notice` is gone (dead code, #58),
+    // so this toast is the *only* surface left: gating it on `panel_zoomed` made
+    // every dashboard notice invisible — push-key errors, import/export results,
+    // SFTP failures — and a silent failure reads as a broken keybind.
+    if let Some(notice) = &app.host_notice {
+        render_notice_toast(frame, areas.footer, notice, app);
     }
 
     // ── Overlay popups ─────────────────────────────────────────
@@ -1238,10 +1237,10 @@ fn footer_keybinds(app: &App) -> (Vec<(String, &'static str)>, usize) {
 }
 
 /// Draw a transient notice (issue #18) as a floating chip right-aligned on the
-/// row *above* the footer keybinds, used while a panel is zoomed and the normal
-/// status-bar notice surface is hidden. Sits above the hints so it never clips
-/// them.
-fn render_zoom_toast(frame: &mut Frame, footer: Rect, notice: &str, app: &App) {
+/// row *above* the footer keybinds. The dashboard's only notice surface — the
+/// status bar it replaced is gone — so it renders zoomed or not. Sits above the
+/// hints so it never clips them.
+fn render_notice_toast(frame: &mut Frame, footer: Rect, notice: &str, app: &App) {
     let label = format!(" {notice} ");
     let w = label.chars().count() as u16;
     if footer.width < w || footer.y == 0 {

--- a/tests/e2e/keychain.rs
+++ b/tests/e2e/keychain.rs
@@ -332,6 +332,53 @@ fn push_key_host_picker_flow() {
     assert!(app.push_key_host_picker.is_none());
 }
 
+/// Shift+P on a group header can't open the picker — but it must say so, not
+/// look like a dead keybind.
+#[test]
+fn push_key_on_group_header_explains_itself() {
+    let file = NamedTempFile::new().unwrap();
+    let db_path = file.path();
+    let store = LauncherStore::open(db_path).unwrap();
+    let group = store
+        .create_group(&sshub::store::NewHostGroup {
+            name: "grp".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let host = store
+        .create_host(&NewHost {
+            name: "test-host".into(),
+            address: "127.0.0.1".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    store.add_host_to_group(host.id, group.id).unwrap();
+    store
+        .create_identity(&sshub::store::NewIdentity {
+            name: "test-key".into(),
+            private_key: Some("/tmp/fake-key".into()),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let mut app = app_with_store(db_path);
+    app.reload_identities().unwrap();
+    app.selected = app
+        .nav_rows
+        .iter()
+        .position(|r| matches!(r, sshub::app::NavRow::Header(_)))
+        .expect("a group header row");
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('P'), KeyModifiers::SHIFT))
+        .unwrap();
+
+    assert_eq!(app.mode, AppMode::Normal);
+    assert!(
+        app.host_notice.is_some(),
+        "a header selection must explain why no picker opened"
+    );
+}
+
 #[test]
 fn push_key_identity_picker_flow() {
     let file = NamedTempFile::new().unwrap();


### PR DESCRIPTION
## What

Two defects that together made `Shift+P` (push key) look like a dead keybind on a fresh start.

**1. Cold identity cache.** `App::identities` is filled lazily — only by `switch_to_keys_tab`, `open_host_form` and `enter_group_manage`. On the hosts tab before any of those it is still `Vec::new()` (`App::new_with_deps`), so `trigger_push_key_from_hosts` read an empty cache, concluded there were no key identities and returned early. Visiting Identities warmed the cache and Shift+P started working — which is exactly the reported symptom: *"мотаешь табы до identities, возвращаешься к хостам, push key начинает работать"*.

It now calls `reload_identities()` itself, like the other three consumers do, but unconditionally rather than behind an `is_empty()` guard: the picker wants current rows anyway (an identity may have appeared via the CLI in another process), and `reload_identities` preserves the selection.

**2. The error message had nowhere to go.** `host_notice` lost its status bar (#58), leaving the footer toast as its only surface — and that toast was gated on `panel_zoomed`. So the "No key identities available" notice was set and then never drawn, and the same held for import/export results and SFTP failures. Gate removed; `render_zoom_toast` renamed to `render_notice_toast` to match. This is why the failure was *silent* rather than merely wrong.

Two further silent `return Ok(())` paths in `push_key.rs` gained a notice: a group header has no key target, and an empty Keys selection has no identity to push.

## Why it went unnoticed

`push_key.rs` had no covering tests, and the empty-cache guard the sibling call sites carry (`host_form.rs:11`, `groups.rs:78`) was simply missing here. Both new tests fail on the parent commit.

## Testing

```
cargo test --lib               1168 passed; 0 failed
cargo test --test e2e            84 passed; 0 failed
cargo fmt --check                clean
cargo clippy --all-targets       no warnings
```

New tests:
- `app::tests::misc::push_key_from_hosts_opens_picker_without_visiting_keys_tab` — cold cache, identity with a private key in the store, expects `AppMode::PushKeyIdentityPicker`.
- `e2e::keychain::push_key_on_group_header_explains_itself` — real `Shift+P` on a header row must set a notice instead of doing nothing.

## Key handling

No change to the security model: what gets pushed, how the identity is chosen and the ssh invocation itself are untouched. The diff only decides *when the identity list is read from the store* and *whether a refusal is displayed*. Worth a look at `src/app/push_key.rs` all the same, since it is the key path.

## Review notes

`src/tui/mod.rs` is a two-line behavioural change plus a rename — it was carried across the theme-system rewrite in `development`, so the theme-aware `app.theme().style(StyleRole::StatusBarToast)` body is dev's, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
