### PR TITLE
fix: session mouse/paging, stale tunnels, whole-field delete in forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,54 +4,76 @@ All notable changes to SSHub are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Ctrl+U and Ctrl+W kill a form field in one chord** (issue #115) - a wrong
+  password, a wrong username or a mistyped port could only be removed one
+  Backspace per character, which for a long masked secret is a dozen keystrokes
+  with no way to tell when the field is finally empty. The host form, the
+  identity form and the tunnel form now take readline's binds: Ctrl+U kills
+  everything before the cursor (the whole value with the cursor parked at the
+  end), Ctrl+W eats one word back. Both live in `text_input` beside the existing
+  backspace/cursor helpers, so they are multibyte-safe and clamp a cursor past
+  the end instead of panicking on a byte boundary. The three form footers, the
+  help overlay and the README name both chords; they are fixed editing keys, not
+  rebindable actions, like Backspace and the arrows they sit next to.
+
 ### Fixed
 
-- **The wheel and PageUp/PageDown scroll the remote app again** - inside `tmux`,
-  `vim`, `less` or anything else on the alternate screen, neither the wheel nor
-  PageUp/PageDown did anything: the alternate grid keeps no scrollback of its own
-  (vt100 gives it zero rows), and sshub was spending both on a local scroll that
-  had nothing to move. The keys now go to the app that drew the screen, and a
-  wheel notch there becomes three arrow keys — xterm's `alternateScroll`, which
-  is what makes a wheel scroll a remote pager at all. On the primary screen
-  nothing changes: the wheel and PageUp/PageDown still walk sshub's own
-  scrollback.
+- **The wheel and PageUp/PageDown reach the remote app on the alternate screen**
+  (issue #115) - inside `vim`, `less`, `man`, `tmux` or anything else drawing on
+  the alternate screen, neither did anything: that grid keeps no scrollback of
+  its own (vt100 gives it zero rows), and sshub was spending both on a local
+  scroll that had nothing to move. They now go to the app that drew the screen,
+  and a wheel notch there becomes three arrow keys — xterm's `alternateScroll`,
+  which is what makes a wheel scroll a remote pager at all. Shift opts out and
+  keeps the wheel on sshub's own scrollback. Two limits worth knowing: `tmux`
+  scrolls its *own* history only with `set -g mouse on` (without it tmux never
+  asks for the mouse, so the notch arrives as arrow keys — the same as in a real
+  terminal, where they reach the shell as history navigation), and a pager
+  started with `-X` (git's default `LESS=FRX`, `journalctl`) never takes the
+  alternate screen at all, so `git log` keeps scrolling sshub's buffer as before.
+  On the primary screen nothing changes.
 
-- **A drag at the shell prompt selects text instead of spraying `0;47;13M`** -
-  an app killed before it could send `ESC [ ? 1002 l` leaves mouse reporting on,
-  and every later click or drag was then encoded and echoed back by the remote
-  shell as mouse-report gibberish. Forwarding now needs the remote to be on the
-  alternate screen as well as to have asked for the mouse — vim, htop, tmux and
-  less all draw there, so the app that wants the mouse still gets it, while a
-  leaked mode at a prompt selects text like it should. An app that asks for the
-  mouse while staying on the primary screen (`fzf --height`) gets a local
-  selection instead; Shift still forces one everywhere.
+- **A drag at the shell prompt selects text instead of spraying `0;47;13M`**
+  (issue #115) - an app killed before it could send `ESC [ ? 1002 l` leaves mouse
+  reporting on, and every later click or drag was then encoded and echoed back by
+  the remote shell as mouse-report gibberish. Forwarding now needs the remote to
+  be on the alternate screen as well as to have asked for the mouse — vim, htop
+  and tmux all draw there, so the app that wants the mouse still gets it, while a
+  leaked mode at a prompt selects text like it should. Shift **inverts** that
+  decision either way: it takes a local selection over a full-screen app, and it
+  hands the mouse to an app that asked for it without leaving the primary screen
+  (an inline picker), which is also the recovery path if the guess is ever wrong.
+  Terminals that keep Shift+mouse for their own selection give you theirs
+  instead. A stray click on sshub's own header or footer row no longer reports
+  itself to the remote as an edge row of the grid.
 
-- **`sshub exec` says out loud who reads a `&&`** - `sshub exec web -- ls &&
-  uptime` runs `ls` on the host and `uptime` at home, because the local shell
-  splits the line before sshub ever sees it — the same as with `ssh`, and
-  reported as a bug because nothing said so. `--help`, the man page and the
-  README now show the quoted form (`-- 'ls && uptime'`) next to the note that a
-  full-screen command (vim, top, less) needs `--tty`. Behaviour unchanged.
+- **A tunnel changed in another sshub window no longer lingers here** (issue
+  #115) - the tunnel list is a snapshot and the store is shared, so a tunnel
+  deleted or edited in a second window, or by `sshub tunnel`, stayed in this
+  window's session top bar and tunnels tab for as long as the window lived. The
+  list is now re-read from the store every two seconds, with the selection
+  re-anchored by id so a row deleted above the cursor cannot slide a different
+  tunnel under the next `d`. Running children are left alone: an edit elsewhere
+  is a delete plus an insert (tunnels have no `UPDATE`), so a vanished id does
+  not mean a vanished tunnel. Cross-window *run state* stays per-window — the
+  TUI's tunnels are its own children, with no pid file to see another window's by.
 
-- **A tunnel changed in another sshub window no longer lingers here** - the
-  tunnel list is a snapshot and the store is shared, so a tunnel deleted (or
-  edited) in a second window, or by `sshub tunnel`, stayed in this window's
-  session top bar and tunnels tab for as long as the window lived. The list is
-  now re-read from the store every two seconds; a child process we still own for
-  a row that no longer exists is stopped, so a deleted tunnel stops holding its
-  local port. Cross-window *run state* is still per-window: the TUI's tunnels
-  are its own children, with no pid file to see another window's by.
+- **`Ctrl+U`, `End` or Backspace on the host form's *Session log* row no longer
+  edits the address** - every non-text row (the pickers, the toggles, the
+  tri-state) was handed `&mut address` as its "active field", so editing keys
+  aimed at them rewrote the address invisibly; with Ctrl+U in hand it went from
+  one character per press to the whole value in one chord. The accessor now
+  returns `Option`, which makes the compiler ask each caller what a non-text row
+  means, and answers "nothing to edit".
 
-- **Ctrl+U and Ctrl+W clear a form field in one chord** - a wrong password, a
-  wrong username or a mistyped port could only be removed one Backspace per
-  character, which for a long secret is a dozen keystrokes with no way to tell
-  when the field is finally empty. The host form, the identity form and the
-  tunnel form now take readline's binds: Ctrl+U kills everything before the
-  cursor (the whole value with the cursor parked at the end), Ctrl+W eats one
-  word back. Both live in `text_input` beside the existing backspace/cursor
-  helpers, so they are multibyte-safe and clamp a cursor past the end instead
-  of panicking on a byte boundary; the forms advertise Ctrl+U in their footer
-  hint.
+- **`sshub exec` says out loud which shell reads a `&&`** (issue #115) - `sshub
+  exec web -- ls && uptime` runs `ls` on the host and `uptime` at home, because
+  the local shell splits the line before sshub ever sees it — the same as with
+  `ssh`, and reported as a bug because nothing said so. `--help`, the man page
+  and the README now show the quoted form (`-- 'ls && uptime'`) next to the note
+  that a full-screen command (vim, top, less) needs `--tty`. Behaviour unchanged.
 
 ## [0.15.1] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ All notable changes to SSHub are documented in this file.
 
 ### Fixed
 
+- **A masked password says how to unmask itself** (issue #115) - the host and
+  identity forms arrive prefilled with the stored secret and mask it, and the
+  only mention of the bind that shows it was a footer row: 70% of a 24-row
+  terminal is 16 rows, the host form needs 22, and the overflow — reveal hint,
+  save, cancel — fell off the bottom. So the field read as a wall of dots with no
+  way out. The reveal bind now rides the password row itself while that row is
+  focused (`Ctrl+R: show + copy` by default, whatever it is bound to), and a form
+  popup is sized to the rows it actually draws instead of a flat 70%, so its own
+  footer stops being the first thing clipped. A render test at 80x24 holds both,
+  so adding a field cannot quietly re-clip them.
+
 - **The wheel and PageUp/PageDown reach the remote app on the alternate screen**
   (issue #115) - inside `vim`, `less`, `man`, `tmux` or anything else drawing on
   the alternate screen, neither did anything: that grid keeps no scrollback of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ All notable changes to SSHub are documented in this file.
   alternate screen at all, so `git log` keeps scrolling sshub's buffer as before.
   On the primary screen nothing changes.
 
+- **The wheel says where tmux's own scrolling switch is** (issue #115) - on the
+  alternate screen a terminal can only turn a notch into arrow keys, and inside
+  `tmux` those land in the shell's history rather than scrolling anything, which
+  reads as "the wheel is broken". The session now says it once, in its own toast:
+  `wheel → ↑ keys here — tmux scrolls with: set -g mouse on`. Once per session,
+  not once per notch, and it fires on the notch rather than on a guess about what
+  is running — from a PTY we see a byte stream, not processes, and tmux's status
+  line is the first thing people re-style. Nothing is sent to the remote and
+  nothing is reconfigured there: what to run stays the user's call.
+
 - **A wheel that cannot scroll no longer drags the selection instead** (issue
   #115) - reported from a live `tmux`: the wheel moved the highlighted block down
   the screen while the text stayed exactly where it was. The view is allowed to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to SSHub are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The wheel and PageUp/PageDown scroll the remote app again** - inside `tmux`,
+  `vim`, `less` or anything else on the alternate screen, neither the wheel nor
+  PageUp/PageDown did anything: the alternate grid keeps no scrollback of its own
+  (vt100 gives it zero rows), and sshub was spending both on a local scroll that
+  had nothing to move. The keys now go to the app that drew the screen, and a
+  wheel notch there becomes three arrow keys — xterm's `alternateScroll`, which
+  is what makes a wheel scroll a remote pager at all. On the primary screen
+  nothing changes: the wheel and PageUp/PageDown still walk sshub's own
+  scrollback.
+
+- **A drag at the shell prompt selects text instead of spraying `0;47;13M`** -
+  an app killed before it could send `ESC [ ? 1002 l` leaves mouse reporting on,
+  and every later click or drag was then encoded and echoed back by the remote
+  shell as mouse-report gibberish. Forwarding now needs the remote to be on the
+  alternate screen as well as to have asked for the mouse — vim, htop, tmux and
+  less all draw there, so the app that wants the mouse still gets it, while a
+  leaked mode at a prompt selects text like it should. An app that asks for the
+  mouse while staying on the primary screen (`fzf --height`) gets a local
+  selection instead; Shift still forces one everywhere.
+
+- **`sshub exec` says out loud who reads a `&&`** - `sshub exec web -- ls &&
+  uptime` runs `ls` on the host and `uptime` at home, because the local shell
+  splits the line before sshub ever sees it — the same as with `ssh`, and
+  reported as a bug because nothing said so. `--help`, the man page and the
+  README now show the quoted form (`-- 'ls && uptime'`) next to the note that a
+  full-screen command (vim, top, less) needs `--tty`. Behaviour unchanged.
+
+- **A tunnel changed in another sshub window no longer lingers here** - the
+  tunnel list is a snapshot and the store is shared, so a tunnel deleted (or
+  edited) in a second window, or by `sshub tunnel`, stayed in this window's
+  session top bar and tunnels tab for as long as the window lived. The list is
+  now re-read from the store every two seconds; a child process we still own for
+  a row that no longer exists is stopped, so a deleted tunnel stops holding its
+  local port. Cross-window *run state* is still per-window: the TUI's tunnels
+  are its own children, with no pid file to see another window's by.
+
+- **Ctrl+U and Ctrl+W clear a form field in one chord** - a wrong password, a
+  wrong username or a mistyped port could only be removed one Backspace per
+  character, which for a long secret is a dozen keystrokes with no way to tell
+  when the field is finally empty. The host form, the identity form and the
+  tunnel form now take readline's binds: Ctrl+U kills everything before the
+  cursor (the whole value with the cursor parked at the end), Ctrl+W eats one
+  word back. Both live in `text_input` beside the existing backspace/cursor
+  helpers, so they are multibyte-safe and clamp a cursor past the end instead
+  of panicking on a byte boundary; the forms advertise Ctrl+U in their footer
+  hint.
+
 ## [0.15.1] - 2026-08-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ All notable changes to SSHub are documented in this file.
   alternate screen at all, so `git log` keeps scrolling sshub's buffer as before.
   On the primary screen nothing changes.
 
+- **A wheel that cannot scroll no longer drags the selection instead** (issue
+  #115) - reported from a live `tmux`: the wheel moved the highlighted block down
+  the screen while the text stayed exactly where it was. The view is allowed to
+  move less than asked — the top of the buffer clamps, and the alternate screen
+  keeps no scrollback at all — but the selection was shifted by the full
+  requested amount regardless, so the highlight slid across static rows. It now
+  moves by however far the view actually moved, which on the alternate screen is
+  nothing. Both the wheel and PageUp/PageDown went through the same unguarded
+  path; they share one method now.
+
 - **A drag at the shell prompt selects text instead of spraying `0;47;13M`**
   (issue #115) - an app killed before it could send `ESC [ ? 1002 l` leaves mouse
   reporting on, and every later click or drag was then encoded and echoed back by

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ sshub exec prod-web -- systemctl is-active nginx
 sshub exec prod-web -- 'tail -n 200 /var/log/nginx/error.log' > errors.log
 echo "$payload" | sshub exec db-01 -- 'psql -f -'
 sshub exec prod-web --timeout 30 --format json -- uptime
+sshub exec prod-web -- 'ls && uptime'        # quote it: bare `&&` runs locally
+sshub exec prod-web --tty -- top             # full-screen commands need a PTY
 
 # Groups and identities
 sshub groups                                 # list host groups

--- a/README.md
+++ b/README.md
@@ -287,6 +287,16 @@ Defaults below. Rebind any action with **Ctrl+K** (saved to `config.toml`). Pres
 | `Ctrl+[` / `Ctrl+]`   | Previous / next session tab         |
 | `Ctrl+Shift+S`         | Focus session from dashboard        |
 | `Alt+S`                | Switch to an open session (searchable) |
+| `PgUp`/`PgDn`, wheel   | Scroll session history; both go to the remote app while it holds the alternate screen (tmux, vim, less), where the wheel becomes arrow keys |
+| drag                   | Select terminal text, copied on release; `Shift` inverts it when the remote app owns the mouse |
+
+`Ctrl+W` closes a session tab, but inside a form it kills the word before the
+cursor (`Ctrl+U` kills everything before it) — the host, identity and tunnel
+forms take readline's editing chords.
+
+The wheel inside `tmux` reaches tmux's own scrollback only with
+`set -g mouse on`; without it tmux never asks for the mouse, so the notch
+arrives as arrow keys, exactly as in a real terminal.
 
 ### Hosts (tab 1)
 

--- a/man/sshub.1
+++ b/man/sshub.1
@@ -105,7 +105,18 @@ so an unknown host key fails instead of waiting for a human. Everything after
 .B \-\-
 is the command; a single quoted string
 .RB ( "sshub exec web-01 \(dquptime\(dq" )
-works too.
+works too. Shell operators are read by whichever shell sees them first:
+.RB ( "sshub exec web-01 \-\- ls && uptime" )
+runs
+.B ls
+on the host and
+.B uptime
+at home, exactly as
+.BR ssh (1)
+does \(em quote the whole command
+.RB ( "sshub exec web-01 \-\- \(dqls && uptime\(dq" )
+to send it all remotely. A full-screen command (vim, top, less) needs
+.BR \-\-tty .
 .B \-\-tty
 forces a PTY
 .RB ( "ssh \-tt" )

--- a/src/app/host_form.rs
+++ b/src/app/host_form.rs
@@ -460,12 +460,13 @@ impl App {
         if form.metadata_only && form.field.is_connection_field() {
             return;
         }
-        if form.field.is_picker() || form.field.is_toggle() {
+        let c = form.cursor;
+        if c == 0 {
             return;
         }
-        let c = form.cursor;
-        if c > 0 {
-            form.cursor = text_input::backspace_at(form.active_field_mut(), c);
+        // `None` = a picker, a toggle or the tri-state: nothing to delete.
+        if let Some(v) = form.active_field_mut() {
+            form.cursor = text_input::backspace_at(v, c);
             form.dirty = true;
         }
     }
@@ -477,12 +478,12 @@ impl App {
         if form.metadata_only && form.field.is_connection_field() {
             return;
         }
-        if form.field.is_picker() || form.field.is_toggle() {
+        let cursor = form.cursor;
+        if cursor == 0 {
             return;
         }
-        let cursor = form.cursor;
-        if cursor > 0 {
-            form.cursor = text_input::clear_before_cursor(form.active_field_mut(), cursor);
+        if let Some(v) = form.active_field_mut() {
+            form.cursor = text_input::clear_before_cursor(v, cursor);
             form.dirty = true;
         }
     }
@@ -494,12 +495,11 @@ impl App {
         if form.metadata_only && form.field.is_connection_field() {
             return;
         }
-        if form.field.is_picker() || form.field.is_toggle() {
-            return;
-        }
         let len_before = text_input::char_len(form.active_field());
         let cursor = form.cursor;
-        form.cursor = text_input::delete_word_before(form.active_field_mut(), cursor);
+        if let Some(v) = form.active_field_mut() {
+            form.cursor = text_input::delete_word_before(v, cursor);
+        }
         if text_input::char_len(form.active_field()) != len_before {
             form.dirty = true;
         }
@@ -512,24 +512,22 @@ impl App {
         if form.metadata_only && form.field.is_connection_field() {
             return;
         }
-        if form.field.is_picker() || form.field.is_toggle() {
-            return;
-        }
         let c = form.cursor;
-        form.cursor = text_input::insert_at(form.active_field_mut(), c, ch);
-        form.dirty = true;
+        if let Some(v) = form.active_field_mut() {
+            form.cursor = text_input::insert_at(v, c, ch);
+            form.dirty = true;
+        }
     }
 
     fn host_form_cursor_key(&mut self, code: KeyCode) {
         if let Some(form) = self.host_form.as_mut() {
-            if form.field.is_picker() || form.field.is_toggle() {
-                return;
-            }
             if code == KeyCode::Delete && form.metadata_only && form.field.is_connection_field() {
                 return;
             }
             let mut cursor = form.cursor;
-            let changed = text_input::handle_cursor_key(code, form.active_field_mut(), &mut cursor);
+            let changed = form
+                .active_field_mut()
+                .and_then(|v| text_input::handle_cursor_key(code, v, &mut cursor));
             form.cursor = cursor;
             if changed == Some(true) {
                 form.dirty = true;

--- a/src/app/host_form.rs
+++ b/src/app/host_form.rs
@@ -391,6 +391,15 @@ impl App {
                 self.host_form_toggle();
             }
             KeyCode::Backspace => self.host_form_backspace(),
+            // Readline-style bulk edits (Ctrl+U kills to start, Ctrl+W eats a
+            // word) so a wrong password or user does not have to be deleted one
+            // character at a time.
+            KeyCode::Char('u') if key.modifiers == KeyModifiers::CONTROL => {
+                self.host_form_kill_to_start()
+            }
+            KeyCode::Char('w') if key.modifiers == KeyModifiers::CONTROL => {
+                self.host_form_kill_word()
+            }
             KeyCode::Char(c)
                 if (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)
                     && !c.is_control()
@@ -457,6 +466,41 @@ impl App {
         let c = form.cursor;
         if c > 0 {
             form.cursor = text_input::backspace_at(form.active_field_mut(), c);
+            form.dirty = true;
+        }
+    }
+
+    pub(crate) fn host_form_kill_to_start(&mut self) {
+        let Some(form) = self.host_form.as_mut() else {
+            return;
+        };
+        if form.metadata_only && form.field.is_connection_field() {
+            return;
+        }
+        if form.field.is_picker() || form.field.is_toggle() {
+            return;
+        }
+        let cursor = form.cursor;
+        if cursor > 0 {
+            form.cursor = text_input::clear_before_cursor(form.active_field_mut(), cursor);
+            form.dirty = true;
+        }
+    }
+
+    pub(crate) fn host_form_kill_word(&mut self) {
+        let Some(form) = self.host_form.as_mut() else {
+            return;
+        };
+        if form.metadata_only && form.field.is_connection_field() {
+            return;
+        }
+        if form.field.is_picker() || form.field.is_toggle() {
+            return;
+        }
+        let len_before = text_input::char_len(form.active_field());
+        let cursor = form.cursor;
+        form.cursor = text_input::delete_word_before(form.active_field_mut(), cursor);
+        if text_input::char_len(form.active_field()) != len_before {
             form.dirty = true;
         }
     }

--- a/src/app/identities.rs
+++ b/src/app/identities.rs
@@ -143,6 +143,15 @@ impl App {
             }
             KeyCode::BackTab | KeyCode::Up => self.identity_form_field_prev(),
             KeyCode::Backspace => self.identity_form_backspace(),
+            // Readline-style bulk edits: Ctrl+U kills to the field start,
+            // Ctrl+W eats one word back — a wrong passphrase must not have to
+            // be deleted character by character.
+            KeyCode::Char('u') if key.modifiers == KeyModifiers::CONTROL => {
+                self.identity_form_kill_to_start()
+            }
+            KeyCode::Char('w') if key.modifiers == KeyModifiers::CONTROL => {
+                self.identity_form_kill_word()
+            }
             KeyCode::Left | KeyCode::Right | KeyCode::Home | KeyCode::End | KeyCode::Delete => {
                 self.identity_form_cursor_key(key.code)
             }
@@ -408,6 +417,35 @@ impl App {
         let c = form.cursor;
         if c > 0 {
             form.cursor = text_input::backspace_at(form.active_field_mut(), c);
+            form.dirty = true;
+        }
+    }
+
+    /// Ctrl+U: kill everything before the cursor — one chord wipes a whole
+    /// wrong passphrase instead of holding backspace.
+    pub(crate) fn identity_form_kill_to_start(&mut self) {
+        let Some(form) = self.identity_form.as_mut() else {
+            return;
+        };
+        // A pasted key blob goes wholesale (mirrors the backspace guard).
+        form.clear_pasted_key_marker();
+        let cursor = form.cursor;
+        if cursor > 0 {
+            form.cursor = text_input::clear_before_cursor(form.active_field_mut(), cursor);
+            form.dirty = true;
+        }
+    }
+
+    /// Ctrl+W: delete the word before the cursor.
+    pub(crate) fn identity_form_kill_word(&mut self) {
+        let Some(form) = self.identity_form.as_mut() else {
+            return;
+        };
+        form.clear_pasted_key_marker();
+        let len_before = text_input::char_len(form.active_field());
+        let cursor = form.cursor;
+        form.cursor = text_input::delete_word_before(form.active_field_mut(), cursor);
+        if text_input::char_len(form.active_field()) != len_before {
             form.dirty = true;
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -456,6 +456,10 @@ pub struct App {
     pub tunnel_manager: crate::tunnel::TunnelManager,
     /// One-shot startup hook for `auto_connect` tunnels.
     tunnels_auto_started: bool,
+    /// Last time the tunnel list was re-read from the store. Another sshub
+    /// window (or the CLI) writes to the same SQLite file, so the snapshot in
+    /// `tunnels` goes stale behind our back.
+    tunnels_synced: std::time::Instant,
     pub terminal_area: ratatui::layout::Rect,
     /// Embedded PTY sessions. Multiple may coexist (Ctrl+T opens a new tab).
     /// Empty when not in `Connecting` / `Session` mode.
@@ -1021,6 +1025,7 @@ impl App {
             tunnel_notice: None,
             tunnel_manager: crate::tunnel::TunnelManager::new(),
             tunnels_auto_started: false,
+            tunnels_synced: std::time::Instant::now(),
             terminal_area: ratatui::layout::Rect::default(),
             sessions: Vec::new(),
             active_session: None,

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -480,8 +480,7 @@ impl App {
 
         // Local text selection drives the mouse when the remote app isn't
         // consuming it (plain shell → just drag to select, no Shift needed);
-        // when the remote wants the mouse (vim/tmux/…), Shift forces a local
-        // selection instead of forwarding the event. See
+        // Shift inverts that decision in either direction. See
         // [`crate::session::keys::selects_locally`] for why the mouse mode
         // alone does not decide it.
         let selecting = crate::session::keys::selects_locally(mode, alternate_screen, shift);
@@ -509,8 +508,11 @@ impl App {
                 // xterm's alternateScroll: the alternate grid keeps no
                 // scrollback, so the notch becomes arrow keys for the app that
                 // owns the screen instead of a local scroll that can move
-                // nothing.
-                MouseEventKind::ScrollUp | MouseEventKind::ScrollDown if alternate_screen => {
+                // nothing. Shift opts out — it is the wheel's way back to our
+                // own scrollback, which is what it means in a real terminal.
+                MouseEventKind::ScrollUp | MouseEventKind::ScrollDown
+                    if alternate_screen && !shift =>
+                {
                     let app_cursor = session.parser.screen().application_cursor();
                     if let Some(bytes) =
                         crate::session::keys::alternate_scroll_keys(mouse.kind, app_cursor)
@@ -534,10 +536,14 @@ impl App {
         }
 
         // Remote app is consuming mouse — translate to the wire protocol.
-        let local_y = mouse.row.saturating_sub(1);
-        if let Some(bytes) =
-            crate::session::keys::encode_mouse(mouse, mouse.column, local_y, mode, encoding)
-        {
+        // Only events inside the grid go out: row 0 is our own header and
+        // anything past the last row is the footer, and reporting either as an
+        // edge row of the grid made a stray click on sshub's chrome land on the
+        // remote (tmux's status line with `status-position top`, for one).
+        if mouse.row == 0 || mouse.row.saturating_sub(1) >= rows || mouse.column >= cols {
+            return;
+        }
+        if let Some(bytes) = crate::session::keys::encode_mouse(mouse, col, row, mode, encoding) {
             let _ = session.write(&bytes);
         }
     }

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -4,7 +4,9 @@ impl App {
     /// Handle a keystroke while an embedded session is active.
     ///
     /// Session tab keys are user-configurable (see [`KeyAction::SessionNewTab`]
-    /// and friends). `PgUp` / `PgDn` without Ctrl navigate scrollback locally.
+    /// and friends). `PgUp` / `PgDn` without Ctrl navigate scrollback locally,
+    /// except while the remote is on the alternate screen — there the app that
+    /// drew it owns paging and the keys are forwarded.
     pub(crate) fn handle_key_session(&mut self, key: KeyEvent) -> Result<()> {
         if self.is_action(KeyAction::LocalShell, &key) {
             self.open_local_shell()?;
@@ -87,8 +89,15 @@ impl App {
             self.active_session().map(|s| &s.phase),
             Some(crate::session::SessionPhase::Connecting { .. })
         ) && self.is_action(KeyAction::SessionCancel, &key);
-        let scroll_up = self.is_action(KeyAction::SessionScrollUp, &key);
-        let scroll_down = self.is_action(KeyAction::SessionScrollDown, &key);
+        // On the alternate screen the remote app owns paging: tmux, vim and
+        // less draw there, and the alternate grid has no scrollback of its own
+        // (vt100 gives it zero rows), so stealing PageUp/PageDown for a local
+        // scroll made the key do nothing at all. Forward it instead.
+        let alternate_screen = self
+            .active_session()
+            .is_some_and(|s| s.parser.screen().alternate_screen());
+        let scroll_up = !alternate_screen && self.is_action(KeyAction::SessionScrollUp, &key);
+        let scroll_down = !alternate_screen && self.is_action(KeyAction::SessionScrollDown, &key);
 
         if cancel_connecting {
             self.close_active_session();
@@ -461,6 +470,7 @@ impl App {
 
         let mode = session.parser.screen().mouse_protocol_mode();
         let encoding = session.parser.screen().mouse_protocol_encoding();
+        let alternate_screen = session.parser.screen().alternate_screen();
         let (rows, cols) = session.parser.screen().size();
 
         // Body-local grid coordinates (header takes row 0).
@@ -471,8 +481,10 @@ impl App {
         // Local text selection drives the mouse when the remote app isn't
         // consuming it (plain shell → just drag to select, no Shift needed);
         // when the remote wants the mouse (vim/tmux/…), Shift forces a local
-        // selection instead of forwarding the event.
-        let selecting = mode == vt100::MouseProtocolMode::None || shift;
+        // selection instead of forwarding the event. See
+        // [`crate::session::keys::selects_locally`] for why the mouse mode
+        // alone does not decide it.
+        let selecting = crate::session::keys::selects_locally(mode, alternate_screen, shift);
 
         if selecting {
             match mouse.kind {
@@ -492,6 +504,18 @@ impl App {
                             Ok(()) => session.set_copy_notice(format!("copied {chars} chars")),
                             Err(e) => session.set_copy_notice(format!("copy failed: {e}")),
                         }
+                    }
+                }
+                // xterm's alternateScroll: the alternate grid keeps no
+                // scrollback, so the notch becomes arrow keys for the app that
+                // owns the screen instead of a local scroll that can move
+                // nothing.
+                MouseEventKind::ScrollUp | MouseEventKind::ScrollDown if alternate_screen => {
+                    let app_cursor = session.parser.screen().application_cursor();
+                    if let Some(bytes) =
+                        crate::session::keys::alternate_scroll_keys(mouse.kind, app_cursor)
+                    {
+                        let _ = session.write(&bytes);
                     }
                 }
                 MouseEventKind::ScrollUp => {

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -516,6 +516,10 @@ impl App {
                         crate::session::keys::alternate_scroll_keys(mouse.kind, app_cursor)
                     {
                         let _ = session.write(&bytes);
+                        // Arrow keys are all a terminal can do here, and in tmux
+                        // they land in the shell's history rather than scrolling
+                        // anything — so say once where the real switch is.
+                        session.hint_alternate_scroll();
                     }
                 }
                 MouseEventKind::ScrollUp => session.scroll_with_selection(3),

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -118,13 +118,11 @@ impl App {
         // selection anchored to the same text as the view scrolls.
         let half = (body_rows / 2).max(1);
         if scroll_up {
-            session.parser.scroll_up(half);
-            session.selection_scroll_shift(half as i32);
+            session.scroll_with_selection(half as i32);
             return Ok(());
         }
         if scroll_down {
-            session.parser.scroll_down(half);
-            session.selection_scroll_shift(-(half as i32));
+            session.scroll_with_selection(-(half as i32));
             return Ok(());
         }
 
@@ -520,14 +518,8 @@ impl App {
                         let _ = session.write(&bytes);
                     }
                 }
-                MouseEventKind::ScrollUp => {
-                    session.parser.scroll_up(3);
-                    session.selection_scroll_shift(3);
-                }
-                MouseEventKind::ScrollDown => {
-                    session.parser.scroll_down(3);
-                    session.selection_scroll_shift(-3);
-                }
+                MouseEventKind::ScrollUp => session.scroll_with_selection(3),
+                MouseEventKind::ScrollDown => session.scroll_with_selection(-3),
                 // Any other press clears a pending selection.
                 MouseEventKind::Down(_) => session.selection_clear(),
                 _ => {}

--- a/src/app/tests/host_form.rs
+++ b/src/app/tests/host_form.rs
@@ -281,3 +281,62 @@ pub(crate) fn secret_field_hints_name_the_binds_and_follow_rebinds() {
         "a rebind shows through and an unbound action says nothing"
     );
 }
+
+/// Ctrl+U wipes the field the user is looking at — and *only* that field. Every
+/// non-text row used to be handed `&mut address` as its "active field", so
+/// `End` then `Ctrl+U` on *Session log* emptied the address behind the user's
+/// back (Backspace did the same, one character at a time).
+#[test]
+pub(crate) fn ctrl_u_on_a_non_text_row_leaves_the_address_alone() {
+    let mut app = test_app(vec![]);
+    app.enter_host_form(None, false).unwrap();
+    if let Some(form) = app.host_form.as_mut() {
+        form.address = "10.0.0.1".into();
+        form.field = HostFormField::SessionLogging;
+        form.cursor = 0;
+    }
+
+    for k in [KeyCode::End, KeyCode::Char('u'), KeyCode::Backspace] {
+        let ev = if k == KeyCode::Char('u') {
+            KeyEvent::new(k, KeyModifiers::CONTROL)
+        } else {
+            key(k)
+        };
+        app.handle_key(ev).unwrap();
+    }
+
+    let form = app.host_form.as_ref().unwrap();
+    assert_eq!(form.address, "10.0.0.1");
+    assert_eq!(form.field, HostFormField::SessionLogging);
+    assert!(!form.dirty, "nothing was edited, so nothing is dirty");
+}
+
+/// The chords the bug report asked for, at the layer they were reported: the
+/// key has to reach the field, not just the helper in `text_input`.
+#[test]
+pub(crate) fn ctrl_u_and_ctrl_w_clear_the_focused_form_field() {
+    let mut app = test_app(vec![]);
+    app.enter_host_form(None, false).unwrap();
+    if let Some(form) = app.host_form.as_mut() {
+        form.field = HostFormField::Username;
+        form.username = "deploy".into();
+        form.cursor = text_input::char_len(&form.username);
+    }
+    app.handle_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL))
+        .unwrap();
+    let form = app.host_form.as_ref().unwrap();
+    assert_eq!(form.username, "", "Ctrl+U killed the whole username");
+    assert_eq!(form.cursor, 0);
+    assert!(form.dirty);
+
+    // Ctrl+W is not eaten upstream by the session's "close tab" bind.
+    if let Some(form) = app.host_form.as_mut() {
+        form.field = HostFormField::Password;
+        form.password = "one two".into();
+        form.cursor = text_input::char_len(&form.password);
+    }
+    app.handle_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL))
+        .unwrap();
+    assert_eq!(app.mode, AppMode::HostForm, "the form is still open");
+    assert_eq!(app.host_form.as_ref().unwrap().password, "one ");
+}

--- a/src/app/tests/host_form.rs
+++ b/src/app/tests/host_form.rs
@@ -340,3 +340,71 @@ pub(crate) fn ctrl_u_and_ctrl_w_clear_the_focused_form_field() {
     assert_eq!(app.mode, AppMode::HostForm, "the form is still open");
     assert_eq!(app.host_form.as_ref().unwrap().password, "one ");
 }
+
+/// A masked password has to say how to unmask itself, on the row and in the
+/// footer, at the size a terminal actually is. 70% of a 24-row terminal is 16
+/// rows and the host form needs 22, so the hints used to fall off the bottom and
+/// the field read as a wall of dots with no way out.
+#[test]
+pub(crate) fn the_password_row_shows_the_reveal_bind_at_80x24() {
+    let (mut app, _secrets) = test_app_with_secrets(vec![]);
+    let created = app
+        .store
+        .create_host(&crate::store::NewHost {
+            has_password: true,
+            ..crate::store::NewHost::launcher("edge", "10.0.0.9")
+        })
+        .unwrap();
+    app.password_store
+        .set(&crate::credentials::host_key(created.id), "s3cret-pw")
+        .unwrap();
+    app.reload_hosts().unwrap();
+    app.enter_host_form(Some(&created), false).unwrap();
+    while app.host_form.as_ref().unwrap().field != HostFormField::Password {
+        app.handle_key(key(KeyCode::Down)).unwrap();
+    }
+
+    let (w, h) = (80u16, 24u16);
+    app.terminal_area = ratatui::layout::Rect::new(0, 0, w, h);
+    let mut term = ratatui::Terminal::new(ratatui::backend::TestBackend::new(w, h)).unwrap();
+    term.draw(|f| crate::tui::render(f, &app)).unwrap();
+    let buf = term.backend().buffer().clone();
+    let screen: String = (0..h)
+        .map(|y| {
+            (0..w)
+                .map(|x| buf[(x, y)].symbol())
+                .collect::<String>()
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let reveal = app.config.keybinds.primary(KeyAction::RevealSecret);
+    assert!(!reveal.is_empty(), "the reveal action has a default bind");
+    assert!(
+        screen.contains(reveal),
+        "the focused password row must name the reveal bind ({reveal}):\n{screen}"
+    );
+    assert!(
+        screen.contains("\u{25CF}"),
+        "the value itself stays masked until asked:\n{screen}"
+    );
+    assert!(
+        screen.contains("Esc: cancel"),
+        "the form's own footer must still be on screen at 24 rows:\n{screen}"
+    );
+
+    // And the bind does reveal, in place.
+    app.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL))
+        .unwrap();
+    assert!(app.host_form.as_ref().unwrap().password_revealed);
+    let mut term = ratatui::Terminal::new(ratatui::backend::TestBackend::new(w, h)).unwrap();
+    term.draw(|f| crate::tui::render(f, &app)).unwrap();
+    let buf = term.backend().buffer().clone();
+    let revealed: String = buf.content().iter().map(|c| c.symbol()).collect();
+    assert!(
+        revealed.contains("s3cret-pw"),
+        "Ctrl+R shows the stored secret in the field"
+    );
+}

--- a/src/app/tests/misc.rs
+++ b/src/app/tests/misc.rs
@@ -822,3 +822,56 @@ fn push_key_from_hosts_opens_picker_without_visiting_keys_tab() {
         app.host_notice
     );
 }
+
+/// Another sshub window (or `sshub tunnel delete`) writes to the same store, so
+/// this window's snapshot has to be re-read: the deleted tunnel used to sit in
+/// the session top bar and the tunnels tab for as long as the window lived.
+#[test]
+fn a_tunnel_deleted_elsewhere_leaves_this_windows_list_on_the_next_sync() {
+    let mut app = test_app(vec![("edge", host("edge"))]);
+    let id = app
+        .store
+        .create_tunnel(&crate::store::NewTunnel {
+            host_id: None,
+            tunnel_type: crate::store::TunnelType::Local,
+            local_port: 5432,
+            remote_host: "127.0.0.1".into(),
+            remote_port: 5432,
+            label: Some("pg".into()),
+            auto_connect: false,
+        })
+        .unwrap();
+    app.reload_tunnels().unwrap();
+    assert_eq!(app.tunnels.len(), 1);
+    app.tunnel_selected = 0;
+
+    // The other window removes the row from the shared SQLite file.
+    assert!(app.store.delete_tunnel(id).unwrap());
+    assert_eq!(app.tunnels.len(), 1, "our snapshot is still stale");
+
+    app.sync_tunnels_from_store().unwrap();
+
+    assert!(app.tunnels.is_empty());
+    assert_eq!(
+        app.tunnel_selected, 0,
+        "selection clamped to the short list"
+    );
+}
+
+/// A bracketed paste has to land in the focused form field: the tunnel form was
+/// reported as "cannot paste into the port", which turned out to be the host
+/// terminal's mouse paste being swallowed by our mouse capture, not this path.
+#[test]
+fn a_paste_reaches_the_tunnel_form_port_field() {
+    let mut app = test_app(vec![("edge", host("edge"))]);
+    app.active_tab = 2;
+    app.handle_key(key(KeyCode::Char('a'))).unwrap();
+    assert_eq!(app.mode, AppMode::TunnelForm);
+    if let Some(f) = app.tunnel_form.as_mut() {
+        f.active_field = TunnelFormField::LocalPort;
+        f.cursor = 0;
+    }
+    app.handle_paste("8080").unwrap();
+    let f = app.tunnel_form.as_ref().unwrap();
+    assert_eq!(f.local_port, "8080", "paste landed: {:?}", f.local_port);
+}

--- a/src/app/tests/misc.rs
+++ b/src/app/tests/misc.rs
@@ -858,6 +858,43 @@ fn a_tunnel_deleted_elsewhere_leaves_this_windows_list_on_the_next_sync() {
     );
 }
 
+/// The selection is an index, so a row deleted *above* the cursor in another
+/// window used to slide a different tunnel under it — and the next `d` would
+/// have deleted that one.
+#[test]
+fn the_tunnel_selection_follows_its_row_across_a_sync() {
+    let mut app = test_app(vec![]);
+    for port in [5432u16, 6379, 8080] {
+        app.store
+            .create_tunnel(&crate::store::NewTunnel {
+                host_id: None,
+                tunnel_type: crate::store::TunnelType::Local,
+                local_port: port,
+                remote_host: "127.0.0.1".into(),
+                remote_port: port,
+                label: Some(format!("t{port}")),
+                auto_connect: false,
+            })
+            .unwrap();
+    }
+    app.reload_tunnels().unwrap();
+    assert_eq!(app.tunnels.len(), 3);
+
+    // Point at a known row, then have "another window" delete a different one.
+    let want = app.tunnels[2].id;
+    app.tunnel_selected = 2;
+    let other = app.tunnels[0].id;
+    assert!(app.store.delete_tunnel(other).unwrap());
+
+    app.sync_tunnels_from_store().unwrap();
+
+    assert_eq!(app.tunnels.len(), 2);
+    assert_eq!(
+        app.tunnels[app.tunnel_selected].id, want,
+        "the cursor stayed on the tunnel it was on, not on whatever took its index"
+    );
+}
+
 /// A bracketed paste has to land in the focused form field: the tunnel form was
 /// reported as "cannot paste into the port", which turned out to be the host
 /// terminal's mouse paste being swallowed by our mouse capture, not this path.

--- a/src/app/tests/session.rs
+++ b/src/app/tests/session.rs
@@ -1049,3 +1049,68 @@ pub(crate) fn a_wheel_that_cannot_scroll_leaves_the_selection_where_it_is() {
         "when the view moves, the highlight moves with it"
     );
 }
+
+/// The wheel on the alternate screen can only send arrow keys, and in tmux those
+/// go to the shell's history instead of scrolling — so the session says once
+/// where the switch that does scroll actually lives.
+#[test]
+pub(crate) fn a_wheel_on_the_alternate_screen_names_the_tmux_switch_once() {
+    let mut app = test_app(vec![("edge", host("edge"))]);
+    app.terminal_area = ratatui::layout::Rect::new(0, 0, 80, 24);
+    let cfg = crate::session::SessionConfig {
+        argv: vec!["true".into()],
+        display_name: "edge".into(),
+        meta: crate::session::SessionMeta::default(),
+        pending_secret: None,
+        key_push_identity: None,
+        host_name: "edge".into(),
+    };
+    let mut session = crate::session::Session::spawn(cfg, 24, 80, None).unwrap();
+    session.parser.process(b"\x1b[?1049h"); // tmux / vim / less draw here
+    app.sessions.push(session);
+    app.active_session = Some(0);
+    app.mode = AppMode::Session;
+
+    let wheel = |kind| MouseEvent {
+        kind,
+        column: 10,
+        row: 10,
+        modifiers: KeyModifiers::empty(),
+    };
+    app.handle_mouse(wheel(MouseEventKind::ScrollUp)).unwrap();
+
+    let notice = app
+        .active_session()
+        .unwrap()
+        .copy_notice
+        .as_ref()
+        .map(|(m, _)| m.clone())
+        .expect("the hint fires on the notch");
+    assert!(
+        notice.contains("set -g mouse on"),
+        "the hint carries the command to run: {notice}"
+    );
+
+    // Said once: a second notch must not put it back after it was dismissed.
+    app.active_session_mut().unwrap().copy_notice = None;
+    app.handle_mouse(wheel(MouseEventKind::ScrollDown)).unwrap();
+    assert!(
+        app.active_session().unwrap().copy_notice.is_none(),
+        "one hint per session, not one per notch"
+    );
+
+    // And on the primary screen it never fires — the wheel scrolls for real.
+    let cfg = crate::session::SessionConfig {
+        argv: vec!["true".into()],
+        display_name: "plain".into(),
+        meta: crate::session::SessionMeta::default(),
+        pending_secret: None,
+        key_push_identity: None,
+        host_name: "plain".into(),
+    };
+    app.sessions
+        .push(crate::session::Session::spawn(cfg, 24, 80, None).unwrap());
+    app.active_session = Some(1);
+    app.handle_mouse(wheel(MouseEventKind::ScrollUp)).unwrap();
+    assert!(app.active_session().unwrap().copy_notice.is_none());
+}

--- a/src/app/tests/session.rs
+++ b/src/app/tests/session.rs
@@ -992,3 +992,60 @@ pub(crate) fn the_config_opt_out_drops_every_relay() {
         "an opted-out relay must stay silent"
     );
 }
+
+/// Reported from a live tmux: the wheel moved the *selection* and left the text
+/// where it was. tmux draws on the alternate screen, which keeps no scrollback,
+/// so the view could not move — but the selection was shifted by the full
+/// requested amount regardless, sliding the highlight over static rows.
+#[test]
+pub(crate) fn a_wheel_that_cannot_scroll_leaves_the_selection_where_it_is() {
+    let cfg = crate::session::SessionConfig {
+        argv: vec!["true".into()],
+        display_name: "edge".into(),
+        meta: crate::session::SessionMeta::default(),
+        pending_secret: None,
+        key_push_identity: None,
+        host_name: "edge".into(),
+    };
+    let mut session = crate::session::Session::spawn(cfg, 24, 80, None).unwrap();
+    // Alternate screen, as tmux / vim leave it.
+    session.parser.process(b"\x1b[?1049h");
+    assert!(session.parser.screen().alternate_screen());
+    session.selection_start(5, 0);
+    session.selection_extend(8, 10);
+    let before = session.selection.expect("a selection");
+
+    session.scroll_with_selection(3);
+
+    let after = session.selection.expect("still a selection");
+    assert_eq!(session.parser.scrollback(), 0, "nothing to scroll there");
+    assert_eq!(
+        (after.anchor, after.cursor),
+        (before.anchor, before.cursor),
+        "the highlight must stay on the text it was on"
+    );
+
+    // On the primary screen, with scrollback to walk, it does follow the view.
+    let cfg = crate::session::SessionConfig {
+        argv: vec!["true".into()],
+        display_name: "edge".into(),
+        meta: crate::session::SessionMeta::default(),
+        pending_secret: None,
+        key_push_identity: None,
+        host_name: "edge".into(),
+    };
+    let mut session = crate::session::Session::spawn(cfg, 24, 80, None).unwrap();
+    for i in 0..60 {
+        session.parser.process(format!("line {i}\r\n").as_bytes());
+    }
+    session.selection_start(5, 0);
+    session.selection_extend(8, 10);
+    let anchor_before = session.selection.as_ref().unwrap().anchor.0;
+    session.scroll_with_selection(3);
+    assert_eq!(session.parser.scrollback(), 3);
+    assert_eq!(
+        session.selection.as_ref().unwrap().anchor.0,
+        anchor_before + 3,
+        "when the view moves, the highlight moves with it"
+    );
+}

--- a/src/app/tunnels.rs
+++ b/src/app/tunnels.rs
@@ -624,24 +624,28 @@ impl App {
     /// Re-read the tunnel list from the store, throttled to once every two
     /// seconds.
     ///
-    /// The list is a snapshot, and the store is shared: a second sshub window
-    /// or a `sshub tunnel` command can add, edit or delete a row under us. Until
+    /// The list is a snapshot, and the store is shared: a second sshub window or
+    /// a `sshub tunnel` command can add, edit or delete a row under us. Until
     /// this ran, a tunnel deleted in another window stayed in this window's
-    /// session top bar and tunnels tab for as long as the window lived. A child
-    /// we still own for a row that no longer exists is stopped — otherwise it
-    /// keeps its local port bound with nothing left to describe it.
+    /// session top bar and tunnels tab for as long as the window lived.
+    ///
+    /// The selection is re-anchored by id, the way [`Self::reload_identities`]
+    /// does: it is a raw index, and another window deleting a row above it used
+    /// to slide it onto a different tunnel — with the reload now running on a
+    /// timer, the next `d` would have hit whatever moved under the cursor.
+    ///
+    /// Our own children are left alone. An edit elsewhere is a delete plus an
+    /// insert (there is no `UPDATE` for tunnels), so "this id is gone" does not
+    /// mean "this tunnel is gone", and killing the child on that signal would
+    /// take down a tunnel someone merely relabelled in another window.
     pub(crate) fn sync_tunnels_from_store(&mut self) -> Result<()> {
         self.tunnels_synced = std::time::Instant::now();
-        let before: Vec<i64> = self.tunnels.iter().map(|t| t.id).collect();
+        let selected_id = self.tunnels.get(self.tunnel_selected).map(|t| t.id);
         self.reload_tunnels()?;
-        for id in before {
-            if !self.tunnels.iter().any(|t| t.id == id) && self.tunnel_manager.has_child(id) {
-                let _ = self.tunnel_manager.stop_user(id);
-            }
-        }
-        if self.tunnel_selected >= self.tunnels.len() {
-            self.tunnel_selected = self.tunnels.len().saturating_sub(1);
-        }
+        self.tunnel_selected = selected_id
+            .and_then(|id| self.tunnels.iter().position(|t| t.id == id))
+            .unwrap_or(self.tunnel_selected)
+            .min(self.tunnels.len().saturating_sub(1));
         Ok(())
     }
 

--- a/src/app/tunnels.rs
+++ b/src/app/tunnels.rs
@@ -621,6 +621,30 @@ impl App {
         Ok(())
     }
 
+    /// Re-read the tunnel list from the store, throttled to once every two
+    /// seconds.
+    ///
+    /// The list is a snapshot, and the store is shared: a second sshub window
+    /// or a `sshub tunnel` command can add, edit or delete a row under us. Until
+    /// this ran, a tunnel deleted in another window stayed in this window's
+    /// session top bar and tunnels tab for as long as the window lived. A child
+    /// we still own for a row that no longer exists is stopped — otherwise it
+    /// keeps its local port bound with nothing left to describe it.
+    pub(crate) fn sync_tunnels_from_store(&mut self) -> Result<()> {
+        self.tunnels_synced = std::time::Instant::now();
+        let before: Vec<i64> = self.tunnels.iter().map(|t| t.id).collect();
+        self.reload_tunnels()?;
+        for id in before {
+            if !self.tunnels.iter().any(|t| t.id == id) && self.tunnel_manager.has_child(id) {
+                let _ = self.tunnel_manager.stop_user(id);
+            }
+        }
+        if self.tunnel_selected >= self.tunnels.len() {
+            self.tunnel_selected = self.tunnels.len().saturating_sub(1);
+        }
+        Ok(())
+    }
+
     pub(crate) fn tick_tunnels(&mut self) -> Result<()> {
         if !self.tunnels_auto_started {
             self.bootstrap_auto_connect_tunnels()?;
@@ -628,6 +652,9 @@ impl App {
         }
         if self.tunnel_manager.needs_tunnel_list() && self.tunnels.is_empty() {
             self.reload_tunnels()?;
+        }
+        if self.tunnels_synced.elapsed() >= std::time::Duration::from_secs(2) {
+            self.sync_tunnels_from_store()?;
         }
         let health_events = self
             .tunnel_manager

--- a/src/app/tunnels.rs
+++ b/src/app/tunnels.rs
@@ -213,6 +213,41 @@ impl App {
         Ok(())
     }
 
+    /// Ctrl+U on the tunnel form: kill the active text field back to its start.
+    pub(crate) fn tunnel_form_kill_to_start(&mut self) {
+        let Some(form) = self.tunnel_form.as_mut() else {
+            return;
+        };
+        if form.cursor > 0 {
+            let cursor = form.cursor;
+            let nc = form
+                .active_text_field_mut()
+                .map(|v| text_input::clear_before_cursor(v, cursor))
+                .unwrap_or(cursor);
+            form.cursor = nc;
+            form.dirty = true;
+        }
+    }
+
+    /// Ctrl+W on the tunnel form: delete the word before the cursor.
+    pub(crate) fn tunnel_form_kill_word(&mut self) {
+        let Some(form) = self.tunnel_form.as_mut() else {
+            return;
+        };
+        let len_before = form.active_text_field().map(text_input::char_len);
+        let cursor = form.cursor;
+        let nc = form
+            .active_text_field_mut()
+            .map(|v| text_input::delete_word_before(v, cursor))
+            .unwrap_or(cursor);
+        form.cursor = nc;
+        if len_before.is_some_and(|before| {
+            form.active_text_field().map(text_input::char_len) != Some(before)
+        }) {
+            form.dirty = true;
+        }
+    }
+
     pub(crate) fn handle_key_tunnel_form(&mut self, key: KeyEvent) -> Result<()> {
         let Some(form) = self.tunnel_form.as_ref() else {
             return Ok(());
@@ -312,6 +347,14 @@ impl App {
                         form.dirty = true;
                     }
                 }
+            }
+            // Readline-style bulk edits: Ctrl+U clears the field (a wrong port
+            // need not be backspaced digit by digit), Ctrl+W eats one word.
+            KeyCode::Char('u') if key.modifiers == KeyModifiers::CONTROL => {
+                self.tunnel_form_kill_to_start()
+            }
+            KeyCode::Char('w') if key.modifiers == KeyModifiers::CONTROL => {
+                self.tunnel_form_kill_word()
             }
             KeyCode::Char(c)
                 if (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT)

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1497,23 +1497,30 @@ impl HostFormEdit {
         }
     }
 
-    pub(crate) fn active_field_mut(&mut self) -> &mut String {
+    /// The active field's buffer, or `None` on a field that holds no text — a
+    /// picker, a toggle or the tri-state. It used to hand out `&mut address` for
+    /// those, so every edit key aimed at them silently rewrote the address
+    /// instead: `End` then `Ctrl+U` on *Session log* emptied it in two
+    /// keystrokes. `Option` makes the compiler ask each caller what a non-text
+    /// field means, the way [`TunnelFormEdit::active_text_field_mut`] already
+    /// does.
+    pub(crate) fn active_field_mut(&mut self) -> Option<&mut String> {
         match self.field {
-            HostFormField::Address => &mut self.address,
-            HostFormField::Username => &mut self.username,
-            HostFormField::Label => &mut self.label,
-            HostFormField::Name => &mut self.name,
-            HostFormField::Port => &mut self.port,
-            HostFormField::Group | HostFormField::Identity | HostFormField::OsIcon => {
-                &mut self.address
-            }
-            HostFormField::Tags => &mut self.tags,
-            HostFormField::ProxyJump => &mut self.proxy_jump,
-            HostFormField::RemoteCommand => &mut self.remote_command,
-            HostFormField::ForwardAgent
+            HostFormField::Address => Some(&mut self.address),
+            HostFormField::Username => Some(&mut self.username),
+            HostFormField::Label => Some(&mut self.label),
+            HostFormField::Name => Some(&mut self.name),
+            HostFormField::Port => Some(&mut self.port),
+            HostFormField::Tags => Some(&mut self.tags),
+            HostFormField::ProxyJump => Some(&mut self.proxy_jump),
+            HostFormField::RemoteCommand => Some(&mut self.remote_command),
+            HostFormField::Password => Some(&mut self.password),
+            HostFormField::Group
+            | HostFormField::Identity
+            | HostFormField::OsIcon
+            | HostFormField::ForwardAgent
             | HostFormField::Transport
-            | HostFormField::SessionLogging => &mut self.address,
-            HostFormField::Password => &mut self.password,
+            | HostFormField::SessionLogging => None,
         }
     }
 }

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -456,6 +456,23 @@ mod tests {
         assert_eq!(cmd.as_deref(), Some("tail -n 5 log"));
     }
 
+    /// The docs now promise that quoting sends a shell operator to the far side
+    /// (`-- 'ls && uptime'`), so the operator has to survive as one argv word —
+    /// unquoted, the local shell splits the line before we are even started.
+    #[test]
+    fn a_quoted_shell_operator_reaches_ssh_as_one_word() {
+        let (head, cmd) = split_at_dashes(&s(&["web", "--", "ls && uptime"]));
+        assert_eq!(head, s(&["web"]));
+        assert_eq!(cmd.as_deref(), Some("ls && uptime"));
+
+        let argv = exec_argv(s(&["ssh", "web"]), None, "ls && uptime", false, false);
+        assert_eq!(
+            &argv[argv.len() - 2..],
+            &s(&["--", "ls && uptime"])[..],
+            "the operator must stay in one word: {argv:?}"
+        );
+    }
+
     #[test]
     fn split_at_dashes_without_a_separator_leaves_the_command_to_the_positionals() {
         let (head, cmd) = split_at_dashes(&s(&["web", "uptime"]));

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -78,6 +78,12 @@ OPTIONS:
                           stdout, stderr, duration_ms}}; plain (default) streams
     -v, --verbose         Verbose ssh logging on stderr
 
+Shell operators belong to whichever shell reads them: `sshub exec web -- ls &&
+uptime` runs `ls` on the host and `uptime` at home, exactly as `ssh` does. Quote
+the whole thing to send it all remotely: `sshub exec web -- 'ls && uptime'`. A
+full-screen command (vim, top, less) needs `--tty`; without it there is no
+terminal on the far side and it will complain or misdraw.
+
 stdout/stderr pass through, stdin is inherited so pipes work, and the exit code
 is the remote command's (ssh's own failures keep ssh's 255). Never prompts: with
 no stored credential exec runs ssh in BatchMode, so an unknown host key fails

--- a/src/osc52.rs
+++ b/src/osc52.rs
@@ -45,15 +45,14 @@ pub(crate) fn write_text(text: &str) -> std::io::Result<()> {
 pub(crate) fn base64_encode(input: &[u8]) -> String {
     const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
-    let mut chunks = input.chunks_exact(3);
-    for chunk in chunks.by_ref() {
+    let (chunks, rem) = input.as_chunks::<3>();
+    for chunk in chunks {
         let b = ((chunk[0] as u32) << 16) | ((chunk[1] as u32) << 8) | (chunk[2] as u32);
         out.push(ALPHABET[((b >> 18) & 0x3f) as usize] as char);
         out.push(ALPHABET[((b >> 12) & 0x3f) as usize] as char);
         out.push(ALPHABET[((b >> 6) & 0x3f) as usize] as char);
         out.push(ALPHABET[(b & 0x3f) as usize] as char);
     }
-    let rem = chunks.remainder();
     match rem.len() {
         1 => {
             let b = (rem[0] as u32) << 16;

--- a/src/session/keys.rs
+++ b/src/session/keys.rs
@@ -97,6 +97,41 @@ fn arrow_seq(final_byte: char, mods: KeyModifiers, application_cursor: bool) -> 
 
 // ── Mouse encoding ────────────────────────────────────────────
 
+/// Whether a mouse event should drive a *local* selection / scroll instead of
+/// being forwarded to the remote.
+///
+/// The remote's mouse mode is not enough on its own: an app killed before it
+/// could send `?1002l` leaves reporting on, and every later drag at the shell
+/// prompt was encoded and echoed back by the shell as `0;47;13M` gibberish. An
+/// app that genuinely wants the mouse is also on the alternate screen (vim,
+/// htop, tmux, less all draw there), so the two together decide it, and Shift
+/// always forces a local selection.
+///
+/// Ceiling: an app that asks for the mouse while staying on the primary screen
+/// (`fzf --height`) gets local selection instead — the same trade xterm makes
+/// for its alternateScroll heuristic.
+pub fn selects_locally(mode: MouseProtocolMode, alternate_screen: bool, shift: bool) -> bool {
+    let remote_wants_mouse = mode != MouseProtocolMode::None && alternate_screen;
+    !remote_wants_mouse || shift
+}
+
+/// xterm's `alternateScroll`: the alternate grid keeps no scrollback of its own,
+/// so a wheel notch there becomes three arrow keys for the app that owns the
+/// screen. Without it the wheel scrolled nothing at all in `less`, `man` or a
+/// remote pager. `None` for anything that isn't a wheel event.
+pub fn alternate_scroll_keys(kind: MouseEventKind, application_cursor: bool) -> Option<Vec<u8>> {
+    let code = match kind {
+        MouseEventKind::ScrollUp => KeyCode::Up,
+        MouseEventKind::ScrollDown => KeyCode::Down,
+        _ => return None,
+    };
+    let one = encode(
+        KeyEvent::new(code, KeyModifiers::empty()),
+        application_cursor,
+    )?;
+    Some(one.repeat(3))
+}
+
 /// Encode a mouse event into the byte sequence expected by the remote app,
 /// or `None` if either the remote hasn't enabled mouse reporting or the
 /// event isn't relevant under the active protocol mode.
@@ -367,6 +402,42 @@ mod tests {
             encode_normal(k(KeyCode::Char('é'))).unwrap(),
             "é".as_bytes().to_vec()
         );
+    }
+
+    // ── Mouse routing tests ──────────────────────────────────
+
+    #[test]
+    fn a_shell_prompt_selects_locally_even_with_mouse_reporting_left_on() {
+        // The leak an app killed mid-run leaves behind: mode is still on, but
+        // the prompt is on the primary screen, so a drag must select text
+        // rather than spray SGR reports at the shell.
+        assert!(selects_locally(
+            MouseProtocolMode::ButtonMotion,
+            false,
+            false
+        ));
+        assert!(selects_locally(MouseProtocolMode::None, false, false));
+        assert!(selects_locally(MouseProtocolMode::None, true, false));
+    }
+
+    #[test]
+    fn a_full_screen_app_that_asked_for_the_mouse_gets_it() {
+        assert!(!selects_locally(
+            MouseProtocolMode::ButtonMotion,
+            true,
+            false
+        ));
+        // Shift is the escape hatch back to a local selection.
+        assert!(selects_locally(MouseProtocolMode::ButtonMotion, true, true));
+    }
+
+    #[test]
+    fn alternate_scroll_sends_three_arrows_per_notch() {
+        let up = alternate_scroll_keys(MouseEventKind::ScrollUp, false).unwrap();
+        assert_eq!(up, b"\x1b[A\x1b[A\x1b[A".to_vec());
+        let down = alternate_scroll_keys(MouseEventKind::ScrollDown, true).unwrap();
+        assert_eq!(down, b"\x1bOB\x1bOB\x1bOB".to_vec());
+        assert!(alternate_scroll_keys(MouseEventKind::Moved, false).is_none());
     }
 
     // ── Mouse encoding tests ─────────────────────────────────

--- a/src/session/keys.rs
+++ b/src/session/keys.rs
@@ -103,16 +103,19 @@ fn arrow_seq(final_byte: char, mods: KeyModifiers, application_cursor: bool) -> 
 /// The remote's mouse mode is not enough on its own: an app killed before it
 /// could send `?1002l` leaves reporting on, and every later drag at the shell
 /// prompt was encoded and echoed back by the shell as `0;47;13M` gibberish. An
-/// app that genuinely wants the mouse is also on the alternate screen (vim,
-/// htop, tmux, less all draw there), so the two together decide it, and Shift
-/// always forces a local selection.
+/// app that genuinely wants the mouse is normally also on the alternate screen
+/// (vim, htop, tmux, less all draw there), so the two together decide it.
 ///
-/// Ceiling: an app that asks for the mouse while staying on the primary screen
-/// (`fzf --height`) gets local selection instead — the same trade xterm makes
-/// for its alternateScroll heuristic.
+/// Shift **inverts** whatever that decision was, which is the escape hatch in
+/// both directions: it takes a local selection over a full-screen app, and it
+/// forwards the mouse to an app that asked for it without taking the alternate
+/// screen (an inline picker drawn in place). With no mouse mode at all there is
+/// nothing to forward, so Shift changes nothing there.
 pub fn selects_locally(mode: MouseProtocolMode, alternate_screen: bool, shift: bool) -> bool {
-    let remote_wants_mouse = mode != MouseProtocolMode::None && alternate_screen;
-    !remote_wants_mouse || shift
+    if mode == MouseProtocolMode::None {
+        return true;
+    }
+    alternate_screen == shift
 }
 
 /// xterm's `alternateScroll`: the alternate grid keeps no scrollback of its own,
@@ -429,6 +432,21 @@ mod tests {
         ));
         // Shift is the escape hatch back to a local selection.
         assert!(selects_locally(MouseProtocolMode::ButtonMotion, true, true));
+    }
+
+    #[test]
+    fn shift_forwards_to_an_inline_app_that_kept_the_primary_screen() {
+        // The other direction of the same escape hatch: a picker drawn in place
+        // that asked for the mouse is indistinguishable from a leaked mode, so
+        // Shift is what lets the user hand it the mouse anyway.
+        assert!(!selects_locally(
+            MouseProtocolMode::ButtonMotion,
+            false,
+            true
+        ));
+        // With no mouse mode there is nothing to forward, Shift or not.
+        assert!(selects_locally(MouseProtocolMode::None, false, true));
+        assert!(selects_locally(MouseProtocolMode::None, true, true));
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -191,6 +191,9 @@ pub struct Session {
     /// Transient "copied" toast: (message, shown_at). Rendered in a corner for
     /// a few seconds after a copy-on-select.
     pub copy_notice: Option<(String, Instant)>,
+    /// Whether this session has already been told what the wheel does on the
+    /// alternate screen. Said once, not on every notch.
+    alt_scroll_hinted: bool,
     /// While a selection drag is held past the top/bottom edge, the view keeps
     /// scrolling on each poll tick so you can select content beyond the
     /// viewport. `(dir, col)`: dir `+1` scrolls toward newer output (bottom
@@ -281,6 +284,7 @@ impl Session {
             saw_pty_bytes: false,
             selection: None,
             copy_notice: None,
+            alt_scroll_hinted: false,
             drag_autoscroll: None,
             key_push_identity: config.key_push_identity.clone(),
             logged_exit: false,
@@ -473,6 +477,25 @@ impl Session {
         if moved != 0 {
             self.selection_scroll_shift(moved);
         }
+    }
+
+    /// Say once per session what a wheel notch on the alternate screen does,
+    /// and name the tmux switch that makes the wheel scroll tmux's own history.
+    ///
+    /// It fires on the notch rather than on "we think tmux is running": from the
+    /// PTY we see a byte stream, not processes, and tmux's status line — the
+    /// only thing that would give it away — is the first thing people re-style.
+    /// The moment of confusion is the honest trigger, and the advice holds for
+    /// whatever owns the alternate screen.
+    pub fn hint_alternate_scroll(&mut self) {
+        if self.alt_scroll_hinted {
+            return;
+        }
+        self.alt_scroll_hinted = true;
+        self.set_copy_notice(
+            "wheel \u{2192} \u{2191} keys here \u{2014} tmux scrolls with: set -g mouse on"
+                .to_string(),
+        );
     }
 
     /// Record a transient "copied" toast.

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -454,6 +454,27 @@ impl Session {
         }
     }
 
+    /// Scroll the view by `rows` (positive = toward older output) and carry a
+    /// live selection along by however far the view *actually* moved.
+    ///
+    /// It can move less than asked, or not at all: the top of the buffer clamps,
+    /// and the alternate screen keeps no scrollback whatsoever (vt100 gives that
+    /// grid zero rows). Shifting the selection by the requested amount anyway
+    /// slid the highlight across text that stayed exactly where it was — inside
+    /// `tmux` the wheel appeared to move the selection instead of the screen.
+    pub fn scroll_with_selection(&mut self, rows: i32) {
+        let before = self.parser.scrollback() as i32;
+        if rows >= 0 {
+            self.parser.scroll_up(rows as usize);
+        } else {
+            self.parser.scroll_down(rows.unsigned_abs() as usize);
+        }
+        let moved = self.parser.scrollback() as i32 - before;
+        if moved != 0 {
+            self.selection_scroll_shift(moved);
+        }
+    }
+
     /// Record a transient "copied" toast.
     pub fn set_copy_notice(&mut self, msg: String) {
         self.copy_notice = Some((msg, Instant::now()));

--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -49,6 +49,37 @@ pub fn delete_at(value: &mut String, cursor: usize) -> usize {
     cursor
 }
 
+/// Kill everything before `cursor` (readline's `unix-line-discard`, Ctrl+U).
+/// With the cursor parked at the end of a field this wipes the whole value in
+/// one chord instead of one backspace per character. Returns the new cursor.
+pub fn clear_before_cursor(value: &mut String, cursor: usize) -> usize {
+    let clamped = cursor.min(char_len(value));
+    let idx = byte_index(value, clamped);
+    value.replace_range(..idx, "");
+    0
+}
+
+/// Delete the word before `cursor` (readline's Ctrl+W). A word is a run of
+/// non-space characters; surrounding spaces go with it, so repeated chords
+/// keep eating back through a value. Returns the new cursor.
+pub fn delete_word_before(value: &mut String, cursor: usize) -> usize {
+    let len = char_len(value);
+    let mut pos = cursor.min(len);
+    while pos > 0 && value[..byte_index(value, pos)].ends_with(' ') {
+        pos -= 1;
+    }
+    while pos > 0 {
+        let prev = byte_index(value, pos - 1);
+        if value.as_bytes()[prev] == b' ' {
+            break;
+        }
+        pos -= 1;
+    }
+    let idx = byte_index(value, pos);
+    value.replace_range(idx..byte_index(value, cursor.min(len)), "");
+    pos
+}
+
 /// Handle a cursor-movement / forward-delete key on a `(value, cursor)` pair —
 /// the shared body of every form's Left/Right/Home/End/Delete handling.
 /// Returns `None` when the key isn't one of those; `Some(changed)` otherwise,
@@ -173,5 +204,63 @@ mod tests {
         let c = delete_at(&mut v, len);
         assert_eq!(v, "риет");
         assert_eq!(c, len);
+    }
+
+    #[test]
+    fn clear_before_cursor_wipes_the_whole_field_from_the_end() {
+        let mut v = "s3cret-pw".to_string();
+        let len = char_len(&v);
+        let c = clear_before_cursor(&mut v, len);
+        assert_eq!(v, "");
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn clear_before_cursor_keeps_the_tail() {
+        let mut v = "user@host".to_string();
+        let c = clear_before_cursor(&mut v, 4); // kill "user"
+        assert_eq!(v, "@host");
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn clear_before_cursor_is_multibyte_safe_and_clamps() {
+        let mut v = "привет".to_string();
+        // Cursor past the end clamps instead of panicking on a byte boundary.
+        let c = clear_before_cursor(&mut v, 99);
+        assert_eq!(v, "");
+        assert_eq!(c, 0);
+
+        let mut v = "🙂🙂".to_string();
+        let _ = clear_before_cursor(&mut v, 1); // kill one emoji
+        assert_eq!(v, "🙂");
+    }
+
+    #[test]
+    fn delete_word_before_eats_one_word_plus_trailing_space() {
+        let mut v = "docker compose up".to_string();
+        let end = char_len(&v);
+        let c = delete_word_before(&mut v, end);
+        assert_eq!(v, "docker compose ");
+        assert_eq!(c, char_len("docker compose "));
+
+        // Second chord eats the previous word too.
+        assert_eq!(delete_word_before(&mut v, c), char_len("docker "));
+        assert_eq!(v, "docker ");
+    }
+
+    #[test]
+    fn delete_word_before_stops_at_start_and_handles_empty_gap() {
+        let mut v = String::from("word");
+        let end = char_len(&v);
+        let c = delete_word_before(&mut v, end);
+        assert_eq!(v, "");
+        assert_eq!(c, 0);
+
+        // Nothing to delete: no-op, cursor unchanged.
+        let mut v = String::new();
+        let c = delete_word_before(&mut v, 0);
+        assert_eq!(v, "");
+        assert_eq!(c, 0);
     }
 }

--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -59,9 +59,10 @@ pub fn clear_before_cursor(value: &mut String, cursor: usize) -> usize {
     0
 }
 
-/// Delete the word before `cursor` (readline's Ctrl+W). A word is a run of
-/// non-space characters; surrounding spaces go with it, so repeated chords
-/// keep eating back through a value. Returns the new cursor.
+/// Delete the word before `cursor` (readline's `backward-kill-word`, Ctrl+W). A
+/// word is a run of non-space characters; the spaces *after* it go with it, the
+/// one in front stays, so repeated chords keep eating back through a value one
+/// word at a time. Returns the new cursor.
 pub fn delete_word_before(value: &mut String, cursor: usize) -> usize {
     let len = char_len(value);
     let mut pos = cursor.min(len);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1712,6 +1712,7 @@ fn render_audit_body(frame: &mut Frame, areas: &dashboard_layout::DashboardAreas
     screens::audit::render_audit(frame, areas.body, app);
 }
 
+#[derive(Clone, Copy)]
 enum FormKind {
     Host,
     Identity,
@@ -1719,10 +1720,29 @@ enum FormKind {
     Group,
 }
 
+/// Rows each form needs to show everything it draws, hint lines included.
+const fn form_rows_needed(kind: FormKind) -> u16 {
+    match kind {
+        // 16 fields + a blank + 2 hint rows + 2 borders, plus the extra hint row
+        // the password field adds.
+        FormKind::Host => 23,
+        FormKind::Identity => 14,
+        FormKind::Keygen => 14,
+        FormKind::Group => 12,
+    }
+}
+
 fn render_form_popup(frame: &mut Frame, app: &App, kind: FormKind) {
     let area = frame.area();
     let popup_width = (area.width * 70 / 100).max(50).min(area.width);
-    let popup_height = (area.height * 70 / 100).max(18).min(area.height);
+    // Rows the form itself draws (fields + hint lines + both borders). 70% of a
+    // 24-row terminal is 16, and the host form needs 22 — the overflow fell off
+    // the bottom, taking the save/cancel and reveal hints with it, which is how
+    // a masked password ended up looking unrevealable. `form_rows_needed` is
+    // guarded by a render test at 80x24 so a new field cannot re-clip them.
+    let popup_height = (area.height * 70 / 100)
+        .max(form_rows_needed(kind))
+        .min(area.height);
     let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -413,15 +413,23 @@ pub const HELP_ITEMS: &[HelpItem] = &[
     },
     HelpItem::Entry {
         key: "PgUp/PgDn",
-        desc: "Scroll session history (goes to the remote app on its alternate screen: tmux, vim, less)",
+        desc: "Scroll session history; goes to the remote app while it holds the alternate screen (tmux, vim, less)",
+    },
+    HelpItem::Entry {
+        key: "wheel",
+        desc: "Scroll history; on the alternate screen it becomes arrow keys for the remote app (tmux needs `set -g mouse on` to scroll its own)",
     },
     HelpItem::Entry {
         key: "drag",
-        desc: "Select and copy terminal text; Shift+drag when the remote app owns the mouse",
+        desc: "Select terminal text, copied on release; Shift inverts it when the remote app owns the mouse (some terminals keep Shift for their own selection and paste)",
     },
     HelpItem::Entry {
-        key: "Shift+mouse",
-        desc: "Your terminal's own selection and middle-click paste — sshub holds the mouse otherwise",
+        key: "[forms]",
+        desc: "",
+    },
+    HelpItem::Entry {
+        key: "Ctrl+U / Ctrl+W",
+        desc: "Host / identity / tunnel form: kill everything before the cursor / the word before it",
     },
     HelpItem::Entry {
         key: "",

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -413,7 +413,15 @@ pub const HELP_ITEMS: &[HelpItem] = &[
     },
     HelpItem::Entry {
         key: "PgUp/PgDn",
-        desc: "Scroll session history",
+        desc: "Scroll session history (goes to the remote app on its alternate screen: tmux, vim, less)",
+    },
+    HelpItem::Entry {
+        key: "drag",
+        desc: "Select and copy terminal text; Shift+drag when the remote app owns the mouse",
+    },
+    HelpItem::Entry {
+        key: "Shift+mouse",
+        desc: "Your terminal's own selection and middle-click paste — sshub holds the mouse otherwise",
     },
     HelpItem::Entry {
         key: "",

--- a/src/tui/screens/host_form.rs
+++ b/src/tui/screens/host_form.rs
@@ -189,7 +189,7 @@ pub fn render_host_form(
         lines.push(Line::from(Span::styled(secret_hints.to_string(), help)));
     }
     lines.push(Line::from(Span::styled(
-        "Tab/↓: next field    Enter: open picker (Group/Identity)",
+        "Tab/↓: next field    Enter: open picker (Group/Identity)    Ctrl+U: clear field",
         help,
     )));
     lines.push(Line::from(Span::styled(

--- a/src/tui/screens/host_form.rs
+++ b/src/tui/screens/host_form.rs
@@ -139,14 +139,22 @@ pub fn render_host_form(
                 "Password",
                 // Masked while typing too, now that the field arrives prefilled
                 // with the stored secret: walking onto it must not expose one.
-                // The reveal bind is the way to see it.
+                // The reveal bind is the way to see it — and it says so on the
+                // row itself, because the footer that used to be its only
+                // mention is the first thing a short terminal clips, which left
+                // a wall of dots and no way to know a reveal exists at all.
                 if editing && form.password_revealed {
                     text_input::with_cursor(&form.password, form.cursor)
                 } else if editing {
-                    text_input::with_cursor(
+                    let masked = text_input::with_cursor(
                         &"\u{25CF}".repeat(form.password.chars().count()),
                         form.cursor,
-                    )
+                    );
+                    if secret_hints.is_empty() {
+                        masked
+                    } else {
+                        format!("{masked}    {}", reveal_hint(secret_hints))
+                    }
                 } else {
                     password_display(&form.password, form.has_password, form.password_revealed)
                 },
@@ -256,4 +264,14 @@ fn identity_label(index: usize, identities: &[Identity]) -> String {
         .get(index)
         .map(|i| i.name.clone())
         .unwrap_or_else(|| "(none)".to_string())
+}
+
+/// The reveal half of the secret hints — the part that fits on the row next to a
+/// masked value. The full pair (show + copy) stays in the footer.
+fn reveal_hint(secret_hints: &str) -> &str {
+    secret_hints
+        .split('\u{2502}')
+        .next()
+        .unwrap_or_default()
+        .trim()
 }

--- a/src/tui/screens/host_form.rs
+++ b/src/tui/screens/host_form.rs
@@ -189,7 +189,7 @@ pub fn render_host_form(
         lines.push(Line::from(Span::styled(secret_hints.to_string(), help)));
     }
     lines.push(Line::from(Span::styled(
-        "Tab/↓: next field    Enter: open picker (Group/Identity)    Ctrl+U: clear field",
+        "Tab/↓: next field    Enter: open picker (Group/Identity)    Ctrl+U/W: kill line/word",
         help,
     )));
     lines.push(Line::from(Span::styled(

--- a/src/tui/screens/keychain.rs
+++ b/src/tui/screens/keychain.rs
@@ -43,10 +43,19 @@ pub fn render_identity_form(
                 if editing && form.password_revealed {
                     text_input::with_cursor(&form.password, form.cursor)
                 } else if editing {
-                    text_input::with_cursor(
+                    // The reveal bind rides the row, not just the footer: on a
+                    // short terminal the footer is what gets clipped, and a
+                    // masked value with no visible way to unmask it reads as
+                    // "this secret cannot be seen at all".
+                    let masked = text_input::with_cursor(
                         &"\u{25CF}".repeat(form.password.chars().count()),
                         form.cursor,
-                    )
+                    );
+                    if secret_hints.is_empty() {
+                        masked
+                    } else {
+                        format!("{masked}    {}", reveal_hint(secret_hints))
+                    }
                 } else if form.password_revealed {
                     form.password.clone()
                 } else if !form.password.is_empty() {
@@ -127,4 +136,14 @@ pub fn render_identity_form(
                 theme.style(StyleRole::PopupTitle),
             )),
     )
+}
+
+/// The reveal half of the secret hints — the part that fits on the row next to a
+/// masked value. The full pair (show + copy) stays in the footer.
+fn reveal_hint(secret_hints: &str) -> &str {
+    secret_hints
+        .split('\u{2502}')
+        .next()
+        .unwrap_or_default()
+        .trim()
 }

--- a/src/tui/screens/keychain.rs
+++ b/src/tui/screens/keychain.rs
@@ -104,7 +104,9 @@ pub fn render_identity_form(
         ]));
     }
     lines.push(ratatui::text::Line::from(""));
-    let base = format!("type to edit │ paste a key or its path into Private key │ Tab/↓: next │ Ctrl+U: clear field │ {save_hint}: save │ Esc: cancel");
+    // Save/cancel stay at the end: the middle of this row is what truncation
+    // eats first on a narrow terminal (see the 0.9.x footer fix).
+    let base = format!("type to edit │ paste a key or its path into Private key │ Tab/↓: next │ {save_hint}: save │ Esc: cancel │ Ctrl+U/W: kill line/word");
     // On the passphrase field the secret binds come first: the value is masked,
     // so that is the moment the user needs to know how to see or copy it.
     let hint = if form.field == IdentityFormField::Password && !secret_hints.is_empty() {

--- a/src/tui/screens/keychain.rs
+++ b/src/tui/screens/keychain.rs
@@ -104,7 +104,7 @@ pub fn render_identity_form(
         ]));
     }
     lines.push(ratatui::text::Line::from(""));
-    let base = format!("type to edit │ paste a key or its path into Private key │ Tab/↓: next │ {save_hint}: save │ Esc: cancel");
+    let base = format!("type to edit │ paste a key or its path into Private key │ Tab/↓: next │ Ctrl+U: clear field │ {save_hint}: save │ Esc: cancel");
     // On the passphrase field the secret binds come first: the value is masked,
     // so that is the moment the user needs to know how to see or copy it.
     let hint = if form.field == IdentityFormField::Password && !secret_hints.is_empty() {

--- a/src/tui/screens/tunnels.rs
+++ b/src/tui/screens/tunnels.rs
@@ -536,7 +536,7 @@ pub fn render_tunnel_form(frame: &mut Frame, app: &App) {
             inner.x + 1,
             footer_top,
             crate::tui::text::ellipsize(
-                "type to edit  Tab/\u{2193}: next field  Ctrl+U: clear",
+                "type to edit  Tab/\u{2193}: next field  Ctrl+U/W: kill line/word",
                 avail,
             ),
             theme.style(StyleRole::TunnelFormHelp),

--- a/src/tui/screens/tunnels.rs
+++ b/src/tui/screens/tunnels.rs
@@ -535,7 +535,10 @@ pub fn render_tunnel_form(frame: &mut Frame, app: &App) {
         buf.set_string(
             inner.x + 1,
             footer_top,
-            crate::tui::text::ellipsize("type to edit  Tab/\u{2193}: next field", avail),
+            crate::tui::text::ellipsize(
+                "type to edit  Tab/\u{2193}: next field  Ctrl+U: clear",
+                avail,
+            ),
             theme.style(StyleRole::TunnelFormHelp),
         );
         let save_esc = format!("{}: save", app.save_key_label());


### PR DESCRIPTION
Closes #115.

A batch of bugs reported from daily use. Three turned out to be real defects, two were `ssh` parity that nothing documented, and one is a feature request now tracked as #116.

## What changed

**The remote app owns the mouse and paging while it holds the alternate screen.** The wheel and PageUp/PageDown did nothing inside `tmux`, `vim`, `less` or `man`: the alternate grid keeps no scrollback of its own (vt100 gives it zero rows), and both were being spent on a local scroll with nothing to move. They now go to the app that drew the screen, and a wheel notch becomes three arrow keys there — xterm's `alternateScroll`. Shift opts out and keeps the wheel on sshub's own scrollback.

**A drag at a shell prompt selects text again.** An app killed before it could send `ESC [ ? 1002 l` leaves mouse reporting on (vt100 clears the mode only on an exact-parameter DECRST, and leaving the alternate screen does not touch it), so every later drag was encoded and echoed back by the remote shell as `0;47;13M` gibberish. Forwarding now needs the remote to be on the alternate screen *as well as* to have asked for the mouse. Shift **inverts** that decision either way — a local selection over a full-screen app, and forwarding to an app that asked for the mouse without leaving the primary screen (an inline picker), which is also the recovery path if the guess is ever wrong. A stray click on sshub's own header or footer row is no longer reported to the remote as an edge row of the grid.

**A tunnel changed in another sshub window stops lingering here.** The list is a snapshot and the store is shared, so a row deleted or edited elsewhere stayed in this window's session top bar and tunnels tab for the window's lifetime. It is re-read every two seconds, with the selection re-anchored by id so a row deleted above the cursor cannot slide a different tunnel under the next `d`. Running children are deliberately left alone: an edit elsewhere is a delete plus an insert (tunnels have no `UPDATE`), so a vanished id does not mean a vanished tunnel.

**Ctrl+U / Ctrl+W kill a form field in one chord** (host, identity and tunnel forms) — a masked password could only be removed one Backspace per character, with no sign of when it was empty. The helpers live in `text_input` next to the existing backspace/cursor ones, so they are multibyte-safe and clamp a cursor past the end.

**Fixed on the way:** every non-text row of the host form (pickers, toggles, the tri-state) was handed `&mut address` as its "active field", so `End` then `Ctrl+U` on *Session log* emptied the address invisibly — Backspace already did it one character at a time. The accessor returns `Option` now, which makes the compiler ask each caller what a non-text row means.

**Documented, not changed:** `sshub exec web -- ls && uptime` runs `ls` on the host and `uptime` at home, because the local shell splits the line first — the same as `ssh`. `--help`, the man page and the README now show `-- 'ls && uptime'` next to the note that a full-screen command needs `--tty`. One `chore(lint)` commit clears a pre-existing `clippy::chunks_exact_to_as_chunks` warning in `osc52.rs`, which CI's `-D warnings` would fail on regardless of this branch.

## Limits worth knowing

- `tmux` reaches its *own* scrollback only with `set -g mouse on`; without it tmux never asks for the mouse, so a notch arrives as arrow keys — exactly what a real terminal does. Said out loud in the help, the README and the changelog.
- A pager started with `-X` (git's default `LESS=FRX`, `journalctl`) never takes the alternate screen, so `git log` keeps scrolling sshub's buffer as before.
- Cross-window tunnel *run state* stays per-window: the TUI's tunnels are its own children with no pid file for another window to find.
- Terminals that keep Shift+mouse for their own selection give you theirs instead of sshub's.

## Test plan

- [x] `just test` green — 1196 lib + 84 e2e + 79 smoke + 1 config_load, 0 failed
- [x] `cargo fmt --check` and `cargo clippy --all-targets` clean (zero warnings)
- [x] Adversarial review by four independent critics; every finding checked against the code before acting. Fixed: the address-aliasing data loss, Shift+wheel going to the remote, the tunnel sync killing a child on a cross-window *edit*, the index-based selection sliding under the cursor, the identity-form footer pushing save/Esc off a narrow terminal, two contradictory mouse help lines, Ctrl+W having no user-facing mention, and changelog claims a critic measured false (`git log`'s pager, tmux's default `mouse off`). Rejected with evidence: "`app.tunnels` never reaches the session top bar" (it does, `src/session/render.rs::tunnel_summary`) and "`fzf --height` loses its mouse" (measured on fzf 0.74.3: height mode enables no mouse reporting at all; only fullscreen does, and that is on the alternate screen).
- [x] Manual smoke against the real binary, driven through a pty with a local shell tab running `cat -v` so every "was this forwarded?" is a grep, one fresh instance per case:

  | case | result |
  |---|---|
  | alt screen, wheel | 3 × `ESC [ A` to the app |
  | alt screen, Shift+wheel | nothing forwarded (local scrollback) |
  | primary + leaked mouse mode, drag | nothing forwarded, selection copied |
  | primary + mouse mode, Shift+drag | forwarded (`ESC [ <` reports) |
  | alt screen + mouse mode, click | `ESC [ < 0;20;15M` — grid row, header accounted for |
  | click on sshub's header row | dropped, not reported to the remote |
  | alt screen, PageUp | `ESC [ 5 ~` to the app |
  | primary screen, PageUp / wheel | not forwarded, our own scrollback |

- [x] The host-form regression test was watched fail against the old accessor (`left: ""`, `right: "10.0.0.1"`) before the fix went back in.

_Written by Claude Opus 5 (Claude Code) on behalf of the maintainer._
