### PR TITLE
feat(tab-bar): show install channel next to the version badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to SSHub are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Version badge shows the install channel** — the tab-bar version now reads
+  `v0.15.2 · npm`, `· cargo` or `· source`, so a support conversation can tell
+  how the binary got onto the machine. npm is detected via an
+  `SSHUB_INSTALL_CHANNEL` env marker set by the npm shim (the prebuilt binary
+  is byte-identical to the release-tarball one, so paths cannot tell them
+  apart); `cargo` and `source` (`cargo run` out of a build dir, `just install`
+  into `~/.local/bin`) come from path heuristics. Distro packages and manual
+  copies show no suffix, and an explicit `SSHUB_VERSION_LABEL` still wins
+  verbatim (demo recordings keep byte-exact labels).
+
 ## [0.15.2] - 2026-08-24
 
 ### Added

--- a/npm/wrapper/bin/sshub.js
+++ b/npm/wrapper/bin/sshub.js
@@ -56,8 +56,13 @@ function main() {
 
   // `stdio: 'inherit'` hands over the real tty, which the TUI needs, and puts
   // the child in the same process group so Ctrl+C reaches it from the terminal
-  // rather than through us.
-  const result = spawnSync(bin, process.argv.slice(2), { stdio: 'inherit' });
+  // rather than through us. The env marker tells the binary it was installed
+  // via npm: the prebuilt binary is byte-identical to the release-tarball one,
+  // so its own path heuristics cannot tell the two apart.
+  const result = spawnSync(bin, process.argv.slice(2), {
+    stdio: 'inherit',
+    env: { ...process.env, SSHUB_INSTALL_CHANNEL: 'npm' },
+  });
   if (result.error) {
     die(`could not start ${bin}: ${result.error.message}`);
   }

--- a/src/tui/widgets/tab_bar.rs
+++ b/src/tui/widgets/tab_bar.rs
@@ -1,6 +1,6 @@
 //! Dashboard tab bar — numbered tabs with active highlight.
 
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 use ratatui::layout::Rect;
 use ratatui::style::Style;
@@ -11,15 +11,32 @@ use crate::theme::model::ResolvedTheme;
 
 /// The version string shown at the far right, resolved once at runtime.
 ///
-/// * `SSHUB_VERSION_LABEL` **unset** → `v{CARGO_PKG_VERSION}` (normal build).
+/// * `SSHUB_VERSION_LABEL` **unset** → `v{CARGO_PKG_VERSION}`, plus an
+///   install-channel suffix when one is detected (see [`install_channel`]).
 /// * set but **empty** → `None`, the version is hidden entirely (used by the
 ///   demo recordings so their GIFs never advertise a stale version).
-/// * set and **non-empty** → that exact string (custom label).
+/// * set and **non-empty** → that exact string, verbatim (custom label wins
+///   over the channel suffix so recordings stay byte-exact).
 fn version_label() -> Option<&'static str> {
-    static LABEL: OnceLock<Option<String>> = OnceLock::new();
-    LABEL
-        .get_or_init(|| resolve_version_label(std::env::var("SSHUB_VERSION_LABEL").ok()))
-        .as_deref()
+    static LABEL: LazyLock<Option<String>> = LazyLock::new(|| {
+        compose_version_label(std::env::var("SSHUB_VERSION_LABEL").ok(), install_channel())
+    });
+    LABEL.as_deref()
+}
+
+/// Pure composition of the final label (extracted so the suffix rules can be
+/// unit tested without touching process-global env): the compiled default
+/// gains the install-channel suffix; a custom label is used verbatim.
+fn compose_version_label(var: Option<String>, channel: Option<String>) -> Option<String> {
+    let custom = var.as_deref().is_some_and(|s| !s.trim().is_empty());
+    let label = resolve_version_label(var)?;
+    if custom {
+        return Some(label);
+    }
+    Some(match channel {
+        Some(channel) => format!("{label} · {channel}"),
+        None => label,
+    })
 }
 
 /// Pure resolution of the version label from the raw env value (extracted so it
@@ -31,6 +48,65 @@ fn resolve_version_label(var: Option<String>) -> Option<String> {
         Some(s) => Some(s),
         None => Some(concat!("v", env!("CARGO_PKG_VERSION")).to_string()),
     }
+}
+
+/// How the running binary was installed, shown next to the version so a
+/// support conversation can tell how the binary got onto the machine.
+///
+/// Detection, most specific first:
+///
+/// * `SSHUB_INSTALL_CHANNEL` set → that value (the npm shim sets `npm`; the
+///   prebuilt npm binary is byte-identical to the release tarball one, so no
+///   path heuristic can tell them apart).
+/// * the binary lives in cargo's install bin dir (`$CARGO_HOME/bin`) → `cargo`.
+/// * the binary sits inside a build-target dir (`target/`, `…-target/`) →
+///   `source` — a `cargo run`/`cargo build` straight out of the checkout.
+/// * the binary lives in `~/.local/bin` → `source` (`just install`).
+/// * otherwise → `None`: a distro package or a manual copy shows no suffix.
+fn install_channel() -> Option<String> {
+    static CHANNEL: LazyLock<Option<String>> = LazyLock::new(|| {
+        let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
+        let cargo_bin = match std::env::var_os("CARGO_HOME") {
+            Some(dir) => Some(std::path::PathBuf::from(dir).join("bin")),
+            None => home.as_ref().map(|h| h.join(".cargo").join("bin")),
+        };
+        let local_bin = home.as_ref().map(|h| h.join(".local").join("bin"));
+        resolve_install_channel(
+            std::env::var("SSHUB_INSTALL_CHANNEL").ok(),
+            std::env::current_exe().ok().as_deref(),
+            cargo_bin.as_deref(),
+            local_bin.as_deref(),
+        )
+    });
+    CHANNEL.clone()
+}
+
+/// Pure resolution of the install channel from its inputs (extracted so it can
+/// be unit tested without touching process-global env or the exe location).
+fn resolve_install_channel(
+    env_val: Option<String>,
+    exe: Option<&std::path::Path>,
+    cargo_bin: Option<&std::path::Path>,
+    local_bin: Option<&std::path::Path>,
+) -> Option<String> {
+    if let Some(channel) = env_val.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        return Some(channel.to_string());
+    }
+    let exe = exe?;
+    if cargo_bin.is_some_and(|dir| exe.starts_with(dir)) {
+        return Some("cargo".into());
+    }
+    // A build-target dir (`target/`, or a custom `…-target/` via CARGO_TARGET_DIR).
+    if exe.components().any(|c| {
+        let name = c.as_os_str();
+        name == "target" || name.to_string_lossy().ends_with("-target")
+    }) {
+        return Some("source".into());
+    }
+    if local_bin.is_some_and(|dir| exe.starts_with(dir)) {
+        return Some("source".into());
+    }
+    None
 }
 
 /// Tab definitions: (number label, display name).
@@ -118,7 +194,9 @@ pub fn render_tab_bar(
 
     match version_label() {
         Some(version) => {
-            let ver_len = version.len() as u16;
+            // Columns, not bytes: the channel suffix's " · " separator is one
+            // column but two UTF-8 bytes.
+            let ver_len = version.chars().count() as u16;
             if area.width > ver_len + 2 {
                 let ver_x = area.x + area.width - ver_len - 1;
                 let ok = Style::default().fg(theme.color(ColorRole::StatusSuccess));
@@ -133,7 +211,108 @@ pub fn render_tab_bar(
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_version_label;
+    use super::{compose_version_label, resolve_install_channel, resolve_version_label};
+    use std::path::Path;
+
+    #[test]
+    fn install_channel_resolution() {
+        let ch = |env_val: Option<&str>,
+                  exe: Option<&Path>,
+                  cargo_bin: Option<&Path>,
+                  local_bin: Option<&Path>| {
+            resolve_install_channel(env_val.map(str::to_string), exe, cargo_bin, local_bin)
+        };
+
+        // The env var wins outright — the npm shim sets it because the prebuilt
+        // npm binary is byte-identical to the release-tarball one.
+        assert_eq!(ch(Some("npm"), None, None, None).as_deref(), Some("npm"));
+        // A blank env value falls through to the path heuristics.
+        assert_eq!(
+            ch(Some("   "), Some(Path::new("/usr/bin/sshub")), None, None),
+            None
+        );
+
+        // cargo install → $CARGO_HOME/bin (or the default ~/.cargo/bin).
+        assert_eq!(
+            ch(
+                None,
+                Some(Path::new("/home/u/.cargo/bin/sshub")),
+                Some(Path::new("/home/u/.cargo/bin")),
+                None
+            )
+            .as_deref(),
+            Some("cargo")
+        );
+
+        // A dev run straight out of a build dir — plain `target/` and a custom
+        // `…-target/` (CARGO_TARGET_DIR) both count.
+        assert_eq!(
+            ch(
+                None,
+                Some(Path::new("/repo/target/release/sshub")),
+                None,
+                None
+            )
+            .as_deref(),
+            Some("source")
+        );
+        assert_eq!(
+            ch(
+                None,
+                Some(Path::new("/repo/.cargo-target/debug/sshub")),
+                None,
+                None
+            )
+            .as_deref(),
+            Some("source")
+        );
+
+        // `just install` destination.
+        assert_eq!(
+            ch(
+                None,
+                Some(Path::new("/home/u/.local/bin/sshub")),
+                None,
+                Some(Path::new("/home/u/.local/bin"))
+            )
+            .as_deref(),
+            Some("source")
+        );
+
+        // A distro package or manual copy — no channel, no suffix.
+        assert_eq!(
+            ch(None, Some(Path::new("/usr/bin/sshub")), None, None),
+            None
+        );
+        // No exe path resolvable at all.
+        assert_eq!(ch(None, None, None, None), None);
+    }
+
+    #[test]
+    fn version_label_gains_channel_suffix() {
+        let v = concat!("v", env!("CARGO_PKG_VERSION"));
+        // Default label + detected channel → suffixed.
+        assert_eq!(
+            compose_version_label(None, Some("npm".into())).as_deref(),
+            Some(concat!("v", env!("CARGO_PKG_VERSION"), " · npm"))
+        );
+        assert_eq!(
+            compose_version_label(None, Some("cargo".into())).as_deref(),
+            Some(concat!("v", env!("CARGO_PKG_VERSION"), " · cargo"))
+        );
+        // No channel detected → the plain compiled label.
+        assert_eq!(compose_version_label(None, None).as_deref(), Some(v));
+        // Hidden stays hidden regardless of the channel.
+        assert_eq!(
+            compose_version_label(Some(String::new()), Some("npm".into())),
+            None
+        );
+        // A custom label wins verbatim — no suffix appended.
+        assert_eq!(
+            compose_version_label(Some("demo".into()), Some("npm".into())).as_deref(),
+            Some("demo")
+        );
+    }
 
     #[test]
     fn version_label_resolution() {


### PR DESCRIPTION
## What

The tab-bar version badge (top right) now names its install channel:

| How installed | Badge shows |
|---|---|
| npm global (`sshub-tui`) | `v0.15.2 · npm` |
| `cargo install sshub` | `v0.15.2 · cargo` |
| `cargo run` / build out of a target dir, or `just install` into `~/.local/bin` | `v0.15.2 · source` |
| distro package / manual copy | unchanged, no suffix |

## Why

Support conversations start with "what version are you on", and for 0.15.x the answer alone was indistinguishable between an npm install and a local source build (both print `sshub 0.15.2`). This bit us in review of #118: two builds with identical versions behaved differently.

## How

- Detection lives in `src/tui/widgets/tab_bar.rs`, next to the existing label resolution:
  - npm is detected via an `SSHUB_INSTALL_CHANNEL` env marker set by the wrapper shim (`npm/wrapper/bin/sshub.js`). The shim spawns a byte-identical prebuilt binary, so path heuristics cannot tell npm apart from the release tarball — only the shim can.
  - `cargo`: `$CARGO_HOME/bin` (default `~/.cargo/bin`).
  - `source`: binary inside a `target/`/`…-target/` dir (dev runs), or in `~/.local/bin` (`just install`).
  - anything else (distro package, manual copy) → no suffix shown.
- Semantics of `SSHUB_VERSION_LABEL` are preserved exactly: unset → default + channel suffix; empty → hidden; non-empty → verbatim custom label (demo recordings stay byte-exact).
- `OnceLock` → `LazyLock` per the project rule.

## Testing

- Unit tests: channel resolution (env override, cargo bin, plain and custom `…-target/` dirs, `~/.local/bin`, unknown paths, missing exe), final-label composition (suffix appended only to the compiled default, custom labels verbatim, hidden stays hidden). Existing `version_label_resolution` contract intact.
- Live smoke over a pty: bare run renders `v0.15.2 · source`; with `SSHUB_INSTALL_CHANNEL=npm` renders `v0.15.2 · npm`; with `SSHUB_VERSION_LABEL=` nothing renders at all.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full lib suite green locally; CI is authoritative on this PR.

The demo-recordings flow keeps byte-exact control: `SSHUB_VERSION_LABEL` wins over the suffix by design.
