### PR TITLE
fix(sftp): resolve ssh_config credentials for imported hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ All notable changes to SSHub are documented in this file.
   copies show no suffix, and an explicit `SSHUB_VERSION_LABEL` still wins
   verbatim (demo recordings keep byte-exact labels).
 
+### Fixed
+
+- **SFTP lost username and key authentication for hosts imported from
+  ssh_config** (#120) - interactive sessions hand the alias to the system `ssh`,
+  which applies `~/.ssh/config` itself, but the native SFTP transport is
+  libssh2 and needs explicit credentials. Launcher rows imported from ssh_config
+  kept only address/port/proxy_jump, so both the TUI browser and headless
+  `sshub sftp` tried to authenticate as the local user with no identity file.
+  Both surfaces now resolve the alias live through the same `ssh -G` machinery
+  the import used and let the resolved config fill what the store does not
+  manage; SSHub-managed usernames and attached identities keep winning when set.
+
 ## [0.15.2] - 2026-08-24
 
 ### Added

--- a/src/app/sftp.rs
+++ b/src/app/sftp.rs
@@ -695,10 +695,7 @@ impl App {
     /// ProxyJump hosts (unsupported by the libssh2 transport in v1) with a
     /// notice instead of a doomed connection attempt.
     fn sftp_connect_to(&mut self, entry: HostEntry) -> Result<()> {
-        let ssh_host = match &entry {
-            HostEntry::Managed(m) => managed_to_ssh_host(m),
-            HostEntry::Legacy { host, .. } => host.clone(),
-        };
+        let ssh_host = sftp_ssh_host(self.resolver.as_ref(), &entry);
 
         if ssh_host.proxy_jump.is_some() {
             self.host_notice =
@@ -803,10 +800,7 @@ impl App {
             self.host_notice = Some("connect the SFTP browser first".into());
             return Ok(());
         }
-        let ssh_host = match &entry {
-            HostEntry::Managed(m) => managed_to_ssh_host(m),
-            HostEntry::Legacy { host, .. } => host.clone(),
-        };
+        let ssh_host = sftp_ssh_host(self.resolver.as_ref(), &entry);
         if ssh_host.proxy_jump.is_some() {
             self.host_notice =
                 Some("SFTP via ProxyJump isn't supported yet — pick a direct host.".into());

--- a/src/app/util.rs
+++ b/src/app/util.rs
@@ -272,6 +272,28 @@ pub(crate) fn managed_to_ssh_host(m: &ManagedHost) -> SshHost {
     host
 }
 
+/// Build the [`SshHost`] the native (libssh2) SFTP transport connects with.
+///
+/// Interactive SSH sessions hand the alias to the system `ssh`, which applies
+/// `~/.ssh/config` itself; libssh2 cannot. Launcher rows imported from
+/// ssh_config keep only address/port/proxy_jump (`build_import_row`), so for
+/// those resolve the alias live through the same `ssh -G` machinery the
+/// import used and let the resolved config fill what the store does not
+/// manage. SSHub-managed fields always win when present.
+pub(crate) fn sftp_ssh_host(resolver: &dyn HostResolver, entry: &HostEntry) -> SshHost {
+    let mut host = entry.ssh_host();
+    if let HostEntry::Managed(m) = entry {
+        if m.source == HostSource::SshConfig {
+            if let Ok(resolved) = resolver.resolve_host(&m.name) {
+                host.user = host.user.or(resolved.user);
+                host.identity_file = host.identity_file.or(resolved.identity_file);
+                host.certificate_file = host.certificate_file.or(resolved.certificate_file);
+            }
+        }
+    }
+    host
+}
+
 pub(crate) fn optional_path(raw: &str) -> Option<std::path::PathBuf> {
     optional_field(raw).map(std::path::PathBuf::from)
 }
@@ -668,5 +690,164 @@ mod tests {
             contract_prefix(std::path::Path::new("/srv/www"), home),
             "/srv/www"
         );
+    }
+}
+
+#[cfg(test)]
+mod sftp_ssh_host_tests {
+    use super::*;
+    use crate::metadata::HostMetadata;
+    use crate::store::{LauncherStore, NewHost, SshConfigHostImport};
+
+    /// A resolver standing in for `ssh -G`: returns one fixed host, or fails.
+    struct StubResolver {
+        result: Option<SshHost>,
+        fail: bool,
+    }
+
+    impl HostResolver for StubResolver {
+        fn list_hosts(&self) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+
+        fn resolve_host(&self, name: &str) -> Result<SshHost> {
+            if self.fail {
+                anyhow::bail!("no ssh_config entry for {name}");
+            }
+            Ok(self.result.clone().unwrap())
+        }
+    }
+
+    fn config_resolved(name: &str) -> SshHost {
+        let mut host = SshHost::new(name);
+        host.user = Some("deploy".into());
+        host.identity_file = Some("/home/u/.ssh/id_deploy".into());
+        host.certificate_file = Some("/home/u/.ssh/id_deploy-cert.pub".into());
+        // ssh -G echoes a default port; the launcher row must stay authoritative.
+        host.port = Some(2222);
+        host
+    }
+
+    fn ssh_config_entry(store: &LauncherStore) -> HostEntry {
+        store
+            .upsert_ssh_config_host(&SshConfigHostImport {
+                name: "myserver".into(),
+                address: "example.com".into(),
+                port: 22,
+                proxy_jump: None,
+                forward_agent: false,
+                remote_command: None,
+                ssh_config_hash: "h1".into(),
+                tags: vec![],
+                notes: None,
+                environment: None,
+                favorite: false,
+                last_connected: None,
+                session_logging: crate::session_log::SessionLoggingOverride::Inherit,
+                transport: crate::session_transport::SessionTransport::Ssh,
+            })
+            .unwrap();
+        let row = &store
+            .list_hosts_filtered(Some(HostSource::SshConfig))
+            .unwrap()[0];
+        HostEntry::from_managed(row.clone())
+    }
+
+    #[test]
+    fn imported_host_fills_credentials_from_ssh_config() {
+        let store = LauncherStore::open_in_memory().unwrap();
+        let entry = ssh_config_entry(&store);
+        let resolver = StubResolver {
+            result: Some(config_resolved("myserver")),
+            fail: false,
+        };
+
+        let host = sftp_ssh_host(&resolver, &entry);
+        assert_eq!(host.user.as_deref(), Some("deploy"));
+        assert_eq!(
+            host.identity_file.as_deref(),
+            Some("/home/u/.ssh/id_deploy")
+        );
+        assert_eq!(
+            host.certificate_file.as_deref(),
+            Some("/home/u/.ssh/id_deploy-cert.pub")
+        );
+        // Address/port stay owned by the launcher row.
+        assert_eq!(host.hostname.as_deref(), Some("example.com"));
+        assert_eq!(host.port, Some(22));
+    }
+
+    #[test]
+    fn managed_username_wins_over_ssh_config() {
+        let store = LauncherStore::open_in_memory().unwrap();
+        let mut entry = ssh_config_entry(&store);
+        {
+            let m = match &mut entry {
+                HostEntry::Managed(m) => m,
+                HostEntry::Legacy { .. } => unreachable!(),
+            };
+            m.username = Some("root".into());
+        }
+        let resolver = StubResolver {
+            result: Some(config_resolved("myserver")),
+            fail: false,
+        };
+
+        let host = sftp_ssh_host(&resolver, &entry);
+        assert_eq!(host.user.as_deref(), Some("root"));
+        // The key the config carries is still filled in — the row had none.
+        assert_eq!(
+            host.identity_file.as_deref(),
+            Some("/home/u/.ssh/id_deploy")
+        );
+    }
+
+    #[test]
+    fn launcher_hosts_never_consult_the_resolver() {
+        let store = LauncherStore::open_in_memory().unwrap();
+        store
+            .create_host(&NewHost::launcher("selfhosted", "10.0.0.9"))
+            .unwrap();
+        let row = &store
+            .list_hosts_filtered(Some(HostSource::Launcher))
+            .unwrap()[0];
+        let entry = HostEntry::from_managed(row.clone());
+        let resolver = StubResolver {
+            result: Some(config_resolved("myserver")),
+            fail: false,
+        };
+
+        let host = sftp_ssh_host(&resolver, &entry);
+        // No ssh_config bleed into fully managed hosts.
+        assert_eq!(host.user, None);
+        assert_eq!(host.identity_file, None);
+    }
+
+    #[test]
+    fn legacy_entries_pass_through_and_resolution_failure_degrades_gracefully() {
+        let legacy = HostEntry::Legacy {
+            host: config_resolved("legacy"),
+            meta: HostMetadata::new("legacy"),
+        };
+        let failing = StubResolver {
+            result: None,
+            fail: true,
+        };
+
+        // Legacy hosts already carry resolved credentials; a failing resolver
+        // must not damage them (the overlay never runs for Legacy).
+        let host = sftp_ssh_host(&failing, &legacy);
+        assert_eq!(
+            host.identity_file.as_deref(),
+            Some("/home/u/.ssh/id_deploy")
+        );
+
+        // An imported host with an unreadable config keeps its old behaviour:
+        // no creds, no panic.
+        let store = LauncherStore::open_in_memory().unwrap();
+        let entry = ssh_config_entry(&store);
+        let host = sftp_ssh_host(&failing, &entry);
+        assert_eq!(host.user, None);
+        assert_eq!(host.identity_file, None);
     }
 }

--- a/src/cli/sftp.rs
+++ b/src/cli/sftp.rs
@@ -54,7 +54,7 @@ fn connect_worker(
             return Err(1);
         }
     };
-    let ssh_host = entry.ssh_host();
+    let ssh_host = crate::app::sftp_ssh_host(&ctx.resolver, &entry);
     if ssh_host.proxy_jump.is_some() {
         eprintln!("sshub: SFTP via ProxyJump is not supported; pick a direct host");
         return Err(1);


### PR DESCRIPTION
Closes #120.

## What changed

Native SFTP (libssh2) to hosts imported from `~/.ssh/config` authenticated as
the local user with no identity file. Interactive SSH sessions work on those
hosts because their argv passes the alias to system `ssh`, which applies the
user's config itself; both SFTP surfaces built the `SshHost` from the launcher
store row instead, and `build_import_row` keeps only address/port/proxy_jump,
never the config's `User`/`IdentityFile`.

Both SFTP connect surfaces (TUI browser via `sftp_connect_to` /
`sftp_connect_left_pane`, headless `sshub sftp` via `connect_worker`) now build
the host through one helper, `app::util::sftp_ssh_host(resolver, entry)`. For
rows imported from ssh_config (`source == HostSource::SshConfig`) it resolves
the alias live through the existing resolver (`ssh -G`, the same machinery the
importer already uses) and fills what the store does not manage:
`user`, `identity_file`, `certificate_file`. Store-managed values keep winning
when set (`Option::or` chains), address/port stay owned by the launcher row,
and Legacy entries pass through untouched — they were resolved at list time
already. Resolution failure degrades silently to exactly the pre-fix behavior;
ProxyJump refusal is unchanged (libssh2 cannot chain a jump).

## Security-sensitive

Touches the authentication path of the native SFTP transport. No new credential
storage: keys still come from the user's own `~/.ssh/config` or attached SSHub
identities; stored passwords/passphrases flow through the unchanged
`resolve_pending_secret` → transport path; agent auth is still attempted first.
A live `ssh -G <alias>` is spawned at connect time for imported rows only
(address is never taken from anywhere but the store).

## How tested

- New unit tests (stub resolver, in-memory store, no real `~/.ssh`): imported
  row picks up config credentials; managed username wins over the config;
  launcher-source rows never consult the resolver; legacy pass-through;
  resolution failure degrades gracefully without panics.
- Local green: `just test` full suite, `cargo fmt --check`,
  `cargo clippy --all-targets -- -D warnings`.
- Adversarial review (2 independent critics) returned SAFE TO COMMIT; accepted
  follow-ups recorded below.

## Known limitations (deliberate scope)

- A failed resolution (config moved/unreadable) keeps working as before
  (auth fails locally with no extra hint). Surfacing a diagnostic needs the
  diag plumbing shared by `resolve_pending_secret`; deferred rather than
  widening this fix.
- `ssh -G` runs synchronously on connect (tens of ms normally), matching what
  the import sync already pays; a pathological `Match exec` config could stall
  a frame. Moving it into the worker is future work.
- `ssh -G` echoes default `identityfile` lines even when the config declares
  none, so an imported row may gain the user's default key path. Harmless with
  the existing agent-first auth order.

_Written by GLM 5.3 Flash (Oh My Pi) on behalf of the maintainer._
